### PR TITLE
Improve validation

### DIFF
--- a/bin/validate.js
+++ b/bin/validate.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+var JSONStream = require('JSONStream');
+var Transform = require('stream').Transform;
+
+var signalkSchema = require('../');
+
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+
+
+function Validator(options) {
+  Transform.call(this, {
+    objectMode: true
+  });
+}
+
+require('util').inherits(Validator, Transform);
+
+Validator.prototype._transform = function(chunk, encoding, done) {
+  var validationResult = signalkSchema.validateFull(chunk);
+  if (!validationResult.valid) {
+    console.error(JSON.stringify(validationResult, null, 2));
+  }
+  done();
+}
+
+process.stdin.pipe(JSONStream.parse()).pipe(new Validator());

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ function chaiAsPromised(chai, utils) {
 
   var Assertion = chai.Assertion
 
-  Assertion.addProperty('validSignalK', function () {    
-    var result = validate(this._obj);
+  function checkValidFullSignalK () { 
+    var result = validateFull(this._obj);
     var message = result.errors.length === 0 ? '' : result.errors[0].message + ':' + result.errors[0].dataPath + 
       ' (' + (result.errors.length-1) + ' other errors not reported here)';
     this.assert(
@@ -12,7 +12,17 @@ function chaiAsPromised(chai, utils) {
       , message
       , 'expected #{this} to not be valid SignalK'
       );
-  });  
+  }
+  Assertion.addProperty('validSignalK', checkValidFullSignalK);
+  Assertion.addProperty('validFullSignalK', checkValidFullSignalK);
+  Assertion.addProperty('validSignalKVessel', function() {
+    this._obj = {
+      'vessels': {
+        '230099999': this._obj
+      }
+    }
+    checkValidFullSignalK.call(this);
+  });
   Assertion.addProperty('validSignalKDelta', function () {
     var result = validateDelta(this._obj);
     var message = result.errors.length === 0 ? '' : result.errors[0].message + ':' + result.errors[0].dataPath + 
@@ -43,7 +53,7 @@ function chaiAsPromised(chai, utils) {
   });
 }
 
-function validate(tree) {
+function validateFull(tree) {
   var tv4 = require('tv4');
   var signalkSchema = require('./schemas/signalk.json');
   var vesselSchema = require('./schemas/vessel.json');
@@ -64,12 +74,8 @@ function validate(tree) {
     tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + schema + '.json', subSchemas[schema]);
   }
 
-  var validTree = {
-    vessels: {
-      '230099999': tree
-    }
-  }
-  var valid = tv4.validateMultiple(validTree, signalkSchema, true, true);
+//  console.log(JSON.stringify(tree, null, 2))
+  var valid = tv4.validateMultiple(tree, signalkSchema, true, true);
   return valid;
 }
 
@@ -93,7 +99,7 @@ function validateWithSchema(msg, schemaName) {
   return valid;
 }
 
-module.exports.validate = validate;
+module.exports.validateFull = validateFull;
 module.exports.validateDelta = validateDelta;
 module.exports.chaiModule = chaiAsPromised;
 module.exports.i18n = require('./i18n/');

--- a/index.js
+++ b/index.js
@@ -100,6 +100,13 @@ function validateWithSchema(msg, schemaName) {
 }
 
 module.exports.validateFull = validateFull;
+module.exports.validateVessel = function(vesselData) {
+  return validateFull({
+      'vessels': {
+        '230099999': vesselData
+      }
+    });
+}
 module.exports.validateDelta = validateDelta;
 module.exports.chaiModule = chaiAsPromised;
 module.exports.i18n = require('./i18n/');

--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ function validateFull(tree) {
     tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + schema + '.json', subSchemas[schema]);
   }
 
-//  console.log(JSON.stringify(tree, null, 2))
   var valid = tv4.validateMultiple(tree, signalkSchema, true, true);
   return valid;
 }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,12 @@
   "bugs": {
     "url": "https://github.com/SignalK/specification/issues"
   },
+  "bin": {
+    "signalk-validate-full": "bin/validate.js"
+  },
   "homepage": "https://github.com/SignalK/specification",
   "dependencies": {
-    "JSONStream": "0.7",
+    "JSONStream": "^0.7.4",
     "chai": "1.9",
     "mocha": "^2.1.0",
     "tv4": "latest"

--- a/test/treeValidation.js
+++ b/test/treeValidation.js
@@ -5,6 +5,6 @@ chai.use(require('../index.js').chaiModule);
 describe('Tree validation', function() {
   it('Depth with meta and attr validates', function() {
     var tree =  require('../samples/signalk-depth-meta-attr');
-    tree.should.be.validSignalK;
+    tree.should.be.validSignalKVessel;
   });
 });


### PR DESCRIPTION
Previously validation code only considered the "vessel" object and not the whole tree. With these changes it is now possible to assert `validSignalK` which is equal to `validFullSignalK` and alternatively `validSignalKVessel`. Furthermore the module exports `validateFull` and `validateVessel`.