### PR TITLE
Update tanks.json

### DIFF
--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -2,29 +2,33 @@
     "type": "object",
     "$schema": "http://json-schema.org/draft-03/schema",
     "id": "https://signalk.github.io/specification/schemas/groups/tanks.json#",
-    "description": "a tank, named by a unique name within this vessel",
+    "description": "A tank, named by an UUID",
     "title": "tank",
     "properties": {
-            "tankType": {
-                "type": "string",
-                "description": "The type of waypoint",
-                "enum": [
-                    "petrol",
-                    "water",
-                    "holding",
-                    "lpg",
-                    "diesil",
-                    "rum"
-                ]
-            },
-            "capacity": {
-                "description": "total tank capacity in liters",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "level": {
-                "description": "current tank contents in liters",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            }
+        "name": {
+            "type": "string",
+            "description": "The name of the tank. Useful if multiple tanks of a certain type are on board"
+        },
+        "type": {
+            "type": "string",
+            "description": "The type of tank",
+            "enum": [
+                "petrol",
+                "fresh water",
+                "greywater",
+                "holding",
+                "lpg",
+                "diesel",
+                "rum"
+            ]
+        },
+        "capacity": {
+            "description": "Total tank capacity in liters",
+            "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "level": {
+            "description": "Current tank contents in liters",
+            "$ref": "../definitions.json#/definitions/numberValue"
         }
     }
-
+}


### PR DESCRIPTION
This is a breaking change.

The addition of the `greywater` tank type and the change from `water` to `fresh water` is motivated by the fact that some boats have rainwater collection systems. If I recall correctly, greywater is also available in the N2K spec.

The addition of the `name` field is explained inline.

The change from `tankType` to `type` reflects the naming convention used in other parts of the spec.

The other changes are just to standardize the formatting and provide reader clarity.