### PR TITLE
Fix to docson.js

### DIFF
--- a/docson/docson.js
+++ b/docson/docson.js
@@ -280,10 +280,10 @@ define(["docson/lib/jquery", "docson/lib/handlebars", "docson/lib/highlight", "d
             var result;
             if(target) {
                 result = options.fn(target);
+                delete target.__ref;
             } else {
                 result = new Handlebars.SafeString("<span class='signature-type-ref'>"+schema.$ref+"</span>");
             }
-            delete target.__ref;
             return result;
         }
     });


### PR DESCRIPTION
This is  a small change to docson.js to allow the rendering of certain JSON specification files which would otherwise cause a null reference error.
