### PR TITLE
Separate group for sails

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -56,6 +56,54 @@
             "minLength": 8,
             "example": "550E8AB0"
         },
+
+        "sail": {
+            "type": "object",
+            "description": "'sail' data type.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "required": true,
+                    "description": "An identifier by which the crew identifies a sail",
+                    "example": "J1"
+                },
+                "type": {
+                    "type": "string",
+                    "required": true,
+                    "description": "The type of sail",
+                    "example": "Genaker"
+                },
+                "material": {
+                    "type": "string",
+                    "required": false,
+                    "description": "The material the sail is made from (optional)",
+                    "example": "canvas"
+                },
+                "brand": {
+                    "type": "string",
+                    "required": false,
+                    "description": "The brand of the sail (optional)",
+                    "example": "North Sails"
+                },
+                "active": {
+                    "type": "boolean",
+                    "required": true,
+                    "description": "Indicates wether this sail is currently in use or not"
+                },
+                "area": {
+                  "type": "number",
+                  "required": true,
+                  "description": "The total area of this sail in square meters (m2)"
+                },
+                "timestamp": { "description":"timestamp of the last update to this data",
+                    "$ref": "#/definitions/timestamp"
+                },
+                "source": {
+                    "$ref": "#/definitions/source"
+                }
+            }
+        },
+
         "stringValue": {
             "type": "object",
             "description": "Data should be of type string.",

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -64,7 +64,7 @@
                 "name": {
                     "type": "string",
                     "required": true,
-                    "description": "An identifier by which the crew identifies a sail",
+                    "description": "An unique identifier by which the crew identifies a sail",
                     "example": "J1"
                 },
                 "type": {
@@ -94,6 +94,16 @@
                   "type": "number",
                   "required": true,
                   "description": "The total area of this sail in square meters (m2)"
+                },
+                "minimumWind": {
+                    "type": "number",
+                    "description": "The minimum wind speed this sail can be used with, measured in m/s",
+                    "default": 0
+                },
+                "maximumWind": {
+                    "type": "number",
+                    "description": "The maximum wind speed this sail can be used with, measured in m/s",
+                    "default": 666
                 },
                 "timestamp": { "description":"timestamp of the last update to this data",
                     "$ref": "#/definitions/timestamp"

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -28,6 +28,14 @@
                 "active": {
                     "description": "The total area of the sails currently in use on the vessel, measured in square meters.",
                     "type": "number"
+                },
+
+                "timestamp": { "description":"timestamp of the last update to this data",
+                    "$ref": "#/definitions/timestamp"
+                },
+                
+                "source": { "description":"Source of this data",
+                    "$ref": "#/definitions/source"
                 }
             }
         }

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -1,0 +1,35 @@
+{
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-03/schema",
+    "id": "https://signalk.github.io/specification/schemas/groups/sails.json#",
+    "description": "An object describing the vessels sails if the vessel is a sailboat.",
+    "title": "sails",
+    "properties": {
+        "available": {
+            "type": "object",
+            "description": "An object containing a description of each sail available to the vessel crew",
+            "patternProperties": {
+                "(^[a-zA-Z0-9]$)": {
+                    "description": "Each sail is identified by a unique name, containing only alphanumeric characters.",
+                    "$ref": "../definitions.json#/definitions/sail" 
+                }
+            }
+        },
+
+        "area": {
+            "type": "object",
+            "description": "An object containing information about the area of the sails.",
+            "properties": {
+                "total": {
+                    "description": "The total area of all sails on the vessel, measured in square meters.",
+                    "type": "number"
+                },
+
+                "active": {
+                    "description": "The total area of the sails currently in use on the vessel, measured in square meters.",
+                    "type": "number"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is about separating `sails` from the `design` group, as the sails of a vessel are not a design feature. 