### PR TITLE
Uuid and mmsi as main vessel identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ function validateFull(tree) {
   }
 
   var valid = tv4.validateMultiple(tree, signalkSchema, true, true);
+  var result = tv4.validateResult(tree, signalkSchema, true, true);
+  //Hack: validateMultiple marks anyOf last match incorrectly as not valid with banUnknownProperties
+  //https://github.com/geraintluff/tv4/issues/128
+  valid.valid = result.valid;
   return valid;
 }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function chaiAsPromised(chai, utils) {
     var vessel = this._obj;
     this._obj = {
       'vessels': {
-        '230099999': this._obj
+        'mmsi:230099999': this._obj
       }
     }
     checkValidFullSignalK.call(this);
@@ -138,7 +138,7 @@ module.exports.validateFull = validateFull;
 module.exports.validateVessel = function(vesselData) {
   return validateFull({
       'vessels': {
-        '230099999': vesselData
+        'mmsi:230099999': vesselData
       }
     });
 }

--- a/index.js
+++ b/index.js
@@ -16,12 +16,21 @@ function chaiAsPromised(chai, utils) {
   Assertion.addProperty('validSignalK', checkValidFullSignalK);
   Assertion.addProperty('validFullSignalK', checkValidFullSignalK);
   Assertion.addProperty('validSignalKVessel', function() {
+    var vessel = this._obj;
     this._obj = {
       'vessels': {
         '230099999': this._obj
       }
     }
     checkValidFullSignalK.call(this);
+    if (vessel.uuid) {
+      var crc = crc32(vessel.uuid.value).toString(16);
+      this.assert(
+         crc === vessel.uuid.checksum,
+         "Uuid checksum error: crc32(" + vessel.uuid.value + ") != " +  vessel.uuid.checksum,
+         "Expected uuid checksum to fail"
+      );
+    }
   });
   Assertion.addProperty('validSignalKDelta', function () {
     var result = validateDelta(this._obj);
@@ -101,6 +110,29 @@ function validateWithSchema(msg, schemaName) {
   var valid = tv4.validateResult(msg,schema, true, true);
   return valid;
 }
+var crcTable = function(){
+    var c;
+    var crcTable = [];
+    for(var n =0; n < 256; n++){
+        c = n;
+        for(var k =0; k < 8; k++){
+            c = ((c&1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1));
+        }
+        crcTable[n] = c;
+    }
+    return crcTable;
+}()
+
+function crc32 (str){
+    var crc = 0 ^ (-1);
+
+    for (var i = 0; i < str.length; i++ ) {
+        crc = (crc >>> 8) ^ crcTable[(crc ^ str.charCodeAt(i)) & 0xFF];
+    }
+
+    return (crc ^ (-1)) >>> 0;
+};
+
 
 module.exports.validateFull = validateFull;
 module.exports.validateVessel = function(vesselData) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "JSONStream": "^0.7.4",
     "chai": "1.9",
+    "lodash": "^3.10.1",
     "mocha": "^2.1.0",
     "tv4": "latest"
   }

--- a/samples/signalk-depth-meta-attr.json
+++ b/samples/signalk-depth-meta-attr.json
@@ -1,4 +1,8 @@
 {
+  "uuid": {
+    "value" : "de305d54-75b4-431b-adb2-eb6b9e546014",
+    "checksum": "74a93ec0"
+  },
     "environment": {
         "depth": {
             "belowKeel": {

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -45,6 +45,7 @@
         "mmsi": {
             "type": "string",
             "description": "Maritime Mobile Service Identity (MMSI). Has to be 9 digits. See http://en.wikipedia.org/wiki/Maritime_Mobile_Service_Identity for information.",
+            "pattern": "^[2-7][0-9]{8,8}$",
             "required": false,
             "maxLength": 9,
             "minLength": 9

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -49,13 +49,6 @@
             "maxLength": 9,
             "minLength": 9
         },
-        "uuid": {
-            "type": "string",
-            "description": "UUID assigned by the implementation of the Signal K server to vessels that don't have a MMSI. Has to be 8 characters (chosen so one could use the first block in a RFC4122 UUID), to distinguish from MMSI.",
-            "maxLength": 8,
-            "minLength": 8,
-            "example": "550E8AB0"
-        },
         "sail": {
             "type": "object",
             "description": "'sail' data type.",

--- a/schemas/signalk.json
+++ b/schemas/signalk.json
@@ -15,8 +15,8 @@
             "required": true,
             "description": "A wrapper object for vessel objects, each describing vessels in range, including this vessel.",
             "patternProperties": {
-                "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-                    "description": "This regex pattern is used for validation of an MMSI or UUID identifier for the vessel",
+                "(^mmsi:[2-7][0-9]{8,8}$|^signalk:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$)": {
+                    "description": "This regex pattern is used for validation of an MMSI or Signal K UUID identifier for the vessel",
                     "$ref": "vessel.json#" }
             }
         },

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -4,14 +4,37 @@
     "id": "https://signalk.github.io/specification/schemas/vessel.json#",
     "description": "An object describing an individual vessel. It should be an object in vessels, named using MMSI or a UUID",
     "title": "vessel",
+    "anyOf": [
+        {"required": ["mmsi"]},
+        {"required": ["uuid"]}
+      ],
     "properties": {
         "mmsi": {
             "description": "MMSI number of the vessel, if available.",
             "$ref": "definitions.json#/definitions/mmsi"
         },
         "uuid": {
-            "description": "A unique ID in UUID v4 format if a MMSI isn't available.",
-            "$ref": "definitions.json#/definitions/uuid"
+            "type": "object",
+            "title": "Uuid",
+            "description": "Uuid identifier",
+            "required": ["value", "checksum"],
+            "properties": {
+              "value": {
+                  "description": "A unique ID in UUID v4 format if a MMSI isn't available.",
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+                  "minLength": 36,
+                  "maxLength": 36,
+                  "example": "de305d54-75b4-431b-adb2-eb6b9e546014"
+              },
+              "checksum": {
+                  "description": "CRC-32 checksum of the uuid value in canonical format",
+                  "type": "string",
+                  "minLength": 8,
+                  "maxLength": 8,
+                  "example": "74a93ec0"
+              }
+            }
         },
         "name": {
             "type": "string",

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -30,6 +30,7 @@
               "checksum": {
                   "description": "CRC-32 checksum of the uuid value in canonical format",
                   "type": "string",
+                  "pattern": "^[a-f0-9]{8,8}$",
                   "minLength": 8,
                   "maxLength": 8,
                   "example": "74a93ec0"

--- a/test/treeValidation.js
+++ b/test/treeValidation.js
@@ -7,4 +7,32 @@ describe('Tree validation', function() {
     var tree =  require('../samples/signalk-depth-meta-attr');
     tree.should.be.validSignalKVessel;
   });
+
+  it('mmsi: vessel property', function() {
+    var msg = {
+      vessels: {
+        "mmsi:230099999": {
+          "mmsi": "230099999"
+        }
+      }
+    }
+    msg.should.be.validSignalK;
+  });
+
+  it('signalk: vessel property', function() {
+    var msg = {
+      vessels: {
+        "signalk:de305d54-75b4-431b-adb2-eb6b9e546014": {
+          "uuid": {
+            "value" : "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "checksum": "74a93ec0"
+          }
+        }
+      }
+    }
+    msg.should.be.validSignalK;
+    msg.vessels["signalk:de305d54-75b4-431b-adb2-eb6b9e546014"].mmsi = "230099999";
+    msg.should.be.validSignalK;
+  });
+
 });

--- a/test/uuid-mmsi.js
+++ b/test/uuid-mmsi.js
@@ -20,14 +20,14 @@ describe('No id', function() {
 describe('MMSI id', function() {
   it('just mmsi validates', function() {
     var msg = {
-      "mmsi": "123456789"
+      "mmsi": "230099999"
     }
     msg.should.be.validSignalKVessel;
   });
 
   it('validates with uuid', function() {
     var msg = _.clone(validVessel);
-    msg.mmsi = "123456789";
+    msg.mmsi = "230099999";
     msg.should.be.validSignalKVessel;
   });
 });

--- a/test/uuid-mmsi.js
+++ b/test/uuid-mmsi.js
@@ -1,0 +1,96 @@
+var chai = require('chai');
+chai.Should();
+chai.use(require('../index.js').chaiModule);
+var _ = require('lodash')
+
+var validVessel ={
+  "uuid": {
+    "value" : "de305d54-75b4-431b-adb2-eb6b9e546014",
+    "checksum": "74a93ec0"
+  }
+};
+
+describe('No id', function() {
+  it('flagged as error', function() {
+    var msg = {};
+    assertInvalidSignalKVessel(msg);
+  });
+});
+
+describe('MMSI id', function() {
+  it('just mmsi validates', function() {
+    var msg = {
+      "mmsi": "123456789"
+    }
+    msg.should.be.validSignalKVessel;
+  });
+
+  it('validates with uuid', function() {
+    var msg = _.clone(validVessel);
+    msg.mmsi = "123456789";
+    msg.should.be.validSignalKVessel;
+  });
+});
+
+describe('UUID:', function() {
+  it('Valid vessel.uuid validates', function() {
+    validVessel.should.be.validSignalKVessel;
+  });
+
+  it('vessel.uuid that is not in uuid canonical format is flagged as error', function() {
+    var msg ={
+      "uuid": {
+        "value" : "de305d54-75b4-431b-adb2-eb6b9e54601",
+        "checksum": "17862a91"
+      }
+    };
+    assertInvalidSignalKVessel(msg);
+  });
+
+
+  it('Invalid vessel.uuid checksum is flagged as error', function() {
+    var msg ={
+      "uuid": {
+        "value" : "de305d54-75b4-431b-adb2-eb6b9e546014",
+        "checksum": "74a93ec1"
+      }
+    };
+    assertInvalidSignalKVessel(msg);
+  });
+
+  it('Missing vessel.uuid.checksum is flagged as error', function() {
+    var msg ={
+      "uuid": {
+        "value" : "de305d54-75b4-431b-adb2-eb6b9e546014"
+      }
+    };
+    assertInvalidSignalKVessel(msg);
+  });
+
+  it('Missing vessel.uuid.value is flagged as error', function() {
+    var msg ={
+      "uuid": {
+        "checksum": "74a93ec1"
+      }
+    };
+    assertInvalidSignalKVessel(msg);
+  });
+
+  it('Missing vessel.uuid properties is flagged as error', function() {
+    var msg ={
+      "uuid": {
+      }
+    };
+    assertInvalidSignalKVessel(msg);
+  });
+});
+
+function assertInvalidSignalKVessel(msg) {
+  var result;
+  try {
+    msg.should.be.validSignalKVessel;
+    result = new Error("Expected " + JSON.stringify(msg) + " to not be a valid Signal K vessel document")
+  } catch (ex) {
+  }
+  if (result) throw result  
+}


### PR DESCRIPTION
Changes:
- either vessels.`<id>`.mmsi or vessels.`<id>`.uuid mandatory
- vessels.`<id>`.uuid consist of
 - UUID in canonical format and
 - checksum calculated with CRC-32
- the id under vessels to be either `signalk:<uuid>` or `mmsi:<mmsi>`

See #91 for more discussion