### PR TITLE
More lenient delta schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,18 @@ function validate(tree) {
   var definitions = require('./schemas/definitions.json');
   tv4.addSchema('https://signalk.github.io/specification/schemas/definitions.json', definitions);
 
-  ['navigation', 'environment', 'propulsion', 'resources', 'sensors', 'steering', 'tanks'].forEach(function(name) {
-    var subSchema = require('./schemas/groups/' + name + '.json');
-    tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + name + '.json', subSchema);
-  });
+  var subSchemas = {
+    'navigation': require('./schemas/groups/navigation.json'),
+    'environment': require('./schemas/groups/environment.json'),
+    'propulsion': require('./schemas/groups/propulsion.json'),
+    'resources': require('./schemas/groups/resources.json'),
+    'sensors': require('./schemas/groups/sensors.json'),
+    'steering': require('./schemas/groups/steering.json'),
+    'tanks': require('./schemas/groups/tanks.json')
+  };
+  for (var schema in subSchemas) {
+    tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + name + '.json', subSchemas[schema]);
+  }
 
   var validTree = {
     vessels: {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function validate(tree) {
     'tanks': require('./schemas/groups/tanks.json')
   };
   for (var schema in subSchemas) {
-    tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + name + '.json', subSchemas[schema]);
+    tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + schema + '.json', subSchemas[schema]);
   }
 
   var validTree = {

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -35,7 +35,9 @@
                                     "type": [
                                       "string",
                                       "number",
-                                      "object"
+                                      "object",
+                                      "boolean",
+                                      "null"
                                     ],
                                     "required": true,
                                     "additionalProperties": true

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -32,7 +32,13 @@
                                     "required": true
                                 },
                                 "value": {
-                                    "required": true
+                                    "type": [
+                                      "string",
+                                      "number",
+                                      "object"
+                                    ],
+                                    "required": true,
+                                    "additionalProperties": true
                                 }
                             }
                         }

--- a/test/validation.js
+++ b/test/validation.js
@@ -26,4 +26,33 @@ describe('Delta validation', function() {
     msg.foo = 'bar';
     msg.should.not.be.validSignalKDelta;
   });
+
+  it('Object value is valid', function() {
+    var msg = {
+      "updates": [{
+        "source": {
+          "label": "",
+          "type": "NMEA2000",
+          "pgn": "129025",
+          "src": "160"
+        },
+        "values": [{
+          "path": "navigation.position",
+          "value": {
+            "longitude": 24.9025173,
+            "latitude": 60.039317,
+            "source": {
+              "label": "",
+              "type": "NMEA2000",
+              "pgn": "129025",
+              "src": "160"
+            },
+            "timestamp": "2014-08-15-16:00:05.770"
+          }
+        }]
+      }],
+      "context": "vessels.123456789"
+    };
+    msg.should.be.validSignalKDelta;
+  });
 });

--- a/test/validation.js
+++ b/test/validation.js
@@ -27,7 +27,7 @@ describe('Delta validation', function() {
     msg.should.not.be.validSignalKDelta;
   });
 
-  it('Object value is valid', function() {
+  it('Object, null, number and boolean values are valid in delta', function() {
     var msg = {
       "updates": [{
         "source": {
@@ -53,6 +53,12 @@ describe('Delta validation', function() {
       }],
       "context": "vessels.123456789"
     };
+    msg.should.be.validSignalKDelta;
+    msg.updates[0].values[0].value = null;
+    msg.should.be.validSignalKDelta;
+    msg.updates[0].values[0].value = 1.0;
+    msg.should.be.validSignalKDelta;
+    msg.updates[0].values[0].value = true;
     msg.should.be.validSignalKDelta;
   });
 });

--- a/test/validation.js
+++ b/test/validation.js
@@ -4,12 +4,11 @@ chai.use(require('../index.js').chaiModule);
 
 
 
-describe('Delta validation', function () {
-  it('works', function () {
+describe('Delta validation', function() {
+  it('Simple path with value is valid and not when modified', function() {
     var msg = {
-      context:'bar',
-      updates:[
-      {
+      context: 'bar',
+      updates: [{
         "source": {
           "label": "",
           "type": "NMEA2000",
@@ -17,14 +16,11 @@ describe('Delta validation', function () {
           "src": "204"
         },
         "timestamp": "2013-10-08T15:47:28.263Z",
-        "values": [
-          { 
-            "path":"123",
-            "value":1234
-          }
-        ]
-      }
-      ]
+        "values": [{
+          "path": "123",
+          "value": 1234
+        }]
+      }]
     };
     msg.should.be.validSignalKDelta;
     msg.foo = 'bar';


### PR DESCRIPTION
The current delta schema does not explicitly say what a 'value' should be and by itself does not work if we want to validate against extra properties. 

This change specifies value as string/number/object and explicitly allows additionalProperties.

Please notice that I stupidly I created this branch off the one for #62