### PR TITLE
Housekeeping: cleanup of all schemas

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "chai": "1.9",
     "mocha": "^2.1.0",
     "tv4": "latest"
+  },
+  "devDependencies": {
+    "chai": "^1.9.2",
+    "tv4": "^1.2.7"
   }
 }

--- a/samples/signalk-depth-meta-attr.json
+++ b/samples/signalk-depth-meta-attr.json
@@ -15,7 +15,7 @@
                     "longName": "Depth Below Keel in Meters",
                     "shortName": "DBK",
                     "guageType": "sparkLine",
-                    "unit": "m",
+                    "units": "Meters (m)",
                     "warnMethod": "visual",
                     "alarmMethod": "sound",
                     "zones": [

--- a/schemas/def_loader.json
+++ b/schemas/def_loader.json
@@ -1,14 +1,29 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/def_loader.json#",
-    "title": "def_loader",
-    "description": "Nasty hack to get the definitions loaded first, so they resolve nicely",
-    "properties": {
-        "stringValue": { "$ref": "definitions.json#/definitions/stringValue" },
-        "floatValue": { "$ref": "definitions.json#/definitions/floatValue" },
-        "nullValue": { "$ref": "definitions.json#/definitions/nullValue" },
-        "alarmValue": { "$ref": "definitions.json#/definitions/alarmValue" },
-        "alarmMethod": { "$ref": "definitions.json#/definitions/alarmMethod" }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/def_loader.json#",
+  "title": "def_loader",
+  "description": "Nasty hack to get the definitions loaded first, so they resolve nicely",
+  
+  "properties": {
+    "stringValue": { 
+      "$ref": "definitions.json#/definitions/stringValue" 
+    },
+    
+    "floatValue": { 
+      "$ref": "definitions.json#/definitions/floatValue" 
+    },
+    
+    "nullValue": { 
+      "$ref": "definitions.json#/definitions/nullValue" 
+    },
+    
+    "alarmValue": { 
+      "$ref": "definitions.json#/definitions/alarmValue" 
+    },
+    
+    "alarmMethod": { 
+      "$ref": "definitions.json#/definitions/alarmMethod" 
     }
+  }
 }

--- a/schemas/def_loader_pre.json
+++ b/schemas/def_loader_pre.json
@@ -1,15 +1,33 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/def_loader.json#",
-    "title": "def_loader",
-    "description": "Nasty hack to get the definitions loaded first, so they resolve nicely",
-    "properties": {
-        "source": { "$ref": "definitions.json#/definitions/source" },
-        "timestamp": { "$ref": "definitions.json#/definitions/timestamp" },
-        "version": { "$ref": "definitions.json#/definitions/version" },
-        "number": { "$ref": "definitions.json#/definitions/numberValue" },
-        "mmsi": { "$ref": "definitions.json#/definitions/mmsi" },
-        "uuid": { "$ref": "definitions.json#/definitions/uuid" }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/def_loader.json#",
+  "title": "def_loader",
+  "description": "Nasty hack to get the definitions loaded first, so they resolve nicely",
+
+  "properties": {
+    "source": { 
+      "$ref": "definitions.json#/definitions/source" 
+    },
+    
+    "timestamp": { 
+      "$ref": "definitions.json#/definitions/timestamp" 
+    },
+    
+    "version": { 
+      "$ref": "definitions.json#/definitions/version" 
+    },
+    
+    "number": { 
+      "$ref": "definitions.json#/definitions/numberValue" 
+    },
+    
+    "mmsi": { 
+      "$ref": "definitions.json#/definitions/mmsi" 
+    },
+    
+    "uuid": { 
+      "$ref": "definitions.json#/definitions/uuid" 
     }
+  }
 }

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -1,345 +1,396 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/definitions.json#",
-    "title": "definitions",
-    "description": "Reusable definitions of core object types",
-    "definitions": {
-        "timestamp": {
-            "type": "string",
-            "required": false,
-            "description": "ISO-8601 (UTC) string representing date and time.",
-            "units": "ISO-8601 (UTC)",
-            "example": "2014-04-10T08:33:53Z"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/definitions.json#",
+  "title": "definitions",
+  "description": "Reusable definitions of core object types",
+
+  "definitions": {
+    "timestamp": {
+      "type": "string",
+      "required": false,
+      "description": "ISO-8601 (UTC) string representing date and time.",
+      "units": "ISO-8601 (UTC)",
+      "example": "2014-04-10T08:33:53Z"
+    },
+
+    "source": {
+      "type": "object",
+      "description": "Source of data. An object containing at least the properties defined in 'properties', but can contain anything beyond that.",
+      "required": [
+        "label",
+        "type"
+      ],
+      "properties": {
+        "label": {
+          "type": "string"
         },
-        "source": {
-            "type": "object",
-            "description": "Source of data. An object containing at least the properties defined in 'properties', but can contain anything beyond that.",
-            "required": [
-                "label",
-                "type"
-            ],
-            "properties": {
-                "label": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "default": "NMEA2000"
-                },
-                "src": {
-                    "type": "string",
-                    "description": "NMEA2000 src value or any similar value for encapsulating the original source of the data"
-                },
-                "pgn": {
-                    "type": "number",
-                    "description": "NMEA2000 pgn of the source message"
-                }
-            }
+        "type": {
+          "type": "string",
+          "default": "NMEA2000"
         },
-        "version": {
-            "type": "string",
-            "description": "Version of the Signal K root object.",
-            "example": "0.1"
+        "src": {
+          "type": "string",
+          "description": "NMEA2000 src value or any similar value for encapsulating the original source of the data"
         },
-        "mmsi": {
-            "type": "string",
-            "description": "Maritime Mobile Service Identity (MMSI). Has to be 9 digits. See http://en.wikipedia.org/wiki/Maritime_Mobile_Service_Identity for information.",
-            "required": false,
-            "maxLength": 9,
-            "minLength": 9
-        },
-        "uuid": {
-            "type": "string",
-            "description": "UUID assigned by the implementation of the Signal K server to vessels that don't have a MMSI. Has to be 8 characters (chosen so one could use the first block in a RFC4122 UUID), to distinguish from MMSI.",
-            "maxLength": 8,
-            "minLength": 8,
-            "example": "550E8AB0"
-        },
-        "sail": {
-            "type": "object",
-            "description": "'sail' data type.",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "required": true,
-                    "description": "An unique identifier by which the crew identifies a sail",
-                    "example": "J1"
-                },
-                "type": {
-                    "type": "string",
-                    "required": true,
-                    "description": "The type of sail",
-                    "example": "Genaker"
-                },
-                "material": {
-                    "type": "string",
-                    "required": false,
-                    "description": "The material the sail is made from (optional)",
-                    "example": "canvas"
-                },
-                "brand": {
-                    "type": "string",
-                    "required": false,
-                    "description": "The brand of the sail (optional)",
-                    "example": "North Sails"
-                },
-                "active": {
-                    "type": "boolean",
-                    "required": true,
-                    "description": "Indicates wether this sail is currently in use or not"
-                },
-                "area": {
-                    "type": "number",
-                    "required": true,
-                    "description": "The total area of this sail in square meters (m2)"
-                },
-                "minimumWind": {
-                    "type": "number",
-                    "description": "The minimum wind speed this sail can be used with, measured in m/s",
-                    "default": 0
-                },
-                "maximumWind": {
-                    "type": "number",
-                    "description": "The maximum wind speed this sail can be used with, measured in m/s",
-                    "default": 666
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "#/definitions/timestamp"
-                },
-                "source": {
-                    "$ref": "#/definitions/source"
-                },
-                "_attr": {
-                    "$ref": "#/definitions/_attr"
-                },
-                "meta": {
-                    "$ref": "#/definitions/meta"
-                }
-            }
-        },
-        "stringValue": {
-            "type": "object",
-            "description": "Data should be of type string.",
-            "properties": {
-                "value": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "#/definitions/timestamp"
-                },
-                "source": {
-                    "$ref": "#/definitions/source"
-                },
-                "_attr": {
-                    "$ref": "#/definitions/_attr"
-                },
-                "meta": {
-                    "$ref": "#/definitions/meta"
-                }
-            }
-        },
-        "numberValue": {
-            "type": "object",
-            "description": "Data should be of type number.",
-            "properties": {
-                "value": {
-                    "type": "number"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "#/definitions/timestamp"
-                },
-                "source": {
-                    "$ref": "#/definitions/source"
-                },
-                "_attr": {
-                    "$ref": "#/definitions/_attr"
-                },
-                "meta": {
-                    "$ref": "#/definitions/meta"
-                }
-            }
-        },
-        "floatValue": {
-            "type": "object",
-            "description": "Data should be of type float/double.",
-            "properties": {
-                "value": {
-                    "type": "number"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "#/definitions/timestamp"
-                },
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "#/definitions/source"
-                },
-                "_attr": {
-                    "$ref": "#/definitions/_attr"
-                },
-                "meta": {
-                    "$ref": "#/definitions/meta"
-                }
-            }
-        },
-        "nullValue": {
-            "type": "object",
-            "description": "Data should be of type NULL.",
-            "properties": {
-                "value": {
-                    "type": "null"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "#/definitions/timestamp"
-                },
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "#/definitions/source"
-                },
-                "_attr": {
-                    "$ref": "#/definitions/_attr"
-                },
-                "meta": {
-                    "$ref": "#/definitions/meta"
-                }
-            }
-        },
-        "_attr": {
-            "type": "object",
-            "title": "_attr schema.",
-            "description": "Filesystem specific data, eg security, possibly more later.",
-            "properties": {
-                "_mode": {
-                    "type": "integer",
-                    "title": "_mode schema.",
-                    "description": "Unix style permissions, often written in `owner:group:other` form, `-rw-r--r--`",
-                    "default": 644
-                },
-                "_owner": {
-                    "type": "string",
-                    "title": "_owner schema.",
-                    "description": "The owner of this resource.",
-                    "default": "self"
-                },
-                "_group": {
-                    "type": "string",
-                    "title": "_group schema.",
-                    "description": "The group owning this resource.",
-                    "default": "self"
-                }
-            }
-        },
-        "meta": {
-            "type": "object",
-            "title": "Meta schema.",
-            "description": "Provides meta data to enable alarm and display configuration.",
-            "properties": {
-                "displayName": {
-                    "type": "string",
-                    "title": "DisplayName schema.",
-                    "description": "A display name for this value.",
-                    "example": "Tachometer, Engine 1"
-                },
-                "longName": {
-                    "type": "string",
-                    "title": "LongName schema.",
-                    "description": "A long name for this value.",
-                    "example": "Tachometer, Engine 1"
-                },
-                "shortName": {
-                    "type": "string",
-                    "title": "ShortName schema.",
-                    "description": "A short name for this value.",
-                    "example": "RPM"
-                },
-                "guageType": {
-                    "type": "string",
-                    "title": "guageType schema.",
-                    "description": "The type of gauge necessary to display this value.",
-                    "example": "sparkline"
-                },
-                "unit": {
-                    "type": "string",
-                    "title": "unit schema.",
-                    "description": "The SI unit of this value.",
-                    "example": "m/s"
-                },
-                "warnMethod": {
-                    "type": "string",
-                    "title": "WarnMethod schema.",
-                    "description": "The method to use to raise the warning.",
-                    "default": "visual",
-                    "enum": [
-                        "visual",
-                        "sound"
-                    ]
-                },
-                "alarmMethod": {
-                    "type": "string",
-                    "title": "AlarmMethod schema.",
-                    "description": "The method to use to raise the alarm",
-                    "default": "sound",
-                    "enum": [
-                        "visual",
-                        "sound"
-                    ]
-                },
-                "zones": {
-                    "type": "array",
-                    "title": "Zones schema.",
-                    "description": "The zones defining the range of values for this signalk value.",
-                    "items": [
-                        {
-                            "type": "array",
-                            "title": "zone",
-                            "description": "A zone used to define the display and alarm state when the value is in between bottom and top.",
-                            "items": [
-                                {
-                                    "id": "bottom",
-                                    "type": "number",
-                                    "title": "Bottom",
-                                    "description": "The lowest number in this zone",
-                                    "name": "bottom",
-                                    "example": 3500
-                                },
-                                {
-                                    "id": "top",
-                                    "type": "number",
-                                    "title": "top",
-                                    "description": "The highest value in this zone",
-                                    "name": "1",
-                                    "example": 4000
-                                },
-                                {
-                                    "id": "alarmState",
-                                    "type": "string",
-                                    "title": "alarmState",
-                                    "description": "The alarm state when the value is in this zone.",
-                                    "name": "alarmState",
-                                    "default": "normal",
-                                    "enum": [
-                                        "normal",
-                                        "warn",
-                                        "alarm"
-                                    ]
-                                },
-                                {
-                                    "id": "message",
-                                    "type": "string",
-                                    "title": "message",
-                                    "description": "The message to display for the alarm.",
-                                    "default": "Warning"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
+        "pgn": {
+          "type": "number",
+          "description": "NMEA2000 pgn of the source message"
         }
+      }
+    },
+    
+    "version": {
+      "type": "string",
+      "description": "Version of the Signal K root object.",
+      "example": "1.0"
+    },
+
+    "mmsi": {
+      "type": "string",
+      "description": "Maritime Mobile Service Identity (MMSI). Has to be 9 digits. See http://en.wikipedia.org/wiki/Maritime_Mobile_Service_Identity for information.",
+      "required": false,
+      "maxLength": 9,
+      "minLength": 9
+    },
+
+    "uuid": {
+      "type": "string",
+      "description": "UUID assigned by the implementation of the Signal K server to vessels that don't have a MMSI. Has to be 8 characters (chosen so one could use the first block in a RFC4122 UUID), to distinguish from MMSI.",
+      "maxLength": 8,
+      "minLength": 8,
+      "example": "550E8AB0"
+    },
+
+    "sail": {
+      "type": "object",
+      "description": "'sail' data type.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "required": true,
+          "description": "An unique identifier by which the crew identifies a sail",
+          "example": "J1"
+        },
+        
+        "type": {
+          "type": "string",
+          "required": true,
+          "description": "The type of sail",
+          "example": "Genaker"
+        },
+        
+        "material": {
+          "type": "string",
+          "required": false,
+          "description": "The material the sail is made from (optional)",
+          "example": "canvas"
+        },
+
+        "brand": {
+          "type": "string",
+          "required": false,
+          "description": "The brand of the sail (optional)",
+          "example": "North Sails"
+        },
+
+        "active": {
+          "type": "boolean",
+          "required": true,
+          "description": "Indicates wether this sail is currently in use or not"
+        },
+
+        "area": {
+          "type": "number",
+          "required": true,
+          "description": "The total area of this sail in square meters (m2)"
+        },
+
+        "minimumWind": {
+          "type": "number",
+          "description": "The minimum wind speed this sail can be used with, measured in m/s",
+          "default": 0
+        },
+
+        "maximumWind": {
+          "type": "number",
+          "description": "The maximum wind speed this sail can be used with, measured in m/s",
+          "default": 666
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "#/definitions/timestamp"
+        },
+
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+
+        "_attr": {
+          "$ref": "#/definitions/_attr"
+        },
+
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      }
+    },
+
+    "stringValue": {
+      "type": "object",
+      "description": "Data should be of type string.",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "#/definitions/timestamp"
+        },
+    
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+    
+        "_attr": {
+          "$ref": "#/definitions/_attr"
+        },
+    
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      }
+    },
+
+    "numberValue": {
+      "type": "object",
+      "description": "Data should be of type number.",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "#/definitions/timestamp"
+        },
+  
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+
+        "_attr": {
+          "$ref": "#/definitions/_attr"
+        },
+  
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      }
+    },
+
+    "floatValue": {
+      "type": "object",
+      "description": "Data should be of type float/double.",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+  
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "#/definitions/timestamp"
+        },
+  
+        "source": {
+          "description": "Source of this data",
+          "$ref": "#/definitions/source"
+        },
+
+        "_attr": {
+          "$ref": "#/definitions/_attr"
+        },
+    
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      }
+    },
+
+    "nullValue": {
+      "type": "object",
+      "description": "Data should be of type NULL.",
+      "properties": {
+        "value": {
+          "type": "null"
+        },
+  
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "#/definitions/timestamp"
+        },
+  
+        "source": {
+          "description": "Source of this data",
+          "$ref": "#/definitions/source"
+        },
+
+        "_attr": {
+          "$ref": "#/definitions/_attr"
+        },
+
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      }
+    },
+  
+    "_attr": {
+      "type": "object",
+      "title": "_attr schema.",
+      "description": "Filesystem specific data, eg security, possibly more later.",
+      "properties": {
+        "_mode": {
+          "type": "integer",
+          "title": "_mode schema.",
+          "description": "Unix style permissions, often written in `owner:group:other` form, `-rw-r--r--`",
+          "default": 644
+        },
+
+        "_owner": {
+          "type": "string",
+          "title": "_owner schema.",
+          "description": "The owner of this resource.",
+          "default": "self"
+        },
+
+        "_group": {
+          "type": "string",
+          "title": "_group schema.",
+          "description": "The group owning this resource.",
+          "default": "self"
+        }
+      }
+    },
+  
+    "meta": {
+      "type": "object",
+      "title": "Meta schema.",
+      "description": "Provides meta data to enable alarm and display configuration.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "title": "DisplayName schema.",
+          "description": "A display name for this value.",
+          "example": "Tachometer, Engine 1"
+        },
+  
+        "longName": {
+          "type": "string",
+          "title": "LongName schema.",
+          "description": "A long name for this value.",
+          "example": "Tachometer, Engine 1"
+        },
+  
+        "shortName": {
+          "type": "string",
+          "title": "ShortName schema.",
+          "description": "A short name for this value.",
+          "example": "RPM"
+        },
+  
+        "guageType": {
+          "type": "string",
+          "title": "guageType schema.",
+          "description": "The type of gauge necessary to display this value.",
+          "example": "sparkline"
+        },
+  
+        "unit": {
+          "type": "string",
+          "title": "unit schema.",
+          "description": "The SI unit of this value.",
+          "example": "m/s"
+        },
+
+        "warnMethod": {
+          "type": "string",
+          "title": "WarnMethod schema.",
+          "description": "The method to use to raise the warning.",
+          "default": "visual",
+          "enum": [
+            "visual",
+            "sound"
+          ]
+        },
+  
+        "alarmMethod": {
+          "type": "string",
+          "title": "AlarmMethod schema.",
+          "description": "The method to use to raise the alarm",
+          "default": "sound",
+          "enum": [
+            "visual",
+            "sound"
+          ]
+        },
+  
+        "zones": {
+          "type": "array",
+          "title": "Zones schema.",
+          "description": "The zones defining the range of values for this signalk value.",
+          "items": [
+            {
+              "type": "array",
+              "title": "zone",
+              "description": "A zone used to define the display and alarm state when the value is in between bottom and top.",
+              "items": [
+                {
+                  "id": "bottom",
+                  "type": "number",
+                  "title": "Bottom",
+                  "description": "The lowest number in this zone",
+                  "name": "bottom",
+                  "example": 3500
+                },
+  
+                {
+                  "id": "top",
+                  "type": "number",
+                  "title": "top",
+                  "description": "The highest value in this zone",
+                  "name": "1",
+                  "example": 4000
+                },
+                
+                {
+                  "id": "alarmState",
+                  "type": "string",
+                  "title": "alarmState",
+                  "description": "The alarm state when the value is in this zone.",
+                  "name": "alarmState",
+                  "default": "normal",
+                  "enum": [
+                    "normal",
+                    "warn",
+                    "alarm"
+                  ]
+                },
+                
+                {
+                  "id": "message",
+                  "type": "string",
+                  "title": "message",
+                  "description": "The message to display for the alarm.",
+                  "default": "Warning"
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
+  }
 }

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -50,23 +50,23 @@
       "type": "string",
       "description": "",
       "enum": [
-        "Liters (l)",
-        "Arc degrees (°)",
-        "Arc degrees per second (°/s)",
-        "Amperage (A)",
-        "Amperage per hour (Ah)",
-        "Voltage (V)",
-        "Wattage (W)",
-        "Wattage per hour (Wh)",
-        "Resistance, Ohm (Ω)",
-        "Square meters (m2)",
-        "Meters (m)",
-        "Degree Celcius (°C)",
-        "Pascal (Pa)",
-        "Kilo Pascal (kPa)",
-        "Liters per hour (L/h)",
-        "Percentage (%)",
-        "Meters per second (m/s)"
+        "l",
+        "°",
+        "°/s",
+        "A",
+        "Ah",
+        "V",
+        "W",
+        "Wh",
+        "Ω",
+        "m2",
+        "m",
+        "°C",
+        "Pa",
+        "kPa",
+        "l/h",
+        "%",
+        "m/s"
       ]
     },
 
@@ -128,20 +128,20 @@
           "type": "number",
           "required": true,
           "description": "The total area of this sail in square meters",
-          "units": "Square meters (m2)"
+          "units": "m2"
         },
 
         "minimumWind": {
           "type": "number",
           "description": "The minimum wind speed this sail can be used with, measured in m/s",
-          "units": "Meters per second (m/s)",
+          "units": "m/s",
           "default": 0
         },
 
         "maximumWind": {
           "type": "number",
           "description": "The maximum wind speed this sail can be used with, measured in m/s",
-          "units": "Meters per second (m/s)",
+          "units": "m/s",
           "default": 666
         },
 

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -46,6 +46,30 @@
       "example": "1.0"
     },
 
+    "units": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Liters (l)",
+        "Arc degrees (°)",
+        "Arc degrees per second (°/s)",
+        "Amperage (A)",
+        "Amperage per hour (Ah)",
+        "Voltage (V)",
+        "Wattage (W)",
+        "Wattage per hour (Wh)",
+        "Resistance, Ohm (Ω)",
+        "Square meters (m2)",
+        "Meters (m)",
+        "Degree Celcius (°C)",
+        "Pascal (Pa)",
+        "Kilo Pascal (kPa)",
+        "Liters per hour (L/h)",
+        "Percentage (%)",
+        "Meters per second (m/s)"
+      ]
+    },
+
     "mmsi": {
       "type": "string",
       "description": "Maritime Mobile Service Identity (MMSI). Has to be 9 digits. See http://en.wikipedia.org/wiki/Maritime_Mobile_Service_Identity for information.",
@@ -103,23 +127,25 @@
         "area": {
           "type": "number",
           "required": true,
-          "description": "The total area of this sail in square meters (m2)"
+          "description": "The total area of this sail in square meters",
+          "units": "Square meters (m2)"
         },
 
         "minimumWind": {
           "type": "number",
           "description": "The minimum wind speed this sail can be used with, measured in m/s",
+          "units": "Meters per second (m/s)",
           "default": 0
         },
 
         "maximumWind": {
           "type": "number",
           "description": "The maximum wind speed this sail can be used with, measured in m/s",
+          "units": "Meters per second (m/s)",
           "default": 666
         },
 
         "timestamp": {
-          "description": "timestamp of the last update to this data",
           "$ref": "#/definitions/timestamp"
         },
 
@@ -146,7 +172,6 @@
         },
         
         "timestamp": {
-          "description": "timestamp of the last update to this data",
           "$ref": "#/definitions/timestamp"
         },
     
@@ -173,7 +198,6 @@
         },
 
         "timestamp": {
-          "description": "timestamp of the last update to this data",
           "$ref": "#/definitions/timestamp"
         },
   
@@ -200,12 +224,10 @@
         },
   
         "timestamp": {
-          "description": "timestamp of the last update to this data",
           "$ref": "#/definitions/timestamp"
         },
   
         "source": {
-          "description": "Source of this data",
           "$ref": "#/definitions/source"
         },
 
@@ -228,12 +250,10 @@
         },
   
         "timestamp": {
-          "description": "timestamp of the last update to this data",
           "$ref": "#/definitions/timestamp"
         },
   
         "source": {
-          "description": "Source of this data",
           "$ref": "#/definitions/source"
         },
 
@@ -250,7 +270,7 @@
     "_attr": {
       "type": "object",
       "title": "_attr schema.",
-      "description": "Filesystem specific data, eg security, possibly more later.",
+      "description": "Filesystem specific data, e.g. security, possibly more later.",
       "properties": {
         "_mode": {
           "type": "integer",
@@ -308,9 +328,9 @@
           "example": "sparkline"
         },
   
-        "unit": {
+        "units": {
           "type": "string",
-          "title": "unit schema.",
+          "title": "units schema.",
           "description": "The SI unit of this value.",
           "example": "m/s"
         },

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -1,51 +1,56 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/delta.json#",
-    "title": "SignalK Delta message schema",
-    "description": "Schema for defining updates to parts of a SignalK data model, for example for communicating updates of data",
-    "properties": {
-        "context": {
-            "type": "string",
-            "description": "The context path of the updates, eg. the top level path plus object identifier."
-        },
-        "updates": {
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/delta.json#",
+  "title": "SignalK Delta message schema",
+  "description": "Schema for defining updates to parts of a SignalK data model, for example for communicating updates of data",
+  "properties": {
+    "context": {
+      "type": "string",
+      "description": "The context path of the updates, eg. the top level path plus object identifier."
+    },
+  
+    "updates": {
+      "type": "array",
+      "description": "The updates",
+      "items": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "$ref": "./definitions.json#/definitions/source"
+          },
+          
+          "timestamp": {
+            "$ref": "./definitions.json#/definitions/timestamp"
+          },
+  
+          "values": {
             "type": "array",
-            "description": "The updates",
             "items": {
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "$ref": "./definitions.json#/definitions/source"
-                    },
-                    "timestamp": {
-                        "$ref": "./definitions.json#/definitions/timestamp"
-                    },
-                    "values": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "path": {
-                                    "type": "string",
-                                    "required": true
-                                },
-                                "value": {
-                                    "type": [
-                                      "string",
-                                      "number",
-                                      "object",
-                                      "boolean",
-                                      "null"
-                                    ],
-                                    "required": true,
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    }
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "required": true
+                },
+
+                "value": {
+                  "type": [
+                    "string",
+                    "number",
+                    "object",
+                    "boolean",
+                    "null"
+                  ],
+                  
+                  "required": true,
+                  "additionalProperties": true
                 }
+              }
             }
+          }
         }
+      }
     }
+  }
 }

--- a/schemas/groups/alarms.json
+++ b/schemas/groups/alarms.json
@@ -1,30 +1,33 @@
 {
-    "type": "object",
-    "id": "https://signalk.github.io/specification/schemas/groups/alarms.json#",
-    "title": "alarms",
-    "description": "Alarms, their state, and actions. The alarm limits are set in any Signal K key.meta.zones array.",
-    "required": false,
-    "properties": {
-        "alarmMethod": {
-            "description": "Method to use to raise alarms",
-            "$ref": "../definitions.json#/definitions/alarmMethod"
-        },
-        "alarmState": {
-            "description": "Current alarm state",
-            "$ref": "../definitions.json#/definitions/alarmValue"
-        },
-        "message": {
-            "description": "Message to display or speak",
-            "type": "string"
-        },
-	"timestamp": { 
+  "type": "object",
+  "id": "https://signalk.github.io/specification/schemas/groups/alarms.json#",
+  "title": "alarms",
+  "description": "Alarms, their state, and actions. The alarm limits are set in any Signal K key.meta.zones array.",
+  "required": false,
+  "properties": {
+    "alarmMethod": {
+      "description": "Method to use to raise alarms",
+      "$ref": "../definitions.json#/definitions/alarmMethod"
+    },
+    
+    "alarmState": {
+      "description": "Current alarm state",
+      "$ref": "../definitions.json#/definitions/alarmValue"
+    },
+
+    "message": {
+      "description": "Message to display or speak",
+      "type": "string"
+    },
+
+  	"timestamp": { 
 	    "description":"timestamp of the last update to this data",
 	    "$ref": "../definitions.json#/definitions/timestamp"
-	},
+  	},
 
-	"source": { 
+  	"source": { 
 	    "description":"Source of this data",
 	    "$ref": "../definitions.json#/definitions/source"
-	}
-    }
+  	}
+  }
 }

--- a/schemas/groups/communication.json
+++ b/schemas/groups/communication.json
@@ -1,60 +1,68 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/communication.json#",
-    "description": "Schema describing the communication child-object of a Vessel.",
-    "title": "communication",
-    "properties": {
-        "callsignDsc": {
-            "type": "string",
-            "description": "Callsign for DSC communication",
-            "example": "ZL1234"
-        },
-        "callsignHf": {
-            "type": "string",
-            "description": "Callsign for HF communication",
-            "example": "ZL3RTH"
-        },
-        "callsignVhf": {
-            "type": "string",
-            "description": "Callsign for VHF communication",
-            "example": "ZM2038"
-        },
-        "cellPhone": {
-            "type": "string",
-            "description": "Cellphone number of skipper",
-            "example": "+64xxxxxx"
-        },
-        "emailHf": {
-            "type": "string",
-            "description": "Email address to be used for HF email (Winmail, Airmail, Sailmail)",
-            "example": "motu@xxx.co.nz"
-        },
-        "email": {
-            "type": "string",
-            "description": "Regular email for the skipper",
-            "example": "robert@xxx.co.nz"
-        },
-        "satPhone": {
-            "type": "string",
-            "description": "Satellite phone number for vessel.",
-            "example": "+64xxxxxx"
-        },
-        "skipperName": {
-            "type": "string",
-            "description": "Full name of the skipper of the vessel.",
-            "example": "Fabian Tollenaar"
-        },
-        "crewNames": {
-            "type": "array",
-            "description": "Array with the names of the crew",
-            "additionalProperties": [
-                {
-                    "type": "string",
-                    "description": "Name of a crew member of the vessel.",
-                    "example": "Catherine"
-                }
-            ]
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/communication.json#",
+  "description": "Schema describing the communication child-object of a Vessel.",
+  "title": "communication",
+  "properties": {
+    "callsignDsc": {
+      "type": "string",
+      "description": "Callsign for DSC communication",
+      "example": "ZL1234"
+    },
+
+    "callsignHf": {
+      "type": "string",
+      "description": "Callsign for HF communication",
+      "example": "ZL3RTH"
+    },
+
+    "callsignVhf": {
+      "type": "string",
+      "description": "Callsign for VHF communication",
+      "example": "ZM2038"
+    },
+
+    "phoneNumber": {
+      "type": "string",
+      "description": "Phone number of skipper",
+      "example": "+64xxxxxx"
+    },
+
+    "emailHf": {
+      "type": "string",
+      "description": "Email address to be used for HF email (Winmail, Airmail, Sailmail)",
+      "example": "motu@xxx.co.nz"
+    },
+
+    "email": {
+      "type": "string",
+      "description": "Regular email for the skipper",
+      "example": "robert@xxx.co.nz"
+    },
+
+    "satPhoneNumber": {
+      "type": "string",
+      "description": "Satellite phone number for vessel.",
+      "example": "+64xxxxxx"
+    },
+
+    "skipperName": {
+      "type": "string",
+      "description": "Full name of the skipper of the vessel.",
+      "example": "Fabian Tollenaar"
+    },
+    
+    "crewNames": {
+      "type": "array",
+      "description": "Array with the names of the crew",
+      "additionalProperties": [
+        {
+          "type": "string",
+          "description": "Name of a crew member of the vessel.",
+          "example": "Catherine"
         }
+      ]
     }
+  }
 }

--- a/schemas/groups/design.json
+++ b/schemas/groups/design.json
@@ -1,148 +1,157 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/design.json#",
-    "description": "An object describing the vessels primary dimensions and statistics.",
-    "title": "design",
-    "properties": {
-        "displacement": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "The displacement of the vessel, measured in kilogram"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/design.json#",
+  "description": "An object describing the vessels primary dimensions and statistics.",
+  "title": "design",
+  "properties": {
+    "displacement": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "The displacement of the vessel, measured in kilogram"
+    },
+    
+    "draft": {
+      "type": "object",
+      "title": "draft",
+      "description": "The draft of the vessel, in meters",
+      "properties": {
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
         },
         
-        "draft": {
-            "type": "object",
-            "title": "draft",
-            "description": "The draft of the vessel, in meters",
-            "properties": {
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "minimum": { 
-                    "description": "The minimum draft of the vessel in meters",
-                    "type": "number"
-                },
-                "maximum": { 
-                    "description": "The maximum draft of the vessel in meters",
-                    "type": "number"
-                },
-                "canoe": { 
-                    "description": "The draft of the vessel without it's keel/centerboard",
-                    "type": "number"
-                }
-            }
+        "minimum": { 
+          "description": "The minimum draft of the vessel in meters",
+          "type": "number"
         },
-
-        "length": {
-            "type": "object",
-            "title": "length",
-            "description": "The various lengths of the vessel",
-            "properties": {
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "overall": {
-                    "type": "number",
-                    "description": "Length overall in meters"
-                },
-                "hull": {
-                    "type": "number",
-                    "description": "Length of hull in meters"
-                },
-                "waterline": {
-                    "type": "number",
-                    "description": "Length at waterline in meters"
-                }
-            }
+        
+        "maximum": { 
+          "description": "The maximum draft of the vessel in meters",
+          "type": "number"
         },
-
-        "keel": {
-            "type": "object",
-            "title": "keel",
-            "description": "Information about the vessel's keel",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "description": "The type of keel.",
-                    "enum": [
-                        "long",
-                        "micky_mouse",
-                        "fin",
-                        "flare",
-                        "bulb",
-                        "wing",
-                        "centerboard",
-                        "kanting",
-                        "lifting",
-                        "daggerboard"
-                    ]
-                },
-
-                "angle": {
-                    "type": "number",
-                    "description": "A number indicating at which angle the keel currently is (in case of a canting keel)."
-                },
-
-                "lift": {
-                  "type": "number",
-                  "description": "In the case of a lifting keel, centreboard or daggerboard, the percent of the keel which is submerged. 0 is 'all the way up' and 1 is 'all the way down'. 0.8 would be 80% down.",
-                  "example": 0.8
-                },
-
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-            }
-        },
-
-        "beam": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Beam length in meters"
-        },
-
-        "airHeight": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Total height of the vessel in meters"
-        },
-
-        "rigging": {
-            "type": "object",
-            "title": "rigging",
-            "description": "Information about the vessel's rigging",
-            "properties": {
-                "configuration": {
-                    "type": "string",
-                    "description": "The configuration of the rigging. Example: 'sloop' or 'gaff cutter'"
-                },
-                "masts": {
-                    "type": "number",
-                    "description": "The number of masts on the vessel."
-                },
-
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                }
-            }
+        
+        "canoe": { 
+          "description": "The draft of the vessel without it's keel/centerboard",
+          "type": "number"
         }
+      }
+    },
+
+    "length": {
+      "type": "object",
+      "title": "length",
+      "description": "The various lengths of the vessel",
+      "properties": {
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+        
+        "overall": {
+          "type": "number",
+          "description": "Length overall in meters"
+        },
+        
+        "hull": {
+          "type": "number",
+          "description": "Length of hull in meters"
+        },
+        
+        "waterline": {
+          "type": "number",
+          "description": "Length at waterline in meters"
+        }
+      }
+    },
+
+    "keel": {
+      "type": "object",
+      "title": "keel",
+      "description": "Information about the vessel's keel",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of keel.",
+          "enum": [
+            "long",
+            "micky_mouse",
+            "fin",
+            "flare",
+            "bulb",
+            "wing",
+            "centerboard",
+            "kanting",
+            "lifting",
+            "daggerboard"
+          ]
+        },
+
+        "angle": {
+          "type": "number",
+          "description": "A number indicating at which angle the keel currently is (in case of a canting keel)."
+        },
+
+        "lift": {
+          "type": "number",
+          "description": "In the case of a lifting keel, centreboard or daggerboard, the percent of the keel which is submerged. 0 is 'all the way up' and 1 is 'all the way down'. 0.8 would be 80% down.",
+          "example": 0.8
+        },
+
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        }
+      }
+    },
+
+    "beam": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Beam length in meters"
+    },
+
+    "airHeight": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Total height of the vessel in meters"
+    },
+
+    "rigging": {
+      "type": "object",
+      "title": "rigging",
+      "description": "Information about the vessel's rigging",
+      "properties": {
+        "configuration": {
+          "type": "string",
+          "description": "The configuration of the rigging. Example: 'sloop' or 'gaff cutter'"
+        },
+        "masts": {
+          "type": "number",
+          "description": "The number of masts on the vessel."
+        },
+
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        }
+      }
     }
+  }
 }

--- a/schemas/groups/design.json
+++ b/schemas/groups/design.json
@@ -8,7 +8,7 @@
     "displacement": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "The displacement of the vessel, measured in kilogram",
-      "units": "Kilogram (kg)"
+      "units": "kg"
     },
     
     "draft": {
@@ -29,19 +29,19 @@
         "minimum": { 
           "description": "The minimum draft of the vessel in meters",
           "type": "number",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "maximum": { 
           "description": "The maximum draft of the vessel in meters",
           "type": "number",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "canoe": { 
           "description": "The draft of the vessel without it's keel/centerboard",
           "type": "number",
-          "units": "Meters (m)"
+          "units": "m"
         }
       }
     },
@@ -64,19 +64,19 @@
         "overall": {
           "type": "number",
           "description": "Length overall in meters",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "hull": {
           "type": "number",
           "description": "Length of hull in meters",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "waterline": {
           "type": "number",
           "description": "Length at waterline in meters",
-          "units": "Meters (m)"
+          "units": "m"
         }
       }
     },
@@ -106,7 +106,7 @@
         "angle": {
           "type": "number",
           "description": "A number indicating at which angle the keel currently is (in case of a canting keel).",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
 
         "lift": {
@@ -130,13 +130,13 @@
     "beam": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Beam length in meters",
-      "units": "Meters (m)"
+      "units": "m"
     },
 
     "airHeight": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Total height of the vessel in meters",
-      "units": "Meters (m)"
+      "units": "m"
     },
 
     "rigging": {

--- a/schemas/groups/design.json
+++ b/schemas/groups/design.json
@@ -7,7 +7,8 @@
   "properties": {
     "displacement": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "The displacement of the vessel, measured in kilogram"
+      "description": "The displacement of the vessel, measured in kilogram",
+      "units": "Kilogram (kg)"
     },
     
     "draft": {
@@ -27,17 +28,20 @@
         
         "minimum": { 
           "description": "The minimum draft of the vessel in meters",
-          "type": "number"
+          "type": "number",
+          "units": "Meters (m)"
         },
         
         "maximum": { 
           "description": "The maximum draft of the vessel in meters",
-          "type": "number"
+          "type": "number",
+          "units": "Meters (m)"
         },
         
         "canoe": { 
           "description": "The draft of the vessel without it's keel/centerboard",
-          "type": "number"
+          "type": "number",
+          "units": "Meters (m)"
         }
       }
     },
@@ -59,17 +63,20 @@
         
         "overall": {
           "type": "number",
-          "description": "Length overall in meters"
+          "description": "Length overall in meters",
+          "units": "Meters (m)"
         },
         
         "hull": {
           "type": "number",
-          "description": "Length of hull in meters"
+          "description": "Length of hull in meters",
+          "units": "Meters (m)"
         },
         
         "waterline": {
           "type": "number",
-          "description": "Length at waterline in meters"
+          "description": "Length at waterline in meters",
+          "units": "Meters (m)"
         }
       }
     },
@@ -98,7 +105,8 @@
 
         "angle": {
           "type": "number",
-          "description": "A number indicating at which angle the keel currently is (in case of a canting keel)."
+          "description": "A number indicating at which angle the keel currently is (in case of a canting keel).",
+          "units": "Arc degrees (°)"
         },
 
         "lift": {
@@ -121,12 +129,14 @@
 
     "beam": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Beam length in meters"
+      "description": "Beam length in meters",
+      "units": "Meters (m)"
     },
 
     "airHeight": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Total height of the vessel in meters"
+      "description": "Total height of the vessel in meters",
+      "units": "Meters (m)"
     },
 
     "rigging": {

--- a/schemas/groups/electrical_ac.json
+++ b/schemas/groups/electrical_ac.json
@@ -1,1028 +1,1028 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/electrical_ac.json#",
-    "description": "Schema describing electric measurements pertaining to shore power, AC generators, etc.",
-    "title": "AC Electrical Properties",
-    "properties": {
-        "bus1": {
-            "type": "object",
-            "title": "Bus #1",
-            "description": "Main AC power bus on the vessel",
-            "properties": {
-                "phaseA": {
-                    "type": "object",
-                    "title": "Bus #1, Phase A",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between bus phase A and phase B.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between bus phase A and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Bus phase A frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        }
-                    }
-                },
-                "phaseB": {
-                    "type": "object",
-                    "title": "Bus #1, Phase B",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between bus phase B and phase C.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between bus phase B and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Bus phase B frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        }
-                    }
-                },
-                "phaseC": {
-                    "type": "object",
-                    "title": "Bus #1, Phase C",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between bus phase C and phase A.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between bus phase C and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Bus phase C frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        }
-                    }
-                },
-                "average": {
-                    "type": "object",
-                    "title": "Bus #1, Average",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase bus.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase bus.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Average frequency of the bus.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        }
-                    }
-                }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/electrical_ac.json#",
+  "description": "Schema describing electric measurements pertaining to shore power, AC generators, etc.",
+  "title": "AC Electrical Properties",
+  "properties": {
+    "bus1": {
+      "type": "object",
+      "title": "Bus #1",
+      "description": "Main AC power bus on the vessel",
+      "properties": {
+        "phaseA": {
+          "type": "object",
+          "title": "Bus #1, Phase A",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between bus phase A and phase B.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between bus phase A and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Bus phase A frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
             }
+          }
         },
-        "utility": {
-            "type": "object",
-            "title": "Utility (Shore Power)",
-            "description": "Vessel's shore power connection",
-            "properties": {
-                "phaseA": {
-                    "type": "object",
-                    "title": "Utility, Phase A",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between utility phase A and phase B.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between utility phase A and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Utility phase A frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        },
-                        "reactivePower": {
-                            "type": "object",
-                            "title": "Reactive power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "reactivePower": {
-                                    "type": "integer",
-                                    "description": "Utility phase A reactive power",
-                                    "units": "VAr",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 5000
-                                },
-                                "powerFactor": {
-                                    "type": "number",
-                                    "description": "Utility phase A power factor",
-                                    "minimum": -1.0,
-                                    "maximum": 1.0,
-                                    "example": 0.97
-                                },
-                                "powerFactorLagging": {
-                                    "enum": [
-                                        "leading",
-                                        "lagging",
-                                        "error",
-                                        "not available"
-                                    ],
-                                    "description": "Utility phase A lead/lag status.",
-                                    "example": "Leading"
-                                }
-                            }
-                        },
-                        "realPower": {
-                            "type": "object",
-                            "title": "Real Power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "realPower": {
-                                    "type": "number",
-                                    "description": "Utility phase A real power.",
-                                    "units": "W",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                },
-                                "apparentPower": {
-                                    "type": "number",
-                                    "description": "Utility phase A apparent power.",
-                                    "units": "VA",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                }
-                            }
-                        }
-                    }
-                },
-                "phaseB": {
-                    "type": "object",
-                    "title": "Utility, Phase B",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between utility phase B and phase C.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between utility phase B and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Utility phase B frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        },
-                        "reactivePower": {
-                            "type": "object",
-                            "title": "Reactive power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "reactivePower": {
-                                    "type": "integer",
-                                    "description": "Utility phase B reactive power",
-                                    "units": "VAr",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 5000
-                                },
-                                "powerFactor": {
-                                    "type": "number",
-                                    "description": "Utility phase B power factor",
-                                    "minimum": -1.0,
-                                    "maximum": 1.0,
-                                    "example": 0.97
-                                },
-                                "powerFactorLagging": {
-                                    "enum": [
-                                        "leading",
-                                        "lagging",
-                                        "error",
-                                        "not available"
-                                    ],
-                                    "description": "Utility phase B lead/lag status.",
-                                    "example": "Leading"
-                                }
-                            }
-                        },
-                        "realPower": {
-                            "type": "object",
-                            "title": "Real Power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "realPower": {
-                                    "type": "number",
-                                    "description": "Utility phase B real power.",
-                                    "units": "W",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                },
-                                "apparentPower": {
-                                    "type": "number",
-                                    "description": "Utility phase B apparent power.",
-                                    "units": "VA",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                }
-                            }
-                        }
-                    }
-                },
-                "phaseC": {
-                    "type": "object",
-                    "title": "Utility, Phase C",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between utility phase C and phase A.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between utility phase C and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Utility phase C frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        },
-                        "reactivePower": {
-                            "type": "object",
-                            "title": "Reactive power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "reactivePower": {
-                                    "type": "integer",
-                                    "description": "Utility phase C reactive power",
-                                    "units": "VAr",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 5000
-                                },
-                                "powerFactor": {
-                                    "type": "number",
-                                    "description": "Utility phase C power factor",
-                                    "minimum": -1.0,
-                                    "maximum": 1.0,
-                                    "example": 0.97
-                                },
-                                "powerFactorLagging": {
-                                    "enum": [
-                                        "leading",
-                                        "lagging",
-                                        "error",
-                                        "not available"
-                                    ],
-                                    "description": "Utility phase C lead/lag status.",
-                                    "example": "Leading"
-                                }
-                            }
-                        },
-                        "realPower": {
-                            "type": "object",
-                            "title": "Real Power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "realPower": {
-                                    "type": "number",
-                                    "description": "Utility phase C real power.",
-                                    "units": "W",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                },
-                                "apparentPower": {
-                                    "type": "number",
-                                    "description": "Utility phase C apparent power.",
-                                    "units": "VA",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                }
-                            }
-                        }
-                    }
-                },
-                "average": {
-                    "type": "object",
-                    "title": "Utility, Average",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase utility connection.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase utility connection.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Average frequency of the utility connection.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        }
-                    }
-                },
-                "energy": {
-                    "type": "object",
-                    "title": "Utility, Energy Totals",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "totalExport": {
-                            "type": "integer",
-                            "description": "Total kilowatt hours exported by the utility",
-                            "units": "kWh",
-                            "minimum": 0,
-                            "maximum": 4211081215,
-                            "example": 12000
-                        },
-                        "totalImport": {
-                            "type": "integer",
-                            "description": "Total kilowatt hours imported by the utility",
-                            "units": "kWh",
-                            "minimum": 0,
-                            "maximum": 4211081215,
-                            "example": 12000
-                        }
-                    }
-                },
-                "reactivePower": {
-                    "type": "object",
-                    "title": "Utility, Reactive Power",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "reactivePower": {
-                            "type": "integer",
-                            "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
-                            "units": "VAr",
-                            "minimum": -2000000000,
-                            "maximum": 2211081215,
-                            "example": 5000
-                        },
-                        "powerFactor": {
-                            "type": "number",
-                            "description": "Average power factor for utility.",
-                            "minimum": -1.0,
-                            "maximum": 1.0,
-                            "example": 0.97
-                        },
-                        "powerFactorLagging": {
-                            "enum": ["Leading", "Lagging", "Error", "Not Available"],
-                            "description": "Lead/lag status for utility.",
-                            "example": "Leading"
-                        }
-                    }
-                },
-                "realPower": {
-                    "type": "object",
-                    "title": "Utility, Real Power",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "realPower": {
-                            "type": "number",
-                            "description": "Total real power delivered by the utility. Real power must be signed since power may flow in both directions.",
-                            "units": "W",
-                            "minimum": -2000000000,
-                            "maximum": 2211081215,
-                            "example": 10500
-                        },
-                        "apparentPower": {
-                            "type": "number",
-                            "description": "Total apparent power delivered by the utility. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
-                            "units": "VA",
-                            "minimum": -2000000000,
-                            "maximum": 2211081215,
-                            "example": 10500
-                        }
-                    }
-                }
+        "phaseB": {
+          "type": "object",
+          "title": "Bus #1, Phase B",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between bus phase B and phase C.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between bus phase B and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Bus phase B frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
             }
+          }
         },
-        "generator": {
-            "type": "object",
-            "title": "Generator",
-            "description": "Vessel's generator",
-            "properties": {
-                "phaseA": {
-                    "type": "object",
-                    "title": "Generator, Phase A",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between generator phase A and phase B.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between generator phase A and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Generator phase A frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        },
-                        "reactivePower": {
-                            "type": "object",
-                            "title": "Reactive power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "reactivePower": {
-                                    "type": "integer",
-                                    "description": "Generator phase A reactive power",
-                                    "units": "VAr",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 5000
-                                },
-                                "powerFactor": {
-                                    "type": "number",
-                                    "description": "Generator phase A power factor",
-                                    "minimum": -1.0,
-                                    "maximum": 1.0,
-                                    "example": 0.97
-                                },
-                                "powerFactorLagging": {
-                                    "enum": [
-                                        "leading",
-                                        "lagging",
-                                        "error",
-                                        "not available"
-                                    ],
-                                    "description": "Generator phase A lead/lag status.",
-                                    "example": "Leading"
-                                }
-                            }
-                        },
-                        "realPower": {
-                            "type": "object",
-                            "title": "Real Power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "realPower": {
-                                    "type": "number",
-                                    "description": "Generator phase A real power.",
-                                    "units": "W",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                },
-                                "apparentPower": {
-                                    "type": "number",
-                                    "description": "Generator phase A apparent power.",
-                                    "units": "VA",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                }
-                            }
-                        }
-                    }
-                },
-                "phaseB": {
-                    "type": "object",
-                    "title": "Generator, Phase B",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between generator phase B and phase C.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between generator phase B and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Generator phase B frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        },
-                        "reactivePower": {
-                            "type": "object",
-                            "title": "Reactive power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "reactivePower": {
-                                    "type": "integer",
-                                    "description": "Generator phase B reactive power",
-                                    "units": "VAr",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 5000
-                                },
-                                "powerFactor": {
-                                    "type": "number",
-                                    "description": "Generator phase B power factor",
-                                    "minimum": -1.0,
-                                    "maximum": 1.0,
-                                    "example": 0.97
-                                },
-                                "powerFactorLagging": {
-                                    "enum": [
-                                        "leading",
-                                        "lagging",
-                                        "error",
-                                        "not available"
-                                    ],
-                                    "description": "Generator phase B lead/lag status.",
-                                    "example": "Leading"
-                                }
-                            }
-                        },
-                        "realPower": {
-                            "type": "object",
-                            "title": "Real Power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "realPower": {
-                                    "type": "number",
-                                    "description": "Generator phase B real power.",
-                                    "units": "W",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                },
-                                "apparentPower": {
-                                    "type": "number",
-                                    "description": "Generator phase B apparent power.",
-                                    "units": "VA",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                }
-                            }
-                        }
-                    }
-                },
-                "phaseC": {
-                    "type": "object",
-                    "title": "Generator, Phase C",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between generator phase C and phase A.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "RMS voltage measured between generator phase C and neutral.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Generator phase C frequency.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        },
-                        "reactivePower": {
-                            "type": "object",
-                            "title": "Reactive power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "reactivePower": {
-                                    "type": "integer",
-                                    "description": "Generator phase C reactive power",
-                                    "units": "VAr",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 5000
-                                },
-                                "powerFactor": {
-                                    "type": "number",
-                                    "description": "Generator phase C power factor",
-                                    "minimum": -1.0,
-                                    "maximum": 1.0,
-                                    "example": 0.97
-                                },
-                                "powerFactorLagging": {
-                                    "enum": [
-                                        "leading",
-                                        "lagging",
-                                        "error",
-                                        "not available"
-                                    ],
-                                    "description": "Generator phase C lead/lag status.",
-                                    "example": "Leading"
-                                }
-                            }
-                        },
-                        "realPower": {
-                            "type": "object",
-                            "title": "Real Power",
-                            "properties": {
-                                "timestamp": {
-                                    "$ref": "../definitions.json#/definitions/timestamp"
-                                },
-                                "source": {
-                                    "$ref": "../definitions.json#/definitions/source"
-                                },
-                                "realPower": {
-                                    "type": "number",
-                                    "description": "Generator phase C real power.",
-                                    "units": "W",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                },
-                                "apparentPower": {
-                                    "type": "number",
-                                    "description": "Generator phase C apparent power.",
-                                    "units": "VA",
-                                    "minimum": -2000000000,
-                                    "maximum": 2211081215,
-                                    "example": 10500
-                                }
-                            }
-                        }
-                    }
-                },
-                "average": {
-                    "type": "object",
-                    "title": "Generator, Average",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "lineLineVoltage": {
-                            "type": "integer",
-                            "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase generator.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 480
-                        },
-                        "lineNeutralVoltage": {
-                            "type": "integer",
-                            "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase generator.",
-                            "units": "Vrms",
-                            "minimum": 0,
-                            "maximum": 64255,
-                            "example": 277
-                        },
-                        "frequency": {
-                            "type": "number",
-                            "description": "Average frequency of the generator output.",
-                            "units": "Hz",
-                            "minimum": 0,
-                            "maximum": 501.9921875,
-                            "example": 60.0
-                        }
-                    }
-                },
-                "energy": {
-                    "type": "object",
-                    "title": "Generator, Energy Totals",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "totalExport": {
-                            "type": "integer",
-                            "description": "Total kilowatt hours exported by the generator",
-                            "units": "kWh",
-                            "minimum": 0,
-                            "maximum": 4211081215,
-                            "example": 12000
-                        },
-                        "totalImport": {
-                            "type": "integer",
-                            "description": "Total kilowatt hours imported by the generator",
-                            "units": "kWh",
-                            "minimum": 0,
-                            "maximum": 4211081215,
-                            "example": 12000
-                        }
-                    }
-                },
-                "reactivePower": {
-                    "type": "object",
-                    "title": "Generator, Reactive Power",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "reactivePower": {
-                            "type": "integer",
-                            "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
-                            "units": "VAr",
-                            "minimum": -2000000000,
-                            "maximum": 2211081215,
-                            "example": 5000
-                        },
-                        "powerFactor": {
-                            "type": "number",
-                            "description": "Average power factor for the generator.",
-                            "minimum": -1.0,
-                            "maximum": 1.0,
-                            "example": 0.97
-                        },
-                        "powerFactorLagging": {
-                            "enum": ["Leading", "Lagging", "Error", "Not Available"],
-                            "description": "Lead/lag status for the generator.",
-                            "example": "Leading"
-                        }
-                    }
-                },
-                "realPower": {
-                    "type": "object",
-                    "title": "Generator, Real Power",
-                    "properties": {
-                        "timestamp": {
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "source": {
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "realPower": {
-                            "type": "number",
-                            "description": "Total real power delivered by the generator. Real power must be signed since power may flow in both directions.",
-                            "units": "W",
-                            "minimum": -2000000000,
-                            "maximum": 2211081215,
-                            "example": 10500
-                        },
-                        "apparentPower": {
-                            "type": "number",
-                            "description": "Total apparent power delivered by the generator. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
-                            "units": "VA",
-                            "minimum": -2000000000,
-                            "maximum": 2211081215,
-                            "example": 10500
-                        }
-                    }
-                }
+        "phaseC": {
+          "type": "object",
+          "title": "Bus #1, Phase C",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between bus phase C and phase A.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between bus phase C and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Bus phase C frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
             }
+          }
+        },
+        "average": {
+          "type": "object",
+          "title": "Bus #1, Average",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase bus.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase bus.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Average frequency of the bus.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            }
+          }
         }
+      }
+    },
+    "utility": {
+      "type": "object",
+      "title": "Utility (Shore Power)",
+      "description": "Vessel's shore power connection",
+      "properties": {
+        "phaseA": {
+          "type": "object",
+          "title": "Utility, Phase A",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between utility phase A and phase B.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between utility phase A and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Utility phase A frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            },
+            "reactivePower": {
+              "type": "object",
+              "title": "Reactive power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "reactivePower": {
+                  "type": "integer",
+                  "description": "Utility phase A reactive power",
+                  "units": "VAr",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 5000
+                },
+                "powerFactor": {
+                  "type": "number",
+                  "description": "Utility phase A power factor",
+                  "minimum": -1.0,
+                  "maximum": 1.0,
+                  "example": 0.97
+                },
+                "powerFactorLagging": {
+                  "enum": [
+                    "leading",
+                    "lagging",
+                    "error",
+                    "not available"
+                  ],
+                  "description": "Utility phase A lead/lag status.",
+                  "example": "Leading"
+                }
+              }
+            },
+            "realPower": {
+              "type": "object",
+              "title": "Real Power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "realPower": {
+                  "type": "number",
+                  "description": "Utility phase A real power.",
+                  "units": "W",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                },
+                "apparentPower": {
+                  "type": "number",
+                  "description": "Utility phase A apparent power.",
+                  "units": "VA",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                }
+              }
+            }
+          }
+        },
+        "phaseB": {
+          "type": "object",
+          "title": "Utility, Phase B",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between utility phase B and phase C.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between utility phase B and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Utility phase B frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            },
+            "reactivePower": {
+              "type": "object",
+              "title": "Reactive power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "reactivePower": {
+                  "type": "integer",
+                  "description": "Utility phase B reactive power",
+                  "units": "VAr",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 5000
+                },
+                "powerFactor": {
+                  "type": "number",
+                  "description": "Utility phase B power factor",
+                  "minimum": -1.0,
+                  "maximum": 1.0,
+                  "example": 0.97
+                },
+                "powerFactorLagging": {
+                  "enum": [
+                    "leading",
+                    "lagging",
+                    "error",
+                    "not available"
+                  ],
+                  "description": "Utility phase B lead/lag status.",
+                  "example": "Leading"
+                }
+              }
+            },
+            "realPower": {
+              "type": "object",
+              "title": "Real Power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "realPower": {
+                  "type": "number",
+                  "description": "Utility phase B real power.",
+                  "units": "W",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                },
+                "apparentPower": {
+                  "type": "number",
+                  "description": "Utility phase B apparent power.",
+                  "units": "VA",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                }
+              }
+            }
+          }
+        },
+        "phaseC": {
+          "type": "object",
+          "title": "Utility, Phase C",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between utility phase C and phase A.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between utility phase C and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Utility phase C frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            },
+            "reactivePower": {
+              "type": "object",
+              "title": "Reactive power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "reactivePower": {
+                  "type": "integer",
+                  "description": "Utility phase C reactive power",
+                  "units": "VAr",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 5000
+                },
+                "powerFactor": {
+                  "type": "number",
+                  "description": "Utility phase C power factor",
+                  "minimum": -1.0,
+                  "maximum": 1.0,
+                  "example": 0.97
+                },
+                "powerFactorLagging": {
+                  "enum": [
+                    "leading",
+                    "lagging",
+                    "error",
+                    "not available"
+                  ],
+                  "description": "Utility phase C lead/lag status.",
+                  "example": "Leading"
+                }
+              }
+            },
+            "realPower": {
+              "type": "object",
+              "title": "Real Power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "realPower": {
+                  "type": "number",
+                  "description": "Utility phase C real power.",
+                  "units": "W",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                },
+                "apparentPower": {
+                  "type": "number",
+                  "description": "Utility phase C apparent power.",
+                  "units": "VA",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                }
+              }
+            }
+          }
+        },
+        "average": {
+          "type": "object",
+          "title": "Utility, Average",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase utility connection.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase utility connection.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Average frequency of the utility connection.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            }
+          }
+        },
+        "energy": {
+          "type": "object",
+          "title": "Utility, Energy Totals",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "totalExport": {
+              "type": "integer",
+              "description": "Total kilowatt hours exported by the utility",
+              "units": "kWh",
+              "minimum": 0,
+              "maximum": 4211081215,
+              "example": 12000
+            },
+            "totalImport": {
+              "type": "integer",
+              "description": "Total kilowatt hours imported by the utility",
+              "units": "kWh",
+              "minimum": 0,
+              "maximum": 4211081215,
+              "example": 12000
+            }
+          }
+        },
+        "reactivePower": {
+          "type": "object",
+          "title": "Utility, Reactive Power",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "reactivePower": {
+              "type": "integer",
+              "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
+              "units": "VAr",
+              "minimum": -2000000000,
+              "maximum": 2211081215,
+              "example": 5000
+            },
+            "powerFactor": {
+              "type": "number",
+              "description": "Average power factor for utility.",
+              "minimum": -1.0,
+              "maximum": 1.0,
+              "example": 0.97
+            },
+            "powerFactorLagging": {
+              "enum": ["Leading", "Lagging", "Error", "Not Available"],
+              "description": "Lead/lag status for utility.",
+              "example": "Leading"
+            }
+          }
+        },
+        "realPower": {
+          "type": "object",
+          "title": "Utility, Real Power",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "realPower": {
+              "type": "number",
+              "description": "Total real power delivered by the utility. Real power must be signed since power may flow in both directions.",
+              "units": "W",
+              "minimum": -2000000000,
+              "maximum": 2211081215,
+              "example": 10500
+            },
+            "apparentPower": {
+              "type": "number",
+              "description": "Total apparent power delivered by the utility. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
+              "units": "VA",
+              "minimum": -2000000000,
+              "maximum": 2211081215,
+              "example": 10500
+            }
+          }
+        }
+      }
+    },
+    "generator": {
+      "type": "object",
+      "title": "Generator",
+      "description": "Vessel's generator",
+      "properties": {
+        "phaseA": {
+          "type": "object",
+          "title": "Generator, Phase A",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between generator phase A and phase B.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between generator phase A and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Generator phase A frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            },
+            "reactivePower": {
+              "type": "object",
+              "title": "Reactive power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "reactivePower": {
+                  "type": "integer",
+                  "description": "Generator phase A reactive power",
+                  "units": "VAr",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 5000
+                },
+                "powerFactor": {
+                  "type": "number",
+                  "description": "Generator phase A power factor",
+                  "minimum": -1.0,
+                  "maximum": 1.0,
+                  "example": 0.97
+                },
+                "powerFactorLagging": {
+                  "enum": [
+                    "leading",
+                    "lagging",
+                    "error",
+                    "not available"
+                  ],
+                  "description": "Generator phase A lead/lag status.",
+                  "example": "Leading"
+                }
+              }
+            },
+            "realPower": {
+              "type": "object",
+              "title": "Real Power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "realPower": {
+                  "type": "number",
+                  "description": "Generator phase A real power.",
+                  "units": "W",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                },
+                "apparentPower": {
+                  "type": "number",
+                  "description": "Generator phase A apparent power.",
+                  "units": "VA",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                }
+              }
+            }
+          }
+        },
+        "phaseB": {
+          "type": "object",
+          "title": "Generator, Phase B",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between generator phase B and phase C.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between generator phase B and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Generator phase B frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            },
+            "reactivePower": {
+              "type": "object",
+              "title": "Reactive power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "reactivePower": {
+                  "type": "integer",
+                  "description": "Generator phase B reactive power",
+                  "units": "VAr",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 5000
+                },
+                "powerFactor": {
+                  "type": "number",
+                  "description": "Generator phase B power factor",
+                  "minimum": -1.0,
+                  "maximum": 1.0,
+                  "example": 0.97
+                },
+                "powerFactorLagging": {
+                  "enum": [
+                    "leading",
+                    "lagging",
+                    "error",
+                    "not available"
+                  ],
+                  "description": "Generator phase B lead/lag status.",
+                  "example": "Leading"
+                }
+              }
+            },
+            "realPower": {
+              "type": "object",
+              "title": "Real Power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "realPower": {
+                  "type": "number",
+                  "description": "Generator phase B real power.",
+                  "units": "W",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                },
+                "apparentPower": {
+                  "type": "number",
+                  "description": "Generator phase B apparent power.",
+                  "units": "VA",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                }
+              }
+            }
+          }
+        },
+        "phaseC": {
+          "type": "object",
+          "title": "Generator, Phase C",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between generator phase C and phase A.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "RMS voltage measured between generator phase C and neutral.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Generator phase C frequency.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            },
+            "reactivePower": {
+              "type": "object",
+              "title": "Reactive power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "reactivePower": {
+                  "type": "integer",
+                  "description": "Generator phase C reactive power",
+                  "units": "VAr",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 5000
+                },
+                "powerFactor": {
+                  "type": "number",
+                  "description": "Generator phase C power factor",
+                  "minimum": -1.0,
+                  "maximum": 1.0,
+                  "example": 0.97
+                },
+                "powerFactorLagging": {
+                  "enum": [
+                    "leading",
+                    "lagging",
+                    "error",
+                    "not available"
+                  ],
+                  "description": "Generator phase C lead/lag status.",
+                  "example": "Leading"
+                }
+              }
+            },
+            "realPower": {
+              "type": "object",
+              "title": "Real Power",
+              "properties": {
+                "timestamp": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+                "source": {
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                "realPower": {
+                  "type": "number",
+                  "description": "Generator phase C real power.",
+                  "units": "W",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                },
+                "apparentPower": {
+                  "type": "number",
+                  "description": "Generator phase C apparent power.",
+                  "units": "VA",
+                  "minimum": -2000000000,
+                  "maximum": 2211081215,
+                  "example": 10500
+                }
+              }
+            }
+          }
+        },
+        "average": {
+          "type": "object",
+          "title": "Generator, Average",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "lineLineVoltage": {
+              "type": "integer",
+              "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase generator.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 480
+            },
+            "lineNeutralVoltage": {
+              "type": "integer",
+              "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase generator.",
+              "units": "Vrms",
+              "minimum": 0,
+              "maximum": 64255,
+              "example": 277
+            },
+            "frequency": {
+              "type": "number",
+              "description": "Average frequency of the generator output.",
+              "units": "Hz",
+              "minimum": 0,
+              "maximum": 501.9921875,
+              "example": 60.0
+            }
+          }
+        },
+        "energy": {
+          "type": "object",
+          "title": "Generator, Energy Totals",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "totalExport": {
+              "type": "integer",
+              "description": "Total kilowatt hours exported by the generator",
+              "units": "kWh",
+              "minimum": 0,
+              "maximum": 4211081215,
+              "example": 12000
+            },
+            "totalImport": {
+              "type": "integer",
+              "description": "Total kilowatt hours imported by the generator",
+              "units": "kWh",
+              "minimum": 0,
+              "maximum": 4211081215,
+              "example": 12000
+            }
+          }
+        },
+        "reactivePower": {
+          "type": "object",
+          "title": "Generator, Reactive Power",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "reactivePower": {
+              "type": "integer",
+              "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
+              "units": "VAr",
+              "minimum": -2000000000,
+              "maximum": 2211081215,
+              "example": 5000
+            },
+            "powerFactor": {
+              "type": "number",
+              "description": "Average power factor for the generator.",
+              "minimum": -1.0,
+              "maximum": 1.0,
+              "example": 0.97
+            },
+            "powerFactorLagging": {
+              "enum": ["Leading", "Lagging", "Error", "Not Available"],
+              "description": "Lead/lag status for the generator.",
+              "example": "Leading"
+            }
+          }
+        },
+        "realPower": {
+          "type": "object",
+          "title": "Generator, Real Power",
+          "properties": {
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "realPower": {
+              "type": "number",
+              "description": "Total real power delivered by the generator. Real power must be signed since power may flow in both directions.",
+              "units": "W",
+              "minimum": -2000000000,
+              "maximum": 2211081215,
+              "example": 10500
+            },
+            "apparentPower": {
+              "type": "number",
+              "description": "Total apparent power delivered by the generator. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
+              "units": "VA",
+              "minimum": -2000000000,
+              "maximum": 2211081215,
+              "example": 10500
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/schemas/groups/electrical_ac.json
+++ b/schemas/groups/electrical_ac.json
@@ -25,7 +25,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between bus phase A and phase B.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -34,7 +34,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between bus phase A and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -43,7 +43,7 @@
             "frequency": {
               "type": "number",
               "description": "Bus phase A frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -66,7 +66,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between bus phase B and phase C.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -75,7 +75,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between bus phase B and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -83,7 +83,7 @@
             "frequency": {
               "type": "number",
               "description": "Bus phase B frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -106,7 +106,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between bus phase C and phase A.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -115,7 +115,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between bus phase C and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -124,7 +124,7 @@
             "frequency": {
               "type": "number",
               "description": "Bus phase C frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -147,7 +147,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase bus.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -156,7 +156,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase bus.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -165,7 +165,7 @@
             "frequency": {
               "type": "number",
               "description": "Average frequency of the bus.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -195,7 +195,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between utility phase A and phase B.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -204,7 +204,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between utility phase A and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -213,7 +213,7 @@
             "frequency": {
               "type": "number",
               "description": "Utility phase A frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -234,7 +234,7 @@
                 "reactivePower": {
                   "type": "number",
                   "description": "Utility phase A reactive power",
-                  "units": "Volt-ampere reactive (VAr)",
+                  "units": "VAr",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
@@ -278,7 +278,7 @@
                 "realPower": {
                   "type": "number",
                   "description": "Utility phase A real power.",
-                  "units": "Watts (W)",
+                  "units": "W",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -287,7 +287,7 @@
                 "apparentPower": {
                   "type": "number",
                   "description": "Utility phase A apparent power.",
-                  "units": "Volt-ampere (apparent, VA)",
+                  "units": "VA",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -311,7 +311,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between utility phase B and phase C.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -320,7 +320,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between utility phase B and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -329,7 +329,7 @@
             "frequency": {
               "type": "number",
               "description": "Utility phase B frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -350,7 +350,7 @@
                 "reactivePower": {
                   "type": "number",
                   "description": "Utility phase B reactive power",
-                  "units": "Volt-ampere (reactive, VAr)",
+                  "units": "VAr",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
@@ -393,7 +393,7 @@
                 "realPower": {
                   "type": "number",
                   "description": "Utility phase B real power.",
-                  "units": "Watts (W)",
+                  "units": "W",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -402,7 +402,7 @@
                 "apparentPower": {
                   "type": "number",
                   "description": "Utility phase B apparent power.",
-                  "units": "Volt-ampere (apparent, VA)",
+                  "units": "VA",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -427,7 +427,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between utility phase C and phase A.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -436,7 +436,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between utility phase C and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -445,7 +445,7 @@
             "frequency": {
               "type": "number",
               "description": "Utility phase C frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -466,7 +466,7 @@
                 "reactivePower": {
                   "type": "number",
                   "description": "Utility phase C reactive power",
-                  "units": "Volt-ampere (reactive, VAr)",
+                  "units": "VAr",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
@@ -509,7 +509,7 @@
                 "realPower": {
                   "type": "number",
                   "description": "Utility phase C real power.",
-                  "units": "Watts (W)",
+                  "units": "W",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -518,7 +518,7 @@
                 "apparentPower": {
                   "type": "number",
                   "description": "Utility phase C apparent power.",
-                  "units": "Volt-ampere (apparent, VA)",
+                  "units": "VA",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -543,7 +543,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase utility connection.",
-              "units": "Volt-ampere (reactive, VAr)",
+              "units": "VAr",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -552,7 +552,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase utility connection.",
-              "units": "Volt-ampere (reactive, VAr)",
+              "units": "VAr",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -561,7 +561,7 @@
             "frequency": {
               "type": "number",
               "description": "Average frequency of the utility connection.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -584,7 +584,7 @@
             "totalExport": {
               "type": "number",
               "description": "Total watt hours exported by the utility",
-              "units": "Watts per hour (Wh)",
+              "units": "Wh",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
@@ -593,7 +593,7 @@
             "totalImport": {
               "type": "number",
               "description": "Total watt hours imported by the utility",
-              "units": "Watts per hour (Wh)",
+              "units": "Wh",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
@@ -616,7 +616,7 @@
             "reactivePower": {
               "type": "number",
               "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
-              "units": "Volt-ampere (reactive, VAr)",
+              "units": "VAr",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 5000
@@ -659,7 +659,7 @@
             "realPower": {
               "type": "number",
               "description": "Total real power delivered by the utility. Real power must be signed since power may flow in both directions.",
-              "units": "Watts (W)",
+              "units": "W",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500
@@ -668,7 +668,7 @@
             "apparentPower": {
               "type": "number",
               "description": "Total apparent power delivered by the utility. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
-              "units": "Volt-ampere (apparent, VA)",
+              "units": "VA",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500
@@ -698,7 +698,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between generator phase A and phase B.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -707,7 +707,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between generator phase A and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -716,7 +716,7 @@
             "frequency": {
               "type": "number",
               "description": "Generator phase A frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -737,7 +737,7 @@
                 "reactivePower": {
                   "type": "number",
                   "description": "Generator phase A reactive power",
-                  "units": "Volt-ampere (reactive, VAr)",
+                  "units": "VAr",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
@@ -780,7 +780,7 @@
                 "realPower": {
                   "type": "number",
                   "description": "Generator phase A real power.",
-                  "units": "Watts (W)",
+                  "units": "W",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -789,7 +789,7 @@
                 "apparentPower": {
                   "type": "number",
                   "description": "Generator phase A apparent power.",
-                  "units": "Volt-ampere (apparent, VA)",
+                  "units": "VA",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -814,7 +814,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between generator phase B and phase C.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -823,7 +823,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between generator phase B and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -832,7 +832,7 @@
             "frequency": {
               "type": "number",
               "description": "Generator phase B frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -853,7 +853,7 @@
                 "reactivePower": {
                   "type": "number",
                   "description": "Generator phase B reactive power",
-                  "units": "Volt-ampere (reactive, VAr)",
+                  "units": "VAr",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
@@ -896,7 +896,7 @@
                 "realPower": {
                   "type": "number",
                   "description": "Generator phase B real power.",
-                  "units": "Watts (W)",
+                  "units": "W",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -905,7 +905,7 @@
                 "apparentPower": {
                   "type": "number",
                   "description": "Generator phase B apparent power.",
-                  "units": "Volt-ampere (apparent, VA)",
+                  "units": "VA",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -930,7 +930,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "RMS voltage measured between generator phase C and phase A.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -939,7 +939,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "RMS voltage measured between generator phase C and neutral.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -948,7 +948,7 @@
             "frequency": {
               "type": "number",
               "description": "Generator phase C frequency.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -969,7 +969,7 @@
                 "reactivePower": {
                   "type": "number",
                   "description": "Generator phase C reactive power",
-                  "units": "Volt-ampere (reactive, VAr)",
+                  "units": "VAr",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
@@ -1012,7 +1012,7 @@
                 "realPower": {
                   "type": "number",
                   "description": "Generator phase C real power.",
-                  "units": "Watts (W)",
+                  "units": "W",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -1021,7 +1021,7 @@
                 "apparentPower": {
                   "type": "number",
                   "description": "Generator phase C apparent power.",
-                  "units": "Volt-ampere (apparent, VA)",
+                  "units": "VA",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -1046,7 +1046,7 @@
             "lineLineVoltage": {
               "type": "number",
               "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase generator.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
@@ -1055,7 +1055,7 @@
             "lineNeutralVoltage": {
               "type": "number",
               "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase generator.",
-              "units": "RMS Voltage (Vrms)",
+              "units": "Vrms",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -1064,7 +1064,7 @@
             "frequency": {
               "type": "number",
               "description": "Average frequency of the generator output.",
-              "units": "Hertz (Hz)",
+              "units": "Hz",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -1087,7 +1087,7 @@
             "totalExport": {
               "type": "number",
               "description": "Total watt hours exported by the generator",
-              "units": "Watts per hour (Wh)",
+              "units": "Wh",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
@@ -1096,7 +1096,7 @@
             "totalImport": {
               "type": "number",
               "description": "Total watt hours imported by the generator",
-              "units": "Watts per hour (Wh)",
+              "units": "Wh",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
@@ -1119,7 +1119,7 @@
             "reactivePower": {
               "type": "number",
               "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
-              "units": "Volt-ampere (reactive, VAr)",
+              "units": "VAr",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 5000
@@ -1157,7 +1157,7 @@
             "realPower": {
               "type": "number",
               "description": "Total real power delivered by the generator. Real power must be signed since power may flow in both directions.",
-              "units": "Watts (w)",
+              "units": "W",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500
@@ -1166,7 +1166,7 @@
             "apparentPower": {
               "type": "number",
               "description": "Total apparent power delivered by the generator. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
-              "units": "Volt-ampere (apparent, VA)",
+              "units": "VA",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500

--- a/schemas/groups/electrical_ac.json
+++ b/schemas/groups/electrical_ac.json
@@ -17,35 +17,40 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between bus phase A and phase B.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between bus phase A and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Bus phase A frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             }
           }
         },
+
         "phaseB": {
           "type": "object",
           "title": "Bus #1, Phase B",
@@ -53,21 +58,24 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between bus phase B and phase C.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between bus phase B and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
@@ -75,13 +83,14 @@
             "frequency": {
               "type": "number",
               "description": "Bus phase B frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             }
           }
         },
+
         "phaseC": {
           "type": "object",
           "title": "Bus #1, Phase C",
@@ -89,35 +98,40 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between bus phase C and phase A.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between bus phase C and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Bus phase C frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             }
           }
         },
+
         "average": {
           "type": "object",
           "title": "Bus #1, Average",
@@ -125,29 +139,33 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase bus.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase bus.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Average frequency of the bus.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
@@ -156,6 +174,7 @@
         }
       }
     },
+
     "utility": {
       "type": "object",
       "title": "Utility (Shore Power)",
@@ -168,33 +187,38 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between utility phase A and phase B.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between utility phase A and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Utility phase A frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             },
+
             "reactivePower": {
               "type": "object",
               "title": "Reactive power",
@@ -202,17 +226,20 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "reactivePower": {
-                  "type": "integer",
+                  "type": "number",
                   "description": "Utility phase A reactive power",
-                  "units": "VAr",
+                  "units": "Volt-ampere reactive (VAr)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
                 },
+
                 "powerFactor": {
                   "type": "number",
                   "description": "Utility phase A power factor",
@@ -220,6 +247,7 @@
                   "maximum": 1.0,
                   "example": 0.97
                 },
+
                 "powerFactorLagging": {
                   "enum": [
                     "leading",
@@ -227,11 +255,14 @@
                     "error",
                     "not available"
                   ],
+
+                  "type": "string",
                   "description": "Utility phase A lead/lag status.",
-                  "example": "Leading"
+                  "example": "leading"
                 }
               }
             },
+
             "realPower": {
               "type": "object",
               "title": "Real Power",
@@ -239,21 +270,24 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+                
                 "realPower": {
                   "type": "number",
                   "description": "Utility phase A real power.",
-                  "units": "W",
+                  "units": "Watts (W)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
                 },
+
                 "apparentPower": {
                   "type": "number",
                   "description": "Utility phase A apparent power.",
-                  "units": "VA",
+                  "units": "Volt-ampere (apparent, VA)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -269,33 +303,38 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between utility phase B and phase C.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between utility phase B and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Utility phase B frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             },
+
             "reactivePower": {
               "type": "object",
               "title": "Reactive power",
@@ -303,17 +342,20 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "reactivePower": {
-                  "type": "integer",
+                  "type": "number",
                   "description": "Utility phase B reactive power",
-                  "units": "VAr",
+                  "units": "Volt-ampere (reactive, VAr)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
                 },
+
                 "powerFactor": {
                   "type": "number",
                   "description": "Utility phase B power factor",
@@ -321,6 +363,7 @@
                   "maximum": 1.0,
                   "example": 0.97
                 },
+
                 "powerFactorLagging": {
                   "enum": [
                     "leading",
@@ -329,10 +372,12 @@
                     "not available"
                   ],
                   "description": "Utility phase B lead/lag status.",
-                  "example": "Leading"
+                  "example": "leading",
+                  "type": "string"
                 }
               }
             },
+
             "realPower": {
               "type": "object",
               "title": "Real Power",
@@ -340,21 +385,24 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+                
                 "realPower": {
                   "type": "number",
                   "description": "Utility phase B real power.",
-                  "units": "W",
+                  "units": "Watts (W)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
                 },
+
                 "apparentPower": {
                   "type": "number",
                   "description": "Utility phase B apparent power.",
-                  "units": "VA",
+                  "units": "Volt-ampere (apparent, VA)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -363,6 +411,7 @@
             }
           }
         },
+
         "phaseC": {
           "type": "object",
           "title": "Utility, Phase C",
@@ -370,33 +419,38 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between utility phase C and phase A.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between utility phase C and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Utility phase C frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             },
+
             "reactivePower": {
               "type": "object",
               "title": "Reactive power",
@@ -404,17 +458,20 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "reactivePower": {
-                  "type": "integer",
+                  "type": "number",
                   "description": "Utility phase C reactive power",
-                  "units": "VAr",
+                  "units": "Volt-ampere (reactive, VAr)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
                 },
+
                 "powerFactor": {
                   "type": "number",
                   "description": "Utility phase C power factor",
@@ -422,6 +479,7 @@
                   "maximum": 1.0,
                   "example": 0.97
                 },
+
                 "powerFactorLagging": {
                   "enum": [
                     "leading",
@@ -430,10 +488,12 @@
                     "not available"
                   ],
                   "description": "Utility phase C lead/lag status.",
-                  "example": "Leading"
+                  "example": "leading",
+                  "type": "string"
                 }
               }
             },
+
             "realPower": {
               "type": "object",
               "title": "Real Power",
@@ -441,21 +501,24 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+                
                 "realPower": {
                   "type": "number",
                   "description": "Utility phase C real power.",
-                  "units": "W",
+                  "units": "Watts (W)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
                 },
+
                 "apparentPower": {
                   "type": "number",
                   "description": "Utility phase C apparent power.",
-                  "units": "VA",
+                  "units": "Volt-ampere (apparent, VA)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -464,6 +527,7 @@
             }
           }
         },
+
         "average": {
           "type": "object",
           "title": "Utility, Average",
@@ -471,35 +535,40 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+            
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase utility connection.",
-              "units": "Vrms",
+              "units": "Volt-ampere (reactive, VAr)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase utility connection.",
-              "units": "Vrms",
+              "units": "Volt-ampere (reactive, VAr)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Average frequency of the utility connection.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             }
           }
         },
+
         "energy": {
           "type": "object",
           "title": "Utility, Energy Totals",
@@ -507,27 +576,31 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+            
             "totalExport": {
-              "type": "integer",
-              "description": "Total kilowatt hours exported by the utility",
-              "units": "kWh",
+              "type": "number",
+              "description": "Total watt hours exported by the utility",
+              "units": "Watts per hour (Wh)",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
             },
+
             "totalImport": {
-              "type": "integer",
-              "description": "Total kilowatt hours imported by the utility",
-              "units": "kWh",
+              "type": "number",
+              "description": "Total watt hours imported by the utility",
+              "units": "Watts per hour (Wh)",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
             }
           }
         },
+
         "reactivePower": {
           "type": "object",
           "title": "Utility, Reactive Power",
@@ -535,17 +608,20 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "reactivePower": {
-              "type": "integer",
+              "type": "number",
               "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
-              "units": "VAr",
+              "units": "Volt-ampere (reactive, VAr)",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 5000
             },
+
             "powerFactor": {
               "type": "number",
               "description": "Average power factor for utility.",
@@ -553,13 +629,21 @@
               "maximum": 1.0,
               "example": 0.97
             },
+
             "powerFactorLagging": {
-              "enum": ["Leading", "Lagging", "Error", "Not Available"],
               "description": "Lead/lag status for utility.",
-              "example": "Leading"
+              "example": "Leading",
+              "type": "string",
+              "enum": [
+                "leading",
+                "lagging",
+                "error",
+                "not available"
+              ]
             }
           }
         },
+
         "realPower": {
           "type": "object",
           "title": "Utility, Real Power",
@@ -567,21 +651,24 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "realPower": {
               "type": "number",
               "description": "Total real power delivered by the utility. Real power must be signed since power may flow in both directions.",
-              "units": "W",
+              "units": "Watts (W)",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500
             },
+
             "apparentPower": {
               "type": "number",
               "description": "Total apparent power delivered by the utility. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
-              "units": "VA",
+              "units": "Volt-ampere (apparent, VA)",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500
@@ -590,6 +677,7 @@
         }
       }
     },
+
     "generator": {
       "type": "object",
       "title": "Generator",
@@ -602,33 +690,38 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between generator phase A and phase B.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between generator phase A and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Generator phase A frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             },
+
             "reactivePower": {
               "type": "object",
               "title": "Reactive power",
@@ -636,17 +729,20 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "reactivePower": {
-                  "type": "integer",
+                  "type": "number",
                   "description": "Generator phase A reactive power",
-                  "units": "VAr",
+                  "units": "Volt-ampere (reactive, VAr)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
                 },
+
                 "powerFactor": {
                   "type": "number",
                   "description": "Generator phase A power factor",
@@ -654,18 +750,21 @@
                   "maximum": 1.0,
                   "example": 0.97
                 },
+
                 "powerFactorLagging": {
+                  "description": "Generator phase A lead/lag status.",
+                  "example": "leading",
+                  "type": "string",
                   "enum": [
                     "leading",
                     "lagging",
                     "error",
                     "not available"
-                  ],
-                  "description": "Generator phase A lead/lag status.",
-                  "example": "Leading"
+                  ]
                 }
               }
             },
+
             "realPower": {
               "type": "object",
               "title": "Real Power",
@@ -673,21 +772,24 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "realPower": {
                   "type": "number",
                   "description": "Generator phase A real power.",
-                  "units": "W",
+                  "units": "Watts (W)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
                 },
+
                 "apparentPower": {
                   "type": "number",
                   "description": "Generator phase A apparent power.",
-                  "units": "VA",
+                  "units": "Volt-ampere (apparent, VA)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -696,6 +798,7 @@
             }
           }
         },
+
         "phaseB": {
           "type": "object",
           "title": "Generator, Phase B",
@@ -703,33 +806,38 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between generator phase B and phase C.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between generator phase B and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Generator phase B frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             },
+
             "reactivePower": {
               "type": "object",
               "title": "Reactive power",
@@ -737,17 +845,20 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "reactivePower": {
-                  "type": "integer",
+                  "type": "number",
                   "description": "Generator phase B reactive power",
-                  "units": "VAr",
+                  "units": "Volt-ampere (reactive, VAr)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
                 },
+
                 "powerFactor": {
                   "type": "number",
                   "description": "Generator phase B power factor",
@@ -755,18 +866,21 @@
                   "maximum": 1.0,
                   "example": 0.97
                 },
+
                 "powerFactorLagging": {
+                  "description": "Generator phase B lead/lag status.",
+                  "example": "leading",
+                  "type": "string",
                   "enum": [
                     "leading",
                     "lagging",
                     "error",
                     "not available"
-                  ],
-                  "description": "Generator phase B lead/lag status.",
-                  "example": "Leading"
+                  ]
                 }
               }
             },
+
             "realPower": {
               "type": "object",
               "title": "Real Power",
@@ -774,21 +888,24 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "realPower": {
                   "type": "number",
                   "description": "Generator phase B real power.",
-                  "units": "W",
+                  "units": "Watts (W)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
                 },
+
                 "apparentPower": {
                   "type": "number",
                   "description": "Generator phase B apparent power.",
-                  "units": "VA",
+                  "units": "Volt-ampere (apparent, VA)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -797,6 +914,7 @@
             }
           }
         },
+
         "phaseC": {
           "type": "object",
           "title": "Generator, Phase C",
@@ -804,33 +922,38 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between generator phase C and phase A.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "RMS voltage measured between generator phase C and neutral.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Generator phase C frequency.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             },
+
             "reactivePower": {
               "type": "object",
               "title": "Reactive power",
@@ -838,17 +961,20 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+                
                 "reactivePower": {
-                  "type": "integer",
+                  "type": "number",
                   "description": "Generator phase C reactive power",
-                  "units": "VAr",
+                  "units": "Volt-ampere (reactive, VAr)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 5000
                 },
+
                 "powerFactor": {
                   "type": "number",
                   "description": "Generator phase C power factor",
@@ -856,6 +982,7 @@
                   "maximum": 1.0,
                   "example": 0.97
                 },
+
                 "powerFactorLagging": {
                   "enum": [
                     "leading",
@@ -864,10 +991,12 @@
                     "not available"
                   ],
                   "description": "Generator phase C lead/lag status.",
-                  "example": "Leading"
+                  "example": "leading",
+                  "type": "string"
                 }
               }
             },
+
             "realPower": {
               "type": "object",
               "title": "Real Power",
@@ -875,21 +1004,24 @@
                 "timestamp": {
                   "$ref": "../definitions.json#/definitions/timestamp"
                 },
+
                 "source": {
                   "$ref": "../definitions.json#/definitions/source"
                 },
+
                 "realPower": {
                   "type": "number",
                   "description": "Generator phase C real power.",
-                  "units": "W",
+                  "units": "Watts (W)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
                 },
+
                 "apparentPower": {
                   "type": "number",
                   "description": "Generator phase C apparent power.",
-                  "units": "VA",
+                  "units": "Volt-ampere (apparent, VA)",
                   "minimum": -2000000000,
                   "maximum": 2211081215,
                   "example": 10500
@@ -898,6 +1030,7 @@
             }
           }
         },
+
         "average": {
           "type": "object",
           "title": "Generator, Average",
@@ -905,35 +1038,40 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "lineLineVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "Average RMS voltage measured between two hot legs of a 3-phase or split-phase generator.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 480
             },
+
             "lineNeutralVoltage": {
-              "type": "integer",
+              "type": "number",
               "description": "Average RMS voltage measured between any hot leg and neutral in a 3-phase, split-phase, or single phase generator.",
-              "units": "Vrms",
+              "units": "RMS Voltage (Vrms)",
               "minimum": 0,
               "maximum": 64255,
               "example": 277
             },
+
             "frequency": {
               "type": "number",
               "description": "Average frequency of the generator output.",
-              "units": "Hz",
+              "units": "Hertz (Hz)",
               "minimum": 0,
               "maximum": 501.9921875,
               "example": 60.0
             }
           }
         },
+
         "energy": {
           "type": "object",
           "title": "Generator, Energy Totals",
@@ -941,27 +1079,31 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "totalExport": {
-              "type": "integer",
-              "description": "Total kilowatt hours exported by the generator",
-              "units": "kWh",
+              "type": "number",
+              "description": "Total watt hours exported by the generator",
+              "units": "Watts per hour (Wh)",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
             },
+
             "totalImport": {
-              "type": "integer",
-              "description": "Total kilowatt hours imported by the generator",
-              "units": "kWh",
+              "type": "number",
+              "description": "Total watt hours imported by the generator",
+              "units": "Watts per hour (Wh)",
               "minimum": 0,
               "maximum": 4211081215,
               "example": 12000
             }
           }
         },
+
         "reactivePower": {
           "type": "object",
           "title": "Generator, Reactive Power",
@@ -969,17 +1111,20 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "reactivePower": {
-              "type": "integer",
+              "type": "number",
               "description": "In a normally operating system, the reactive power will be less than half the real power. In order to allow for fault conditions, it is desirable to have the same range for reactive power as for real power. Reactive power is a signed quantity, like real power.",
-              "units": "VAr",
+              "units": "Volt-ampere (reactive, VAr)",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 5000
             },
+
             "powerFactor": {
               "type": "number",
               "description": "Average power factor for the generator.",
@@ -987,13 +1132,16 @@
               "maximum": 1.0,
               "example": 0.97
             },
+
             "powerFactorLagging": {
-              "enum": ["Leading", "Lagging", "Error", "Not Available"],
+              "enum": ["leading", "lagging", "error", "not available"],
               "description": "Lead/lag status for the generator.",
-              "example": "Leading"
+              "example": "leading",
+              "type": "string"
             }
           }
         },
+
         "realPower": {
           "type": "object",
           "title": "Generator, Real Power",
@@ -1001,21 +1149,24 @@
             "timestamp": {
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+
             "source": {
               "$ref": "../definitions.json#/definitions/source"
             },
+            
             "realPower": {
               "type": "number",
               "description": "Total real power delivered by the generator. Real power must be signed since power may flow in both directions.",
-              "units": "W",
+              "units": "Watts (w)",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500
             },
+
             "apparentPower": {
               "type": "number",
               "description": "Total apparent power delivered by the generator. This is an unsigned quantity, but is delivered signed in order to have an equivalent range to real power.",
-              "units": "VA",
+              "units": "Volt-ampere (apparent, VA)",
               "minimum": -2000000000,
               "maximum": 2211081215,
               "example": 10500

--- a/schemas/groups/electrical_dc.json
+++ b/schemas/groups/electrical_dc.json
@@ -1,306 +1,306 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/electrical_dc.json#",
-    "description": "Schema describing the electrical child-object of a Vessel.",
-    "title": "DC Electrical Properties",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/electrical_dc.json#",
+  "description": "Schema describing the electrical child-object of a Vessel.",
+  "title": "DC Electrical Properties",
 
 
-    "definitions": {
-        "identity": {
-            "type": "object",
-            "title": "Electrical ID",
-            "description": " Common ID items shared by electrical items",
-            "required": ["name"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Unique ID of device (houseBattery, alternator, Generator, solar1, inverterCharger, Combiner1, etc.)"
-                },
-                "location": {
-                    "type": "string",
-                    "description": "Installed location of device on vessel"
-                },
-                "manufacturerName": {
-                    "type": "string",
-                    "description": "Manufacturer's name"
-                },
-                "manufacturerModel": {
-                    "type": "string",
-                    "description": "Model or part number"
-                },
-                "dateInstalled": {
-                    "type": "string",
-                    "description": "Date device was installed"
-                }
-            }
+  "definitions": {
+    "identity": {
+      "type": "object",
+      "title": "Electrical ID",
+      "description": " Common ID items shared by electrical items",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique ID of device (houseBattery, alternator, Generator, solar1, inverterCharger, Combiner1, etc.)"
         },
-
-
-
-
-
-
-        "dcSource": {
-            "type": "object",
-            "title": "DC Source",
-            "description": "DC power source common values",
-            "properties": {
-
-                "associatedBus": {
-                    "type": "string",
-                    "description": "Name of BUS source is associated with (if applicable, may = NULL)"
-                },
-
-                "voltage": {
-                    "type": "object",
-                    "properties": {
-                        "measured": {
-                            "type": "object",
-                            "description": "Measured voltage of DC Source terminals",
-                            "properties": {
-                                "value"    : {"type": "number"},
-                                "source"   : {"type": "string"},
-                                "timestamp": {"type": "string"}
-                            }
-                        },
-                        "nominal": {
-                            "type": "number",
-                            "description": "Designed 'voltage' of battery (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
-                        },
-                        "warnUpper": {
-                            "type": "number",
-                            "description": "Upper operational voltage limit"
-                        },
-                        "warnLower": {
-                            "type": "number",
-                            "description": "Lower operational voltage limit"
-                        },
-                        "faultUpper": {
-                            "type": "number",
-                            "description": "Upper fault limit of battery voltage - BMS may disconnect battery"
-                        },
-                        "faultLower": {
-                            "type": "number",
-                            "description": "Lower fault limit of battery voltage - BMS may disconnect battery"
-                        }
-                    }
-                },
-
-                "current": {
-                    "type": "object",
-                    "properties": {
-                        "measured": {
-                            "type": "object",
-                            "description": "Measured amperage being '+' provided (or '-' consumed) by DC source",
-                            "properties": {
-                                "value"    : {"type": "number"},
-                                "source"   : {"type": "string"},
-                                "timestamp": {"type": "string"}
-                            }
-                        },
-                        "warnUpper": {
-                            "type": "number",
-                            "description": "Upper operational current limit"
-                        },
-                        "warnLower": {
-                            "type": "number",
-                            "description": "Lower operational current limit"
-                        },
-                        "faultUpper": {
-                            "type": "number",
-                            "description": "Upper fault limit of battery current - BMS may disconnect battery"
-                        },
-                        "faultLower": {
-                            "type": "number",
-                            "description": "Lower fault limit of battery current - BMS may disconnect battery"
-                        }
-                    }
-                },
-
-                "temperature": {
-                    "type": "object",
-                    "title": "temperature",
-                    "properties": {
-                        "measured": {
-                            "type": "object",
-                            "description": "Temperature of device, in degrees Celsius",
-                            "properties": {
-                                "value"    : {"type": "number"},
-                                "source"   : {"type": "string"},
-                                "timestamp": {"type": "string"}
-                            }
-                        },
-                        "warnUpper": {
-                            "type": "number",
-                            "description": "Upper operational temperature limit"
-                        },
-                        "warnLower": {
-                            "type": "number",
-                            "description": "Lower operational temperature limit"
-                        },
-                        "faultUpper": {
-                            "type": "number",
-                            "description": "Upper fault limit of temperature - device may disable"
-                        },
-                        "faultLower": {
-                            "type": "number",
-                            "description": "Lower fault limit of temperature  - device may disable"
-                        }
-                    }
-                }
-            }
+        "location": {
+          "type": "string",
+          "description": "Installed location of device on vessel"
         },
-
-        "acSource": {
-            "type": "object",
-            "title": "AC Source",
-            "description": "AC power source common values",
-            "properties": {
-
-                "associatedBus": {
-                    "type": "string",
-                    "description": "Name of BUS source is assocated with (if applicable, may = NULL)"
-                },
-
-                "voltage": {
-                    "type": "object",
-                    "properties": {
-                        "measured": {
-                            "type": "object",
-                            "description": "Measured voltage at AC Source terminals",
-                            "properties": {
-                                "value"    : {"type": "number"},
-                                "source"   : {"type": "string"},
-                                "timestamp": {"type": "string"}
-                            }
-                        }
-                    }
-                }
-            }
+        "manufacturerName": {
+          "type": "string",
+          "description": "Manufacturer's name"
+        },
+        "manufacturerModel": {
+          "type": "string",
+          "description": "Model or part number"
+        },
+        "dateInstalled": {
+          "type": "string",
+          "description": "Date device was installed"
         }
+      }
     },
 
 
 
 
 
-    "type": "object",
-    "properties": {
 
-        "battery": {
-            "type": "object",
-            "title": "Battery",
-            "description": "Batteries, one or many, within the vessel",
-            "required": ["ID"],
-            "properties": {
-                "ID": {"$ref": "#/definitions/identity"},
-                "DC": {"$ref": "#/definitions/dcSource"},
-                "mode": {
-                    "type": "string",
-                    "description": "Operational mode of battery",
-                    "enum": [
-                        "charging bulk",
-                        "charging acceptance",
-                        "charging overcharge",
-                        "charging float",
-                        "charging equalize",
-                        "discharging",
-                        "unknown",
-                        "other"
-                    ]
-                },
+    "dcSource": {
+      "type": "object",
+      "title": "DC Source",
+      "description": "DC power source common values",
+      "properties": {
 
-                "chemistry": {
-                    "type": "string",
-                    "description": "Type of battery FLA, LiFePO4, etc."
-                },
+        "associatedBus": {
+          "type": "string",
+          "description": "Name of BUS source is associated with (if applicable, may = NULL)"
+        },
 
-
-
-                "temperature": {
-                    "type": "object",
-                    "title": "temperature",
-                    "description": "Additional / unique temperatures associated with a battery",
-                    "properties": {
-                        "limitDischargeLower": {
-                            "type": "number",
-                            "description": "Operational minimum temperature limit for battery discharge, in degrees Celsius"
-                        },
-                        "limitDischargeUpper": {
-                            "type": "number",
-                            "description": "Operational maximum temperature limit for battery discharge, in degrees Celsius"
-                        },
-                        "limitRechargeLower": {
-                            "type": "number",
-                            "description": "Operational minimum temperature limit for battery recharging, in degrees Celsius"
-                        },
-                        "limitRechargeUpper": {
-                            "type": "number",
-                            "description": "Operational maximum temperature limit for battery recharging, in degrees Celsius"
-                        }
-                    }
-                },
-
-
-                "capacity": {
-                    "type": "object",
-                    "title": "capacity",
-                    "properties": {
-                        "nominal": {
-                            "type": "number",
-                            "description": "The watt-hour capacity of battery as specified by the manufacturer"
-                        },
-                        "actual": {
-                            "type": "number",
-                            "description": "The measured watt-hour capacity of battery. This may change over time and will likely deviate from the nominal capacity."
-                        },
-                        "remaining": {
-                            "type": "number",
-                            "description": "Watt-hours remaining in battery"
-                        },
-                        "dischargeLimit": {
-                            "type": "number",
-                            "description": "Minimum number of watt-hours to be left in the battery while discharging"
-                        }
-                    }
-                },
-
-                "lifetimeDischarge": {
-                    "type": "number",
-                    "description": "Cumulative kWh discharged from battery over operational lifetime of battery"
-                },
-                "lifetimeRecharge": {
-                    "type": "number",
-                    "description": "Cumulative kWh recharged into battery over operational lifetime of battery"
-                }
+        "voltage": {
+          "type": "object",
+          "properties": {
+            "measured": {
+              "type": "object",
+              "description": "Measured voltage of DC Source terminals",
+              "properties": {
+                "value"    : {"type": "number"},
+                "source"   : {"type": "string"},
+                "timestamp": {"type": "string"}
+              }
+            },
+            "nominal": {
+              "type": "number",
+              "description": "Designed 'voltage' of battery (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
+            },
+            "warnUpper": {
+              "type": "number",
+              "description": "Upper operational voltage limit"
+            },
+            "warnLower": {
+              "type": "number",
+              "description": "Lower operational voltage limit"
+            },
+            "faultUpper": {
+              "type": "number",
+              "description": "Upper fault limit of battery voltage - BMS may disconnect battery"
+            },
+            "faultLower": {
+              "type": "number",
+              "description": "Lower fault limit of battery voltage - BMS may disconnect battery"
             }
+          }
+        },
+
+        "current": {
+          "type": "object",
+          "properties": {
+            "measured": {
+              "type": "object",
+              "description": "Measured amperage being '+' provided (or '-' consumed) by DC source",
+              "properties": {
+                "value"    : {"type": "number"},
+                "source"   : {"type": "string"},
+                "timestamp": {"type": "string"}
+              }
+            },
+            "warnUpper": {
+              "type": "number",
+              "description": "Upper operational current limit"
+            },
+            "warnLower": {
+              "type": "number",
+              "description": "Lower operational current limit"
+            },
+            "faultUpper": {
+              "type": "number",
+              "description": "Upper fault limit of battery current - BMS may disconnect battery"
+            },
+            "faultLower": {
+              "type": "number",
+              "description": "Lower fault limit of battery current - BMS may disconnect battery"
+            }
+          }
+        },
+
+        "temperature": {
+          "type": "object",
+          "title": "temperature",
+          "properties": {
+            "measured": {
+              "type": "object",
+              "description": "Temperature of device, in degrees Celsius",
+              "properties": {
+                "value"    : {"type": "number"},
+                "source"   : {"type": "string"},
+                "timestamp": {"type": "string"}
+              }
+            },
+            "warnUpper": {
+              "type": "number",
+              "description": "Upper operational temperature limit"
+            },
+            "warnLower": {
+              "type": "number",
+              "description": "Lower operational temperature limit"
+            },
+            "faultUpper": {
+              "type": "number",
+              "description": "Upper fault limit of temperature - device may disable"
+            },
+            "faultLower": {
+              "type": "number",
+              "description": "Lower fault limit of temperature  - device may disable"
+            }
+          }
+        }
+      }
+    },
+
+    "acSource": {
+      "type": "object",
+      "title": "AC Source",
+      "description": "AC power source common values",
+      "properties": {
+
+        "associatedBus": {
+          "type": "string",
+          "description": "Name of BUS source is assocated with (if applicable, may = NULL)"
+        },
+
+        "voltage": {
+          "type": "object",
+          "properties": {
+            "measured": {
+              "type": "object",
+              "description": "Measured voltage at AC Source terminals",
+              "properties": {
+                "value"    : {"type": "number"},
+                "source"   : {"type": "string"},
+                "timestamp": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+
+
+
+
+  "type": "object",
+  "properties": {
+
+    "battery": {
+      "type": "object",
+      "title": "Battery",
+      "description": "Batteries, one or many, within the vessel",
+      "required": ["ID"],
+      "properties": {
+        "ID": {"$ref": "#/definitions/identity"},
+        "DC": {"$ref": "#/definitions/dcSource"},
+        "mode": {
+          "type": "string",
+          "description": "Operational mode of battery",
+          "enum": [
+            "charging bulk",
+            "charging acceptance",
+            "charging overcharge",
+            "charging float",
+            "charging equalize",
+            "discharging",
+            "unknown",
+            "other"
+          ]
+        },
+
+        "chemistry": {
+          "type": "string",
+          "description": "Type of battery FLA, LiFePO4, etc."
         },
 
 
 
-        "inverter": {
-            "type": "object",
-            "title": "Inverter",
-            "description": "DC to AC inverter, one or many, within the vessel",
-            "required": ["ID"],
-            "properties": {
-                "ID": {"$ref": "#/definitions/identity"},
-                "DC": {"$ref": "#/definitions/dcSource"},
-                "AC": {"$ref": "#/definitions/acSource"},
-                "mode": {
-                    "type": "string",
-                    "description": "Operational mode of Inverter",
-                    "enum": [
-                        "idle",
-                        "inverting",
-                        "disabled",
-                        "standby",
-                        "faulted",
-                        "unknown",
-                        "other"
-                    ]
-                }
+        "temperature": {
+          "type": "object",
+          "title": "temperature",
+          "description": "Additional / unique temperatures associated with a battery",
+          "properties": {
+            "limitDischargeLower": {
+              "type": "number",
+              "description": "Operational minimum temperature limit for battery discharge, in degrees Celsius"
+            },
+            "limitDischargeUpper": {
+              "type": "number",
+              "description": "Operational maximum temperature limit for battery discharge, in degrees Celsius"
+            },
+            "limitRechargeLower": {
+              "type": "number",
+              "description": "Operational minimum temperature limit for battery recharging, in degrees Celsius"
+            },
+            "limitRechargeUpper": {
+              "type": "number",
+              "description": "Operational maximum temperature limit for battery recharging, in degrees Celsius"
             }
+          }
+        },
+
+
+        "capacity": {
+          "type": "object",
+          "title": "capacity",
+          "properties": {
+            "nominal": {
+              "type": "number",
+              "description": "The watt-hour capacity of battery as specified by the manufacturer"
+            },
+            "actual": {
+              "type": "number",
+              "description": "The measured watt-hour capacity of battery. This may change over time and will likely deviate from the nominal capacity."
+            },
+            "remaining": {
+              "type": "number",
+              "description": "Watt-hours remaining in battery"
+            },
+            "dischargeLimit": {
+              "type": "number",
+              "description": "Minimum number of watt-hours to be left in the battery while discharging"
+            }
+          }
+        },
+
+        "lifetimeDischarge": {
+          "type": "number",
+          "description": "Cumulative kWh discharged from battery over operational lifetime of battery"
+        },
+        "lifetimeRecharge": {
+          "type": "number",
+          "description": "Cumulative kWh recharged into battery over operational lifetime of battery"
         }
+      }
+    },
+
+
+
+    "inverter": {
+      "type": "object",
+      "title": "Inverter",
+      "description": "DC to AC inverter, one or many, within the vessel",
+      "required": ["ID"],
+      "properties": {
+        "ID": {"$ref": "#/definitions/identity"},
+        "DC": {"$ref": "#/definitions/dcSource"},
+        "AC": {"$ref": "#/definitions/acSource"},
+        "mode": {
+          "type": "string",
+          "description": "Operational mode of Inverter",
+          "enum": [
+            "idle",
+            "inverting",
+            "disabled",
+            "standby",
+            "faulted",
+            "unknown",
+            "other"
+          ]
+        }
+      }
     }
+  }
 }

--- a/schemas/groups/electrical_dc.json
+++ b/schemas/groups/electrical_dc.json
@@ -3,189 +3,203 @@
   "id": "https://signalk.github.io/specification/schemas/groups/electrical_dc.json#",
   "description": "Schema describing the electrical child-object of a Vessel.",
   "title": "DC Electrical Properties",
-
-
-  "definitions": {
-    "identity": {
-      "type": "object",
-      "title": "Electrical ID",
-      "description": " Common ID items shared by electrical items",
-      "required": ["name"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique ID of device (houseBattery, alternator, Generator, solar1, inverterCharger, Combiner1, etc.)"
-        },
-        "location": {
-          "type": "string",
-          "description": "Installed location of device on vessel"
-        },
-        "manufacturerName": {
-          "type": "string",
-          "description": "Manufacturer's name"
-        },
-        "manufacturerModel": {
-          "type": "string",
-          "description": "Model or part number"
-        },
-        "dateInstalled": {
-          "type": "string",
-          "description": "Date device was installed"
-        }
-      }
-    },
-
-
-
-
-
-
-    "dcSource": {
-      "type": "object",
-      "title": "DC Source",
-      "description": "DC power source common values",
-      "properties": {
-
-        "associatedBus": {
-          "type": "string",
-          "description": "Name of BUS source is associated with (if applicable, may = NULL)"
-        },
-
-        "voltage": {
-          "type": "object",
-          "properties": {
-            "measured": {
-              "type": "object",
-              "description": "Measured voltage of DC Source terminals",
-              "properties": {
-                "value"    : {"type": "number"},
-                "source"   : {"type": "string"},
-                "timestamp": {"type": "string"}
-              }
-            },
-            "nominal": {
-              "type": "number",
-              "description": "Designed 'voltage' of battery (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
-            },
-            "warnUpper": {
-              "type": "number",
-              "description": "Upper operational voltage limit"
-            },
-            "warnLower": {
-              "type": "number",
-              "description": "Lower operational voltage limit"
-            },
-            "faultUpper": {
-              "type": "number",
-              "description": "Upper fault limit of battery voltage - BMS may disconnect battery"
-            },
-            "faultLower": {
-              "type": "number",
-              "description": "Lower fault limit of battery voltage - BMS may disconnect battery"
-            }
-          }
-        },
-
-        "current": {
-          "type": "object",
-          "properties": {
-            "measured": {
-              "type": "object",
-              "description": "Measured amperage being '+' provided (or '-' consumed) by DC source",
-              "properties": {
-                "value"    : {"type": "number"},
-                "source"   : {"type": "string"},
-                "timestamp": {"type": "string"}
-              }
-            },
-            "warnUpper": {
-              "type": "number",
-              "description": "Upper operational current limit"
-            },
-            "warnLower": {
-              "type": "number",
-              "description": "Lower operational current limit"
-            },
-            "faultUpper": {
-              "type": "number",
-              "description": "Upper fault limit of battery current - BMS may disconnect battery"
-            },
-            "faultLower": {
-              "type": "number",
-              "description": "Lower fault limit of battery current - BMS may disconnect battery"
-            }
-          }
-        },
-
-        "temperature": {
-          "type": "object",
-          "title": "temperature",
-          "properties": {
-            "measured": {
-              "type": "object",
-              "description": "Temperature of device, in degrees Celsius",
-              "properties": {
-                "value"    : {"type": "number"},
-                "source"   : {"type": "string"},
-                "timestamp": {"type": "string"}
-              }
-            },
-            "warnUpper": {
-              "type": "number",
-              "description": "Upper operational temperature limit"
-            },
-            "warnLower": {
-              "type": "number",
-              "description": "Lower operational temperature limit"
-            },
-            "faultUpper": {
-              "type": "number",
-              "description": "Upper fault limit of temperature - device may disable"
-            },
-            "faultLower": {
-              "type": "number",
-              "description": "Lower fault limit of temperature  - device may disable"
-            }
-          }
-        }
-      }
-    },
-
-    "acSource": {
-      "type": "object",
-      "title": "AC Source",
-      "description": "AC power source common values",
-      "properties": {
-
-        "associatedBus": {
-          "type": "string",
-          "description": "Name of BUS source is assocated with (if applicable, may = NULL)"
-        },
-
-        "voltage": {
-          "type": "object",
-          "properties": {
-            "measured": {
-              "type": "object",
-              "description": "Measured voltage at AC Source terminals",
-              "properties": {
-                "value"    : {"type": "number"},
-                "source"   : {"type": "string"},
-                "timestamp": {"type": "string"}
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-
-
-
-
-
   "type": "object",
   "properties": {
+    "definitions": {
+      "title": "definitions",
+      "type": "object",
+      "description": "DC related definitions",
+
+      "properties": {
+        "identity": {
+          "type": "object",
+          "title": "Electrical ID",
+          "description": " Common ID items shared by electrical items",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Unique ID of device (houseBattery, alternator, Generator, solar1, inverterCharger, Combiner1, etc.)"
+            },
+
+            "location": {
+              "type": "string",
+              "description": "Installed location of device on vessel"
+            },
+
+            "manufacturerName": {
+              "type": "string",
+              "description": "Manufacturer's name"
+            },
+
+            "manufacturerModel": {
+              "type": "string",
+              "description": "Model or part number"
+            },
+
+            "dateInstalled": {
+              "$ref": "../defintions.json#/definitions/timestamp",
+              "description": "Date device was installed"
+            },
+
+            "timestamp": {
+              "$ref": "../defintions.json#/definitions/timestamp"
+            },
+            
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            }
+          }
+        },
+
+        "dcSource": {
+          "type": "object",
+          "title": "DC Source",
+          "description": "DC power source common values",
+          "properties": {
+            "associatedBus": {
+              "type": "string",
+              "description": "Name of BUS source is associated with (if applicable, may = NULL)"
+            },
+
+            "voltage": {
+              "type": "object",
+              "properties": {
+                "measured": {
+                  "description": "Measured voltage of DC Source terminals",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)"
+                },
+
+                "nominal": {
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)",
+                  "description": "Designed 'voltage' of battery (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
+                },
+
+                "warnUpper": {
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)",
+                  "description": "Upper operational voltage limit"
+                },
+
+                "warnLower": {
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)",
+                  "description": "Lower operational voltage limit"
+                },
+
+                "faultUpper": {
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)",
+                  "description": "Upper fault limit of battery voltage - BMS may disconnect battery"
+                },
+
+                "faultLower": {
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)",
+                  "description": "Lower fault limit of battery voltage - BMS may disconnect battery"
+                }
+              }
+            },
+
+            "current": {
+              "type": "object",
+              "properties": {
+                "measured": {
+                  "description": "Measured amperage being '+' provided (or '-' consumed) by DC source",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Amperage (A)"
+                },
+
+                "warnUpper": {
+                  "description": "Upper operational current limit",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Amperage (A)"
+                },
+
+                "warnLower": {
+                  "description": "Lower operational current limit",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Amperage (A)"
+                },
+
+                "faultUpper": {
+                  "description": "Upper fault limit of battery current - BMS may disconnect battery",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Amperage (A)"
+                },
+
+                "faultLower": {
+                  "description": "Lower fault limit of battery current - BMS may disconnect battery",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Amperage (A)"
+                }
+              }
+            },
+
+            "temperature": {
+              "type": "object",
+              "title": "temperature",
+              "properties": {
+                "measured": {
+                  "description": "Temperature of device, in degrees Celsius",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Degree Celcius (°C)"
+                },
+
+                "warnUpper": {
+                  "description": "Upper operational temperature limit",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Degree Celcius (°C)"
+                },
+
+                "warnLower": {
+                  "description": "Lower operational temperature limit",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Degree Celcius (°C)"
+                },
+
+                "faultUpper": {
+                  "description": "Upper fault limit of temperature - device may disable",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Degree Celcius (°C)"
+                },
+
+                "faultLower": {
+                  "description": "Lower fault limit of temperature  - device may disable",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Degree Celcius (°C)"
+                }
+              }
+            }
+          }
+        },
+
+        "acSource": {
+          "type": "object",
+          "title": "AC Source",
+          "description": "AC power source common values",
+          "properties": {
+            "associatedBus": {
+              "type": "string",
+              "description": "Name of BUS source is assocated with (if applicable, may = NULL)"
+            },
+
+            "voltage": {
+              "type": "object",
+              "properties": {
+                "measured": {
+                  "description": "Measured voltage at AC Source terminals",
+                  "#ref": "../defintions.json#/definitions/numberValue",
+                  "units": "Voltage (V)"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
 
     "battery": {
       "type": "object",
@@ -193,29 +207,46 @@
       "description": "Batteries, one or many, within the vessel",
       "required": ["ID"],
       "properties": {
-        "ID": {"$ref": "#/definitions/identity"},
-        "DC": {"$ref": "#/definitions/dcSource"},
+        "identity": {
+          "$ref": "#/definitions/identity"
+        },
+        
+        "dc": {
+          "$ref": "#/definitions/dcSource"
+        },
+
         "mode": {
-          "type": "string",
+          "type": "object",
           "description": "Operational mode of battery",
-          "enum": [
-            "charging bulk",
-            "charging acceptance",
-            "charging overcharge",
-            "charging float",
-            "charging equalize",
-            "discharging",
-            "unknown",
-            "other"
-          ]
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": [
+                "charging bulk",
+                "charging acceptance",
+                "charging overcharge",
+                "charging float",
+                "charging equalize",
+                "discharging",
+                "unknown",
+                "other"
+              ]
+            },
+
+            "timestamp": {
+              "$ref": "../defintions.json#/definitions/timestamp"
+            },
+            
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            }
+          }
         },
 
         "chemistry": {
-          "type": "string",
+          "$ref": "../defintions.json#/definitions/stringValue",
           "description": "Type of battery FLA, LiFePO4, etc."
         },
-
-
 
         "temperature": {
           "type": "object",
@@ -224,23 +255,37 @@
           "properties": {
             "limitDischargeLower": {
               "type": "number",
-              "description": "Operational minimum temperature limit for battery discharge, in degrees Celsius"
+              "description": "Operational minimum temperature limit for battery discharge, in degrees Celsius",
+              "units": "Degree Celcius (°C)"
             },
+
             "limitDischargeUpper": {
               "type": "number",
-              "description": "Operational maximum temperature limit for battery discharge, in degrees Celsius"
+              "description": "Operational maximum temperature limit for battery discharge, in degrees Celsius",
+              "units": "Degree Celcius (°C)"
             },
+
             "limitRechargeLower": {
               "type": "number",
-              "description": "Operational minimum temperature limit for battery recharging, in degrees Celsius"
+              "description": "Operational minimum temperature limit for battery recharging, in degrees Celsius",
+              "units": "Degree Celcius (°C)"
             },
+
             "limitRechargeUpper": {
               "type": "number",
-              "description": "Operational maximum temperature limit for battery recharging, in degrees Celsius"
+              "description": "Operational maximum temperature limit for battery recharging, in degrees Celsius",
+              "units": "Degree Celcius (°C)"
+            },
+
+            "timestamp": {
+              "$ref": "../defintions.json#/definitions/timestamp"
+            },
+            
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
             }
           }
         },
-
 
         "capacity": {
           "type": "object",
@@ -248,35 +293,43 @@
           "properties": {
             "nominal": {
               "type": "number",
-              "description": "The watt-hour capacity of battery as specified by the manufacturer"
+              "description": "The watt-hour capacity of battery as specified by the manufacturer",
+              "units": "Watts per hour (Wh)"
             },
+
             "actual": {
               "type": "number",
-              "description": "The measured watt-hour capacity of battery. This may change over time and will likely deviate from the nominal capacity."
+              "description": "The measured watt-hour capacity of battery. This may change over time and will likely deviate from the nominal capacity.",
+              "units": "Watts per hour (Wh)"
             },
+
             "remaining": {
               "type": "number",
-              "description": "Watt-hours remaining in battery"
+              "description": "Watt-hours remaining in battery",
+              "units": "Watts per hour (Wh)"
             },
+
             "dischargeLimit": {
               "type": "number",
-              "description": "Minimum number of watt-hours to be left in the battery while discharging"
+              "description": "Minimum number of watt-hours to be left in the battery while discharging",
+              "units": "Watts per hour (Wh)"
             }
           }
         },
 
         "lifetimeDischarge": {
           "type": "number",
-          "description": "Cumulative kWh discharged from battery over operational lifetime of battery"
+          "description": "Cumulative Wh discharged from battery over operational lifetime of battery",
+          "units": "Watts per hour (Wh)"
         },
+
         "lifetimeRecharge": {
           "type": "number",
-          "description": "Cumulative kWh recharged into battery over operational lifetime of battery"
+          "description": "Cumulative Wh recharged into battery over operational lifetime of battery",
+          "units": "Watts per hour (Wh)"
         }
       }
     },
-
-
 
     "inverter": {
       "type": "object",
@@ -284,21 +337,43 @@
       "description": "DC to AC inverter, one or many, within the vessel",
       "required": ["ID"],
       "properties": {
-        "ID": {"$ref": "#/definitions/identity"},
-        "DC": {"$ref": "#/definitions/dcSource"},
-        "AC": {"$ref": "#/definitions/acSource"},
+        "identity": {
+          "$ref": "#/definitions/identity"
+        },
+        
+        "dc": {
+          "$ref": "#/definitions/dcSource"
+        },
+
+        "ac": {
+          "$ref": "#/definitions/acSource"
+        },
+        
         "mode": {
-          "type": "string",
-          "description": "Operational mode of Inverter",
-          "enum": [
-            "idle",
-            "inverting",
-            "disabled",
-            "standby",
-            "faulted",
-            "unknown",
-            "other"
-          ]
+          "type": "object",
+          "description": "Operational mode of battery",
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": [
+                "idle",
+                "inverting",
+                "disabled",
+                "standby",
+                "faulted",
+                "unknown",
+                "other"
+              ]
+            },
+
+            "timestamp": {
+              "$ref": "../defintions.json#/definitions/timestamp"
+            },
+            
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            }
+          }
         }
       }
     }

--- a/schemas/groups/electrical_dc.json
+++ b/schemas/groups/electrical_dc.json
@@ -68,36 +68,36 @@
                 "measured": {
                   "description": "Measured voltage of DC Source terminals",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)"
+                  "units": "V"
                 },
 
                 "nominal": {
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)",
+                  "units": "V",
                   "description": "Designed 'voltage' of battery (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
                 },
 
                 "warnUpper": {
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)",
+                  "units": "V",
                   "description": "Upper operational voltage limit"
                 },
 
                 "warnLower": {
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)",
+                  "units": "V",
                   "description": "Lower operational voltage limit"
                 },
 
                 "faultUpper": {
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)",
+                  "units": "V",
                   "description": "Upper fault limit of battery voltage - BMS may disconnect battery"
                 },
 
                 "faultLower": {
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)",
+                  "units": "V",
                   "description": "Lower fault limit of battery voltage - BMS may disconnect battery"
                 }
               }
@@ -109,31 +109,31 @@
                 "measured": {
                   "description": "Measured amperage being '+' provided (or '-' consumed) by DC source",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Amperage (A)"
+                  "units": "A"
                 },
 
                 "warnUpper": {
                   "description": "Upper operational current limit",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Amperage (A)"
+                  "units": "A"
                 },
 
                 "warnLower": {
                   "description": "Lower operational current limit",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Amperage (A)"
+                  "units": "A"
                 },
 
                 "faultUpper": {
                   "description": "Upper fault limit of battery current - BMS may disconnect battery",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Amperage (A)"
+                  "units": "A"
                 },
 
                 "faultLower": {
                   "description": "Lower fault limit of battery current - BMS may disconnect battery",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Amperage (A)"
+                  "units": "A"
                 }
               }
             },
@@ -145,31 +145,31 @@
                 "measured": {
                   "description": "Temperature of device, in degrees Celsius",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Degree Celcius (°C)"
+                  "units": "°C"
                 },
 
                 "warnUpper": {
                   "description": "Upper operational temperature limit",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Degree Celcius (°C)"
+                  "units": "°C"
                 },
 
                 "warnLower": {
                   "description": "Lower operational temperature limit",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Degree Celcius (°C)"
+                  "units": "°C"
                 },
 
                 "faultUpper": {
                   "description": "Upper fault limit of temperature - device may disable",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Degree Celcius (°C)"
+                  "units": "°C"
                 },
 
                 "faultLower": {
                   "description": "Lower fault limit of temperature  - device may disable",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Degree Celcius (°C)"
+                  "units": "°C"
                 }
               }
             }
@@ -192,7 +192,7 @@
                 "measured": {
                   "description": "Measured voltage at AC Source terminals",
                   "#ref": "../defintions.json#/definitions/numberValue",
-                  "units": "Voltage (V)"
+                  "units": "V"
                 }
               }
             }
@@ -256,25 +256,25 @@
             "limitDischargeLower": {
               "type": "number",
               "description": "Operational minimum temperature limit for battery discharge, in degrees Celsius",
-              "units": "Degree Celcius (°C)"
+              "units": "°C"
             },
 
             "limitDischargeUpper": {
               "type": "number",
               "description": "Operational maximum temperature limit for battery discharge, in degrees Celsius",
-              "units": "Degree Celcius (°C)"
+              "units": "°C"
             },
 
             "limitRechargeLower": {
               "type": "number",
               "description": "Operational minimum temperature limit for battery recharging, in degrees Celsius",
-              "units": "Degree Celcius (°C)"
+              "units": "°C"
             },
 
             "limitRechargeUpper": {
               "type": "number",
               "description": "Operational maximum temperature limit for battery recharging, in degrees Celsius",
-              "units": "Degree Celcius (°C)"
+              "units": "°C"
             },
 
             "timestamp": {
@@ -294,25 +294,25 @@
             "nominal": {
               "type": "number",
               "description": "The watt-hour capacity of battery as specified by the manufacturer",
-              "units": "Watts per hour (Wh)"
+              "units": "Wh"
             },
 
             "actual": {
               "type": "number",
               "description": "The measured watt-hour capacity of battery. This may change over time and will likely deviate from the nominal capacity.",
-              "units": "Watts per hour (Wh)"
+              "units": "Wh"
             },
 
             "remaining": {
               "type": "number",
               "description": "Watt-hours remaining in battery",
-              "units": "Watts per hour (Wh)"
+              "units": "Wh"
             },
 
             "dischargeLimit": {
               "type": "number",
               "description": "Minimum number of watt-hours to be left in the battery while discharging",
-              "units": "Watts per hour (Wh)"
+              "units": "Wh"
             }
           }
         },
@@ -320,13 +320,13 @@
         "lifetimeDischarge": {
           "type": "number",
           "description": "Cumulative Wh discharged from battery over operational lifetime of battery",
-          "units": "Watts per hour (Wh)"
+          "units": "Wh"
         },
 
         "lifetimeRecharge": {
           "type": "number",
           "description": "Cumulative Wh recharged into battery over operational lifetime of battery",
-          "units": "Watts per hour (Wh)"
+          "units": "Wh"
         }
       }
     },

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -7,16 +7,22 @@
   "properties": {
     "airPressureChangeRateAlarm": {
       "description": "Change per hour which will cause an alarm in kPa",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Kilo Pascal (kPa)"
     },
+
     "airPressure": {
       "description": "Current air pressure in kPa",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Kilo Pascal (kPa)"
     },
+    
     "airTemp": {
-      "description": "Current air temperature in degrees Centigrade",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "description": "Current air temperature in degrees Celsius",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Degree Celcius (°C)"
     },
+    
     "depth": {
       "title": "depth",
       "type": "object",
@@ -24,58 +30,84 @@
       "properties": {
         "belowKeel": {
           "description": "Depth below keel in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+
         "belowTransducer": {
           "description": "Depth below Transducer in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+        
         "belowSurface": {
           "description": "Depth from surface in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+        
         "transducerToKeel": {
           "description": "Depth in meters from the transducer to the bottom of the keel.",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+        
         "surfaceToTransducer": {
           "description": "Depth transducer is below the water in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         }
       }
     },
+
     "humidity": {
       "description": "Current relative humidity as percentage",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Percentage (%)"
     },
+    
     "salinity": {
-      "description": "Water salinity",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "description": "Water salinity, measured in parts per thousand",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Parts per thousand (‰)"
     },
+    
     "current": {
       "type": "object",
       "title": "current",
       "description": "Direction and strength of current affecting the vessel",
       "properties": {
-        "timestamp": {"$ref": "../defintions.json#/definitions/timestamp"},
-        "source": {"$ref": "../definitions.json#/definitions/source"},
+        "timestamp": {
+          "$ref": "../defintions.json#/definitions/timestamp"
+        },
+        
+        "source": {
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        
         "drift": {
           "type": "number",
           "description": "The speed component of the water current vector in m/s",
-          "example": 3.12
+          "example": 3.12,
+          "units": "Meters per second (m/s)"
         },
+
         "setTrue": {
           "type": "number",
           "description": "The direction component of the water current vector in decimal degrees referenced to true (geographic) north",
-          "example": 123.45
+          "example": 123.45,
+          "units": "Arc degrees (°), true"
         },
+
         "setMagnetic": {
           "type": "number",
           "description": "The direction component of the water current vector in decimal degrees referenced to magnetic north",
-          "example": 131.22
+          "example": 131.22,
+          "units": "Arc degrees (°), magnetic"
         }
       }
     },
+
     "tide": {
       "type": "object",
       "title": "tide",
@@ -83,30 +115,40 @@
       "properties": {
         "heightHigh": {
           "description": "Next high tide in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+
         "heightNow": {
           "description": "The current tide height in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+        
         "heightLow": {
           "description": "The next low tide height in meters",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters (m)"
         },
+        
         "timeLow": {
           "description": "Time of the next low tide in UTC",
-          "$ref": "../definitions.json#/definitions/stringValue"
+          "$ref": "../definitions.json#/definitions/timestamp"
         },
+        
         "timeHigh": {
           "description": "Time of next high tide in UTC",
-          "$ref": "../definitions.json#/definitions/stringValue"
+          "$ref": "../definitions.json#/definitions/timestamp"
         }
       }
     },
+
     "waterTemp": {
-      "description": "Current water temperature in degrees Centigrade",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "description": "Current water temperature in degrees Celcius",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Degree Celcius (°C)"
     },
+    
     "wind": {
       "type": "object",
       "title": "wind",
@@ -114,46 +156,64 @@
       "properties": {
         "angleApparent": {
           "description": "Apparent wind angle, -180 to +180 degrees from the bow. Negative numbers to port.",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
+
         "angleTrueGround": {
           "description": "'True' wind angle based on Speed Over Ground (SOG), -180 to +180 degrees from the bow. Negative numbers to port.",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
+        
         "angleTrueWater": {
           "description": "'True' wind angle based on Speed Through Water (STW), -180 to +180 degrees from the bow. Negative numbers to port.",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
+        
         "directionChangeAlarm": {
           "description": "The number of degrees the wind needs to shift to raise an alarm",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
+        
         "directionTrue": {
           "description": "The wind direction relative to true north, in compass degrees, 0 = North",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
+        
         "directionMagnetic": {
           "description": "The wind direction relative to magnetic north, in compass degrees, 0 = North",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
+        
         "speedAlarm": {
           "description": "The speed in m/s above which a wind alarm will be raised",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters per second (m/s)"
         },
+        
         "speedTrue": {
           "description": "Wind speed over water in m/s (as calculated from speedApparent and vessel's speed through water)",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters per second (m/s)"
         },
+        
         "speedOverGround": {
           "description": "Wind speed over ground in m/s (as calculated from speedApparent and vessel's speed over ground)",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters per second (m/s)"
         },
+        
         "speedApparent": {
           "description": "Apparent wind speed in m/s",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Meters per second (m/s)"
         }
       }
     }
-
   }
 }

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -8,19 +8,19 @@
     "airPressureChangeRateAlarm": {
       "description": "Change per hour which will cause an alarm in kPa",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Kilo Pascal (kPa)"
+      "units": "kPa"
     },
 
     "airPressure": {
       "description": "Current air pressure in kPa",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Kilo Pascal (kPa)"
+      "units": "kPa"
     },
     
     "airTemp": {
       "description": "Current air temperature in degrees Celsius",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Degree Celcius (°C)"
+      "units": "°C"
     },
     
     "depth": {
@@ -31,31 +31,31 @@
         "belowKeel": {
           "description": "Depth below keel in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
 
         "belowTransducer": {
           "description": "Depth below Transducer in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "belowSurface": {
           "description": "Depth from surface in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "transducerToKeel": {
           "description": "Depth in meters from the transducer to the bottom of the keel.",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "surfaceToTransducer": {
           "description": "Depth transducer is below the water in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         }
       }
     },
@@ -63,13 +63,13 @@
     "humidity": {
       "description": "Current relative humidity as percentage",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Percentage (%)"
+      "units": "%"
     },
     
     "salinity": {
       "description": "Water salinity, measured in parts per thousand",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Parts per thousand (‰)"
+      "units": "‰"
     },
     
     "current": {
@@ -89,21 +89,21 @@
           "type": "number",
           "description": "The speed component of the water current vector in m/s",
           "example": 3.12,
-          "units": "Meters per second (m/s)"
+          "units": "m/s"
         },
 
         "setTrue": {
           "type": "number",
           "description": "The direction component of the water current vector in decimal degrees referenced to true (geographic) north",
           "example": 123.45,
-          "units": "Arc degrees (°), true"
+          "units": "°"
         },
 
         "setMagnetic": {
           "type": "number",
           "description": "The direction component of the water current vector in decimal degrees referenced to magnetic north",
           "example": 131.22,
-          "units": "Arc degrees (°), magnetic"
+          "units": "°"
         }
       }
     },
@@ -116,19 +116,19 @@
         "heightHigh": {
           "description": "Next high tide in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
 
         "heightNow": {
           "description": "The current tide height in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "heightLow": {
           "description": "The next low tide height in meters",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters (m)"
+          "units": "m"
         },
         
         "timeLow": {
@@ -146,7 +146,7 @@
     "waterTemp": {
       "description": "Current water temperature in degrees Celcius",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Degree Celcius (°C)"
+      "units": "°C"
     },
     
     "wind": {
@@ -157,61 +157,61 @@
         "angleApparent": {
           "description": "Apparent wind angle, -180 to +180 degrees from the bow. Negative numbers to port.",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
 
         "angleTrueGround": {
           "description": "'True' wind angle based on Speed Over Ground (SOG), -180 to +180 degrees from the bow. Negative numbers to port.",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
         
         "angleTrueWater": {
           "description": "'True' wind angle based on Speed Through Water (STW), -180 to +180 degrees from the bow. Negative numbers to port.",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
         
         "directionChangeAlarm": {
           "description": "The number of degrees the wind needs to shift to raise an alarm",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
         
         "directionTrue": {
           "description": "The wind direction relative to true north, in compass degrees, 0 = North",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
         
         "directionMagnetic": {
           "description": "The wind direction relative to magnetic north, in compass degrees, 0 = North",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
         
         "speedAlarm": {
           "description": "The speed in m/s above which a wind alarm will be raised",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters per second (m/s)"
+          "units": "m/s"
         },
         
         "speedTrue": {
           "description": "Wind speed over water in m/s (as calculated from speedApparent and vessel's speed through water)",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters per second (m/s)"
+          "units": "m/s"
         },
         
         "speedOverGround": {
           "description": "Wind speed over ground in m/s (as calculated from speedApparent and vessel's speed over ground)",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters per second (m/s)"
+          "units": "m/s"
         },
         
         "speedApparent": {
           "description": "Apparent wind speed in m/s",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Meters per second (m/s)"
+          "units": "m/s"
         }
       }
     }

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -1,159 +1,159 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/environmental.json#",
-    "description": "Schema describing the environmental child-object of a Vessel.",
-    "title": "environment",
-    "properties": {
-        "airPressureChangeRateAlarm": {
-            "description": "Change per hour which will cause an alarm in kPa",
-            "$ref": "../definitions.json#/definitions/numberValue"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/environmental.json#",
+  "description": "Schema describing the environmental child-object of a Vessel.",
+  "title": "environment",
+  "properties": {
+    "airPressureChangeRateAlarm": {
+      "description": "Change per hour which will cause an alarm in kPa",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "airPressure": {
+      "description": "Current air pressure in kPa",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "airTemp": {
+      "description": "Current air temperature in degrees Centigrade",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "depth": {
+      "title": "depth",
+      "type": "object",
+      "description": "Depth related data",
+      "properties": {
+        "belowKeel": {
+          "description": "Depth below keel in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
         },
-        "airPressure": {
-            "description": "Current air pressure in kPa",
-            "$ref": "../definitions.json#/definitions/numberValue"
+        "belowTransducer": {
+          "description": "Depth below Transducer in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
         },
-        "airTemp": {
-            "description": "Current air temperature in degrees Centigrade",
-            "$ref": "../definitions.json#/definitions/numberValue"
+        "belowSurface": {
+          "description": "Depth from surface in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
         },
-        "depth": {
-            "title": "depth",
-            "type": "object",
-            "description": "Depth related data",
-            "properties": {
-                "belowKeel": {
-                    "description": "Depth below keel in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "belowTransducer": {
-                    "description": "Depth below Transducer in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "belowSurface": {
-                    "description": "Depth from surface in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "transducerToKeel": {
-                    "description": "Depth in meters from the transducer to the bottom of the keel.",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "surfaceToTransducer": {
-                    "description": "Depth transducer is below the water in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                }
-            }
+        "transducerToKeel": {
+          "description": "Depth in meters from the transducer to the bottom of the keel.",
+          "$ref": "../definitions.json#/definitions/numberValue"
         },
-        "humidity": {
-            "description": "Current relative humidity as percentage",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "salinity": {
-            "description": "Water salinity",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "current": {
-            "type": "object",
-            "title": "current",
-            "description": "Direction and strength of current affecting the vessel",
-            "properties": {
-                "timestamp": {"$ref": "../defintions.json#/definitions/timestamp"},
-                "source": {"$ref": "../definitions.json#/definitions/source"},
-                "drift": {
-                    "type": "number",
-                    "description": "The speed component of the water current vector in m/s",
-                    "example": 3.12
-                },
-                "setTrue": {
-                    "type": "number",
-                    "description": "The direction component of the water current vector in decimal degrees referenced to true (geographic) north",
-                    "example": 123.45
-                },
-                "setMagnetic": {
-                    "type": "number",
-                    "description": "The direction component of the water current vector in decimal degrees referenced to magnetic north",
-                    "example": 131.22
-                }
-            }
-        },
-        "tide": {
-            "type": "object",
-            "title": "tide",
-            "description": "Tide data",
-            "properties": {
-                "heightHigh": {
-                    "description": "Next high tide in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "heightNow": {
-                    "description": "The current tide height in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "heightLow": {
-                    "description": "The next low tide height in meters",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "timeLow": {
-                    "description": "Time of the next low tide in UTC",
-                    "$ref": "../definitions.json#/definitions/stringValue"
-                },
-                "timeHigh": {
-                    "description": "Time of next high tide in UTC",
-                    "$ref": "../definitions.json#/definitions/stringValue"
-                }
-            }
-        },
-        "waterTemp": {
-            "description": "Current water temperature in degrees Centigrade",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "wind": {
-            "type": "object",
-            "title": "wind",
-            "description": "Wind data.",
-            "properties": {
-                "angleApparent": {
-                    "description": "Apparent wind angle, -180 to +180 degrees from the bow. Negative numbers to port.",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "angleTrueGround": {
-                    "description": "'True' wind angle based on Speed Over Ground (SOG), -180 to +180 degrees from the bow. Negative numbers to port.",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "angleTrueWater": {
-                    "description": "'True' wind angle based on Speed Through Water (STW), -180 to +180 degrees from the bow. Negative numbers to port.",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "directionChangeAlarm": {
-                    "description": "The number of degrees the wind needs to shift to raise an alarm",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "directionTrue": {
-                    "description": "The wind direction relative to true north, in compass degrees, 0 = North",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "directionMagnetic": {
-                    "description": "The wind direction relative to magnetic north, in compass degrees, 0 = North",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "speedAlarm": {
-                    "description": "The speed in m/s above which a wind alarm will be raised",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "speedTrue": {
-                    "description": "Wind speed over water in m/s (as calculated from speedApparent and vessel's speed through water)",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "speedOverGround": {
-                    "description": "Wind speed over ground in m/s (as calculated from speedApparent and vessel's speed over ground)",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "speedApparent": {
-                    "description": "Apparent wind speed in m/s",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                }
-            }
+        "surfaceToTransducer": {
+          "description": "Depth transducer is below the water in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
         }
-
+      }
+    },
+    "humidity": {
+      "description": "Current relative humidity as percentage",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "salinity": {
+      "description": "Water salinity",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "current": {
+      "type": "object",
+      "title": "current",
+      "description": "Direction and strength of current affecting the vessel",
+      "properties": {
+        "timestamp": {"$ref": "../defintions.json#/definitions/timestamp"},
+        "source": {"$ref": "../definitions.json#/definitions/source"},
+        "drift": {
+          "type": "number",
+          "description": "The speed component of the water current vector in m/s",
+          "example": 3.12
+        },
+        "setTrue": {
+          "type": "number",
+          "description": "The direction component of the water current vector in decimal degrees referenced to true (geographic) north",
+          "example": 123.45
+        },
+        "setMagnetic": {
+          "type": "number",
+          "description": "The direction component of the water current vector in decimal degrees referenced to magnetic north",
+          "example": 131.22
+        }
+      }
+    },
+    "tide": {
+      "type": "object",
+      "title": "tide",
+      "description": "Tide data",
+      "properties": {
+        "heightHigh": {
+          "description": "Next high tide in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "heightNow": {
+          "description": "The current tide height in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "heightLow": {
+          "description": "The next low tide height in meters",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "timeLow": {
+          "description": "Time of the next low tide in UTC",
+          "$ref": "../definitions.json#/definitions/stringValue"
+        },
+        "timeHigh": {
+          "description": "Time of next high tide in UTC",
+          "$ref": "../definitions.json#/definitions/stringValue"
+        }
+      }
+    },
+    "waterTemp": {
+      "description": "Current water temperature in degrees Centigrade",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "wind": {
+      "type": "object",
+      "title": "wind",
+      "description": "Wind data.",
+      "properties": {
+        "angleApparent": {
+          "description": "Apparent wind angle, -180 to +180 degrees from the bow. Negative numbers to port.",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "angleTrueGround": {
+          "description": "'True' wind angle based on Speed Over Ground (SOG), -180 to +180 degrees from the bow. Negative numbers to port.",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "angleTrueWater": {
+          "description": "'True' wind angle based on Speed Through Water (STW), -180 to +180 degrees from the bow. Negative numbers to port.",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "directionChangeAlarm": {
+          "description": "The number of degrees the wind needs to shift to raise an alarm",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "directionTrue": {
+          "description": "The wind direction relative to true north, in compass degrees, 0 = North",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "directionMagnetic": {
+          "description": "The wind direction relative to magnetic north, in compass degrees, 0 = North",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "speedAlarm": {
+          "description": "The speed in m/s above which a wind alarm will be raised",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "speedTrue": {
+          "description": "Wind speed over water in m/s (as calculated from speedApparent and vessel's speed through water)",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "speedOverGround": {
+          "description": "Wind speed over ground in m/s (as calculated from speedApparent and vessel's speed over ground)",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "speedApparent": {
+          "description": "Apparent wind speed in m/s",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        }
+      }
     }
+
+  }
 }

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -1,333 +1,333 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/navigation.json#",
-    "description": "Schema describing the navigation child-object of a Vessel.",
-    "title": "navigation",
-    "properties": {
-        "courseOverGroundMagnetic": {
-            "description": "",
-            "$ref": "../definitions.json#/definitions/numberValue"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/navigation.json#",
+  "description": "Schema describing the navigation child-object of a Vessel.",
+  "title": "navigation",
+  "properties": {
+    "courseOverGroundMagnetic": {
+      "description": "",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "courseOverGroundTrue": {
+      "description": "",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "activeRoute": {
+      "type": "object",
+      "title": "Active Route",
+      "description": "The currently active route",
+      "properties": {
+        "timestamp": {
+          "$ref": "../definitions.json#/definitions/timestamp",
+          "description": "Time of last update to active route"
         },
-        "courseOverGroundTrue": {
-            "description": "",
-            "$ref": "../definitions.json#/definitions/numberValue"
+        "source": {
+          "$ref": "../definitions.json#/definitions/source",
+          "description": "Source of last update to active route"
         },
-        "activeRoute": {
-            "type": "object",
-            "title": "Active Route",
-            "description": "The currently active route",
-            "properties": {
-                "timestamp": {
-                    "$ref": "../definitions.json#/definitions/timestamp",
-                    "description": "Time of last update to active route"
-                },
-                "source": {
-                    "$ref": "../definitions.json#/definitions/source",
-                    "description": "Source of last update to active route"
-                },
-                "bearingActual": {
-                    "type": "number",
-                    "description": "The current bearing of the next waypoint in degrees true"
-                },
-                "distanceActual": {
-                    "type": "number",
-                    "description": "The current distance to the next waypoint in meters"
-                },
-                "bearingDirect": {
-                    "type": "number",
-                    "description": "The bearing in degrees true from last waypoint to the next waypoint"
-                },
-                "courseRequired": {
-                    "type": "number",
-                    "description": "The course required to make the next waypoint in degrees true"
-                },
-                "eta": {
-                    "$ref": "../definitions.json#/definitions/timestamp",
-                    "description": "The estimated time of arrival at the end of the current route"
-                },
-                "route": {
-                    "type": "string",
-                    "description": "A pointer to the current route, found in the routes list"
-                },
-                "startTime": {
-                    "$ref": "../definitions.json#/definitions/timestamp",
-                    "description": "The time this route was activated in UTC"
-                },
-                "waypoint": {
-                    "type": "object",
-                    "title": "waypoint",
-                    "description": "The last and next waypoints data",
-                    "properties": {
-                        "lastTime": {
-                            "$ref": "../definitions.json#/definitions/timestamp",
-                            "description": "The time the last waypoint was reached in UTC"
-                        },
-                        "last": {
-                            "type": "string",
-                            "description": "The last waypoint, a pointer to the list of waypoints"
-                        },
-                        "nextEta": {
-                            "$ref": "../definitions.json#/definitions/timestamp",
-                            "description": "Estimated time of arrival at the next waypoint",
-                            "example": "2014-03-24T00:15:41Z"
-                        },
-                        "next": {
-                            "type": "string",
-                            "description": "A pointer to the next waypoint, found in the waypoints list"
-                        },
-                        "xte": {
-                            "type": "number",
-                            "description": "Cross track error in meters"
-                        }
-                    }
-                }
+        "bearingActual": {
+          "type": "number",
+          "description": "The current bearing of the next waypoint in degrees true"
+        },
+        "distanceActual": {
+          "type": "number",
+          "description": "The current distance to the next waypoint in meters"
+        },
+        "bearingDirect": {
+          "type": "number",
+          "description": "The bearing in degrees true from last waypoint to the next waypoint"
+        },
+        "courseRequired": {
+          "type": "number",
+          "description": "The course required to make the next waypoint in degrees true"
+        },
+        "eta": {
+          "$ref": "../definitions.json#/definitions/timestamp",
+          "description": "The estimated time of arrival at the end of the current route"
+        },
+        "route": {
+          "type": "string",
+          "description": "A pointer to the current route, found in the routes list"
+        },
+        "startTime": {
+          "$ref": "../definitions.json#/definitions/timestamp",
+          "description": "The time this route was activated in UTC"
+        },
+        "waypoint": {
+          "type": "object",
+          "title": "waypoint",
+          "description": "The last and next waypoints data",
+          "properties": {
+            "lastTime": {
+              "$ref": "../definitions.json#/definitions/timestamp",
+              "description": "The time the last waypoint was reached in UTC"
+            },
+            "last": {
+              "type": "string",
+              "description": "The last waypoint, a pointer to the list of waypoints"
+            },
+            "nextEta": {
+              "$ref": "../definitions.json#/definitions/timestamp",
+              "description": "Estimated time of arrival at the next waypoint",
+              "example": "2014-03-24T00:15:41Z"
+            },
+            "next": {
+              "type": "string",
+              "description": "A pointer to the next waypoint, found in the waypoints list"
+            },
+            "xte": {
+              "type": "number",
+              "description": "Cross track error in meters"
             }
+          }
+        }
+      }
+    },
+    "magneticVariation": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "The magnetic variation (declination) at the current position"
+    },
+    "destination": {
+      "title": "destination",
+      "description": "The intended destination of this trip",
+      "type": "object",
+      "properties": {
+        "eta": {
+          "$ref": "../definitions.json#/definitions/timestamp"
         },
-        "magneticVariation": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "The magnetic variation (declination) at the current position"
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
         },
-        "destination": {
-            "title": "destination",
-            "description": "The intended destination of this trip",
-            "type": "object",
-            "properties": {
-                "eta": {
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "longitude": {
-                    "type": "number",
-                    "description": "Longitude of the destination in decimal degrees",
-                    "example": 4.98765245
-                },
-                "latitude": {
-                    "type": "number",
-                    "description": "Latitude of the destination in decimal degrees",
-                    "example": 52.0987654
-                },
-                "altitude": {
-                    "type": "number",
-                    "description": "Altitude of the destination in meters"
-                }
-            }
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
         },
-        "gnss": {
-            "type": "object",
-            "title": "gnss",
-            "description": "Global satellite navigation meta information",
-            "properties": {
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "quality": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Quality of the satellite fix"
-                },
-                "satellites": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Number of satellites"
-                },
-                "antennaAltitude": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Altitude of antenna in meters"
-                },
-                "horizontalDilution": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Horizontal position error"
-                },
-                "geoidalSeparation": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Difference between WGS84 earth ellipsoid and mean sea level"
-                },
-                "differentialAge": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Age of DGPS data in seconds"
-                },
-                "differentialReference": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "ID of DGPS base station"
-                }
-            }
+        "longitude": {
+          "type": "number",
+          "description": "Longitude of the destination in decimal degrees",
+          "example": 4.98765245
         },
-        "headingMagnetic": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Current magnetic heading of the vessels in degrees"
+        "latitude": {
+          "type": "number",
+          "description": "Latitude of the destination in decimal degrees",
+          "example": 52.0987654
         },
-        "headingTrue": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "The current true heading of the vessel in degrees"
+        "altitude": {
+          "type": "number",
+          "description": "Altitude of the destination in meters"
+        }
+      }
+    },
+    "gnss": {
+      "type": "object",
+      "title": "gnss",
+      "description": "Global satellite navigation meta information",
+      "properties": {
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+        "quality": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Quality of the satellite fix"
+        },
+        "satellites": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Number of satellites"
+        },
+        "antennaAltitude": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Altitude of antenna in meters"
+        },
+        "horizontalDilution": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Horizontal position error"
+        },
+        "geoidalSeparation": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Difference between WGS84 earth ellipsoid and mean sea level"
+        },
+        "differentialAge": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Age of DGPS data in seconds"
+        },
+        "differentialReference": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "ID of DGPS base station"
+        }
+      }
+    },
+    "headingMagnetic": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Current magnetic heading of the vessels in degrees"
+    },
+    "headingTrue": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "The current true heading of the vessel in degrees"
+    },
+    "position": {
+      "type": "object",
+      "title": "position",
+      "description": "The position of the vessel in 3 dimensions",
+      "properties": {
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+        "longitude": {
+          "type": "number",
+          "description": "Longitude of boat in decimal degrees",
+          "example": 4.98765245
+        },
+        "latitude": {
+          "type": "number",
+          "description": "Latitude of boat in decimal degrees",
+          "example": 52.0987654
+        },
+        "altitude": {
+          "type": "number",
+          "description": "Altitude of boat in meters"
+        }
+      }
+    },
+    "attitude": {
+      "type": "object",
+      "title": "Attitude",
+      "description": "Vessel attitude: roll, pitch and yaw",
+      "properties": {
+        "roll": {
+          "type": "number",
+          "description": "Vessel roll in degrees looking to the bow, level = 0, clockwise is +ve"
+        },
+        "pitch": {
+          "type": "number",
+          "description": "Pitch in degrees, 0 is horizontal, +ve is bow up"
+        },
+        "yaw": {
+          "type": "number",
+          "description": "Yaw in degrees"
+        },
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        }
+      }
+    },
+    "rateOfTurn": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Rate of turn in degrees per second"
+    },
+    "speedOverGround": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Vessel speed over ground, in m/s"
+    },
+    "speedThroughWater": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Vessel speed through the water in m/s"
+    },
+    "log": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Log value in meters"
+    },
+    "logTrip": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Trip log value in meters"
+    },
+    "state": {
+      "type": "object",
+      "title": "state",
+      "description": "Current navigational state of the vessel",
+      "properties": {
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+        "value": {
+          "type": "string",
+          "enum": [
+            "under way using engine",
+            "at anchor",
+            "not under command",
+            "restricted maneuverability",
+            "constrained by her draught",
+            "moored",
+            "aground",
+            "engaged in fishing",
+            "under way sailing",
+            "not defined (example)"
+          ]
+        }
+      }
+    },
+    "anchor": {
+      "type": "object",
+      "title": "anchor",
+      "description": "The anchor data, for anchor watch etc",
+      "properties": {
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+        "maxRadius": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Radius of anchor alarm boundary in meters. The distance from anchor to the center of the boat"
+        },
+        "currentRadius": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Current distance to anchor in meters"
         },
         "position": {
-            "type": "object",
-            "title": "position",
-            "description": "The position of the vessel in 3 dimensions",
-            "properties": {
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "longitude": {
-                    "type": "number",
-                    "description": "Longitude of boat in decimal degrees",
-                    "example": 4.98765245
-                },
-                "latitude": {
-                    "type": "number",
-                    "description": "Latitude of boat in decimal degrees",
-                    "example": 52.0987654
-                },
-                "altitude": {
-                    "type": "number",
-                    "description": "Altitude of boat in meters"
-                }
+          "type": "object",
+          "title": "position",
+          "description": "The actual anchor position of the vessel in 3 dimensions, probably an estimate at best",
+          "properties": {
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+            "longitude": {
+              "type": "number",
+              "description": "Longitude of the anchor in decimal degrees",
+              "example": 4.98765245
+            },
+            "latitude": {
+              "type": "number",
+              "description": "Latitude of the anchor in decimal degrees",
+              "example": 52.0987654
+            },
+            "altitude": {
+              "type": "number",
+              "description": "Altitude of the anchor in meters"
             }
-        },
-        "attitude": {
-            "type": "object",
-            "title": "Attitude",
-            "description": "Vessel attitude: roll, pitch and yaw",
-            "properties": {
-                "roll": {
-                    "type": "number",
-                    "description": "Vessel roll in degrees looking to the bow, level = 0, clockwise is +ve"
-                },
-                "pitch": {
-                    "type": "number",
-                    "description": "Pitch in degrees, 0 is horizontal, +ve is bow up"
-                },
-                "yaw": {
-                    "type": "number",
-                    "description": "Yaw in degrees"
-                },
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                }
-            }
-        },
-        "rateOfTurn": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Rate of turn in degrees per second"
-        },
-        "speedOverGround": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Vessel speed over ground, in m/s"
-        },
-        "speedThroughWater": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Vessel speed through the water in m/s"
-        },
-        "log": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Log value in meters"
-        },
-        "logTrip": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "Trip log value in meters"
-        },
-        "state": {
-            "type": "object",
-            "title": "state",
-            "description": "Current navigational state of the vessel",
-            "properties": {
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "value": {
-                    "type": "string",
-                    "enum": [
-                        "under way using engine",
-                        "at anchor",
-                        "not under command",
-                        "restricted maneuverability",
-                        "constrained by her draught",
-                        "moored",
-                        "aground",
-                        "engaged in fishing",
-                        "under way sailing",
-                        "not defined (example)"
-                    ]
-                }
-            }
-        },
-        "anchor": {
-            "type": "object",
-            "title": "anchor",
-            "description": "The anchor data, for anchor watch etc",
-            "properties": {
-                "source": {
-                    "description": "Source of this data",
-                    "$ref": "../definitions.json#/definitions/source"
-                },
-                "timestamp": {
-                    "description": "timestamp of the last update to this data",
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                },
-                "maxRadius": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Radius of anchor alarm boundary in meters. The distance from anchor to the center of the boat"
-                },
-                "currentRadius": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Current distance to anchor in meters"
-                },
-                "position": {
-                    "type": "object",
-                    "title": "position",
-                    "description": "The actual anchor position of the vessel in 3 dimensions, probably an estimate at best",
-                    "properties": {
-                        "source": {
-                            "description": "Source of this data",
-                            "$ref": "../definitions.json#/definitions/source"
-                        },
-                        "timestamp": {
-                            "description": "timestamp of the last update to this data",
-                            "$ref": "../definitions.json#/definitions/timestamp"
-                        },
-                        "longitude": {
-                            "type": "number",
-                            "description": "Longitude of the anchor in decimal degrees",
-                            "example": 4.98765245
-                        },
-                        "latitude": {
-                            "type": "number",
-                            "description": "Latitude of the anchor in decimal degrees",
-                            "example": 52.0987654
-                        },
-                        "altitude": {
-                            "type": "number",
-                            "description": "Altitude of the anchor in meters"
-                        }
-                    }
-                }
-            }
+          }
         }
+      }
     }
+  }
 }

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -135,12 +135,14 @@
         "longitude": {
           "type": "number",
           "description": "Longitude of the destination in decimal degrees",
+          "units": "°",
           "example": 4.98765245
         },
 
         "latitude": {
           "type": "number",
           "description": "Latitude of the destination in decimal degrees",
+          "units": "°",
           "example": 52.0987654
         },
 
@@ -236,12 +238,14 @@
         "longitude": {
           "type": "number",
           "description": "Longitude of boat in decimal degrees",
+          "units": "°",
           "example": 4.98765245
         },
 
         "latitude": {
           "type": "number",
           "description": "Latitude of boat in decimal degrees",
+          "units": "°",
           "example": 52.0987654
         },
 
@@ -395,12 +399,14 @@
             "longitude": {
               "type": "number",
               "description": "Longitude of the anchor in decimal degrees",
+              "units": "°",
               "example": 4.98765245
             },
             
             "latitude": {
               "type": "number",
               "description": "Latitude of the anchor in decimal degrees",
+              "units": "°",
               "example": 52.0987654
             },
             

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -6,13 +6,17 @@
   "title": "navigation",
   "properties": {
     "courseOverGroundMagnetic": {
-      "description": "",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "description": "Course over ground (magnetic), measured in arc degrees.",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "°"
     },
+
     "courseOverGroundTrue": {
-      "description": "",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "description": "Course over ground (true), measured in arc degrees.",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "°"
     },
+
     "activeRoute": {
       "type": "object",
       "title": "Active Route",
@@ -22,38 +26,51 @@
           "$ref": "../definitions.json#/definitions/timestamp",
           "description": "Time of last update to active route"
         },
+
         "source": {
           "$ref": "../definitions.json#/definitions/source",
           "description": "Source of last update to active route"
         },
+
         "bearingActual": {
           "type": "number",
-          "description": "The current bearing of the next waypoint in degrees true"
+          "description": "The current bearing of the next waypoint in degrees true",
+          "units": "°"
         },
+
         "distanceActual": {
           "type": "number",
-          "description": "The current distance to the next waypoint in meters"
+          "description": "The current distance to the next waypoint in meters",
+          "units": "m"
         },
+
         "bearingDirect": {
           "type": "number",
-          "description": "The bearing in degrees true from last waypoint to the next waypoint"
+          "description": "The bearing in degrees true from last waypoint to the next waypoint",
+          "units": "°"
         },
+
         "courseRequired": {
           "type": "number",
-          "description": "The course required to make the next waypoint in degrees true"
+          "description": "The course required to make the next waypoint in degrees true",
+          "units": "°"
         },
+
         "eta": {
           "$ref": "../definitions.json#/definitions/timestamp",
           "description": "The estimated time of arrival at the end of the current route"
         },
+
         "route": {
           "type": "string",
           "description": "A pointer to the current route, found in the routes list"
         },
+
         "startTime": {
           "$ref": "../definitions.json#/definitions/timestamp",
           "description": "The time this route was activated in UTC"
         },
+
         "waypoint": {
           "type": "object",
           "title": "waypoint",
@@ -63,31 +80,39 @@
               "$ref": "../definitions.json#/definitions/timestamp",
               "description": "The time the last waypoint was reached in UTC"
             },
+
             "last": {
               "type": "string",
               "description": "The last waypoint, a pointer to the list of waypoints"
             },
+
             "nextEta": {
               "$ref": "../definitions.json#/definitions/timestamp",
               "description": "Estimated time of arrival at the next waypoint",
               "example": "2014-03-24T00:15:41Z"
             },
+
             "next": {
               "type": "string",
               "description": "A pointer to the next waypoint, found in the waypoints list"
             },
+
             "xte": {
               "type": "number",
-              "description": "Cross track error in meters"
+              "description": "Cross track error in meters",
+              "units": "m"
             }
           }
         }
       }
     },
+
     "magneticVariation": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "The magnetic variation (declination) at the current position"
+      "description": "The magnetic variation (declination) at the current position",
+      "units": "°"
     },
+
     "destination": {
       "title": "destination",
       "description": "The intended destination of this trip",
@@ -96,30 +121,37 @@
         "eta": {
           "$ref": "../definitions.json#/definitions/timestamp"
         },
+
         "source": {
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
+
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
+
         "longitude": {
           "type": "number",
           "description": "Longitude of the destination in decimal degrees",
           "example": 4.98765245
         },
+
         "latitude": {
           "type": "number",
           "description": "Latitude of the destination in decimal degrees",
           "example": 52.0987654
         },
+
         "altitude": {
           "type": "number",
-          "description": "Altitude of the destination in meters"
+          "description": "Altitude of the destination in meters",
+          "units": "m"
         }
       }
     },
+
     "gnss": {
       "type": "object",
       "title": "gnss",
@@ -129,48 +161,63 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
+
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
+
         "quality": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Quality of the satellite fix"
         },
+
         "satellites": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Number of satellites"
         },
+
         "antennaAltitude": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Altitude of antenna in meters"
+          "description": "Altitude of antenna in meters",
+          "units": "m"
         },
+
         "horizontalDilution": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Horizontal position error"
         },
+
         "geoidalSeparation": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Difference between WGS84 earth ellipsoid and mean sea level"
         },
+
         "differentialAge": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Age of DGPS data in seconds"
+          "description": "Age of DGPS data in seconds",
+          "units": "s"
         },
+
         "differentialReference": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "ID of DGPS base station"
         }
       }
     },
+
     "headingMagnetic": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Current magnetic heading of the vessels in degrees"
+      "description": "Current magnetic heading of the vessels in degrees",
+      "units": "°"
     },
+
     "headingTrue": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "The current true heading of the vessel in degrees"
+      "description": "The current true heading of the vessel in degrees",
+      "units": "°"
     },
+
     "position": {
       "type": "object",
       "title": "position",
@@ -180,26 +227,31 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
+
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
+
         "longitude": {
           "type": "number",
           "description": "Longitude of boat in decimal degrees",
           "example": 4.98765245
         },
+
         "latitude": {
           "type": "number",
           "description": "Latitude of boat in decimal degrees",
           "example": 52.0987654
         },
+
         "altitude": {
           "type": "number",
           "description": "Altitude of boat in meters"
         }
       }
     },
+
     "attitude": {
       "type": "object",
       "title": "Attitude",
@@ -207,46 +259,64 @@
       "properties": {
         "roll": {
           "type": "number",
-          "description": "Vessel roll in degrees looking to the bow, level = 0, clockwise is +ve"
+          "description": "Vessel roll in degrees looking to the bow, level = 0, clockwise is +ve",
+          "units": "°"
         },
+
         "pitch": {
           "type": "number",
-          "description": "Pitch in degrees, 0 is horizontal, +ve is bow up"
+          "description": "Pitch in degrees, 0 is horizontal, +ve is bow up",
+          "units": "°"
         },
+
         "yaw": {
           "type": "number",
-          "description": "Yaw in degrees"
+          "description": "Yaw in degrees",
+          "units": "°"
         },
+
         "source": {
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
+
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         }
       }
     },
+
     "rateOfTurn": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Rate of turn in degrees per second"
+      "description": "Rate of turn in degrees per second",
+      "units": "°/s"
     },
+
     "speedOverGround": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Vessel speed over ground, in m/s"
+      "description": "Vessel speed over ground, in m/s",
+      "units": "m/s"
     },
+
     "speedThroughWater": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Vessel speed through the water in m/s"
+      "description": "Vessel speed through the water in m/s",
+      "units": "m/s"
     },
+
     "log": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Log value in meters"
+      "description": "Log value in meters",
+      "units": "m"
     },
+
     "logTrip": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Trip log value in meters"
+      "description": "Trip log value in meters",
+      "units": "m"
     },
+
     "state": {
       "type": "object",
       "title": "state",
@@ -256,10 +326,12 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
+
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
+        
         "value": {
           "type": "string",
           "enum": [
@@ -277,6 +349,7 @@
         }
       }
     },
+
     "anchor": {
       "type": "object",
       "title": "anchor",
@@ -286,18 +359,24 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
+
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
+        
         "maxRadius": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Radius of anchor alarm boundary in meters. The distance from anchor to the center of the boat"
+          "description": "Radius of anchor alarm boundary in meters. The distance from anchor to the center of the boat",
+          "units": "m"
         },
+        
         "currentRadius": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Current distance to anchor in meters"
+          "description": "Current distance to anchor in meters",
+          "units": "m"
         },
+        
         "position": {
           "type": "object",
           "title": "position",
@@ -307,23 +386,28 @@
               "description": "Source of this data",
               "$ref": "../definitions.json#/definitions/source"
             },
+
             "timestamp": {
               "description": "timestamp of the last update to this data",
               "$ref": "../definitions.json#/definitions/timestamp"
             },
+            
             "longitude": {
               "type": "number",
               "description": "Longitude of the anchor in decimal degrees",
               "example": 4.98765245
             },
+            
             "latitude": {
               "type": "number",
               "description": "Latitude of the anchor in decimal degrees",
               "example": 52.0987654
             },
+            
             "altitude": {
               "type": "number",
-              "description": "Altitude of the anchor in meters"
+              "description": "Altitude of the anchor in meters",
+              "units": "m"
             }
           }
         }

--- a/schemas/groups/performance.json
+++ b/schemas/groups/performance.json
@@ -8,79 +8,79 @@
     "polarSpeed": {
       "description": "The current polar speed in m/s based on current polar, trueWindSpeed and truewindAngle.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "polarSpeedPercent": {
       "description": "The percentage of current speed through water to the polar speed.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Percentage (%)"
+      "units": "%"
     },
 
     "velocityMadeGood": {
       "description": "The current velocity made good in m/s derived from the speed through water and appearant wind angle. A positive value is heading to upwind, negative to downwind.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "velocityMadeGoodToWaypoint": {
       "description": "The current velocity made good in m/s to the next waypoint derived from the speedOverGround, courseOverGround.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "beatAngle": {
       "description": "The true wind beat angle for the best velocity made good based on current current polar and trueWindSpeed.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Arc degrees (°)"
+      "units": "°"
     },
 
     "beatAngleVelocityMadeGood": {
       "description": "The velocity made good in m/s for the beat angle.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "beatAngleTargetSpeed": {
       "description": "The target speed in m/s for the beat angle.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "gybeAngle": {
       "description": "The true wind gybe angle for the best velocity made good downwind based on current polar and trueWindSpeed.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Arc degrees (°)"
+      "units": "°"
     },
 
     "gybeAngleVelocityMadeGood": {
       "description": "The velocity made good in m/s for the gybe angle",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "gybeAngleTargetSpeed": {
       "description": "The target speed in m/s for the gybe angle.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Meters per second (m/s)"
+      "units": "m/s"
     },
 
     "leeway": {
       "description": "Current leeway in degrees.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Arc degrees (°)"
+      "units": "°"
     },
 
     "tackMagnetic": {
       "description": "Magnetic heading on opposite tack.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Arc degrees (°)"
+      "units": "°"
     },
 
     "tackTrue": {
       "description": "True heading on opposite tack.",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Arc degrees (°)"
+      "units": "°"
     }
   }
 }

--- a/schemas/groups/performance.json
+++ b/schemas/groups/performance.json
@@ -1,61 +1,61 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/performance.json#",
-    "description": "Schema describing the performance child-object of a Vessel.",
-    "title": "performance",
-    "properties": {
-        "polarSpeed": {
-            "description": "The current polar speed in m/s based on current polar, trueWindSpeed and truewindAngle.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "polarSpeedPercent": {
-            "description": "The percentage of current speed through water to the polar speed.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "velocityMadeGood": {
-            "description": "The current velocity made good in m/s derived from the speed through water and appearant wind angle. A positive value is heading to upwind, negative to downwind.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "velocityMadeGoodToWaypoint": {
-            "description": "The current velocity made good in m/s to the next waypoint derived from the speedOverGround, courseOverGround.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "beatAngle": {
-            "description": "The true wind beat angle for the best velocity made good based on current current polar and trueWindSpeed.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "beatAngleVelocityMadeGood": {
-            "description": "The velocity made good in m/s for the beat angle.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "beatAngleTargetSpeed": {
-            "description": "The target speed in m/s for the beat angle.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "gybeAngle": {
-            "description": "The true wind gybe angle for the best velocity made good downwind based on current polar and trueWindSpeed.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "gybeAngleVelocityMadeGood": {
-            "description": "The velocity made good in m/s for the gybe angle",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "gybeAngleTargetSpeed": {
-            "description": "The target speed in m/s for the gybe angle.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "leeway": {
-            "description": "Current leeway in degrees.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "tackMagnetic": {
-            "description": "Magnetic heading on opposite tack.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        },
-        "tackTrue": {
-            "description": "True heading on opposite tack.",
-            "$ref": "../definitions.json#/definitions/numberValue"
-        }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/performance.json#",
+  "description": "Schema describing the performance child-object of a Vessel.",
+  "title": "performance",
+  "properties": {
+    "polarSpeed": {
+      "description": "The current polar speed in m/s based on current polar, trueWindSpeed and truewindAngle.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "polarSpeedPercent": {
+      "description": "The percentage of current speed through water to the polar speed.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "velocityMadeGood": {
+      "description": "The current velocity made good in m/s derived from the speed through water and appearant wind angle. A positive value is heading to upwind, negative to downwind.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "velocityMadeGoodToWaypoint": {
+      "description": "The current velocity made good in m/s to the next waypoint derived from the speedOverGround, courseOverGround.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "beatAngle": {
+      "description": "The true wind beat angle for the best velocity made good based on current current polar and trueWindSpeed.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "beatAngleVelocityMadeGood": {
+      "description": "The velocity made good in m/s for the beat angle.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "beatAngleTargetSpeed": {
+      "description": "The target speed in m/s for the beat angle.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "gybeAngle": {
+      "description": "The true wind gybe angle for the best velocity made good downwind based on current polar and trueWindSpeed.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "gybeAngleVelocityMadeGood": {
+      "description": "The velocity made good in m/s for the gybe angle",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "gybeAngleTargetSpeed": {
+      "description": "The target speed in m/s for the gybe angle.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "leeway": {
+      "description": "Current leeway in degrees.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "tackMagnetic": {
+      "description": "Magnetic heading on opposite tack.",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "tackTrue": {
+      "description": "True heading on opposite tack.",
+      "$ref": "../definitions.json#/definitions/numberValue"
     }
+  }
 }

--- a/schemas/groups/performance.json
+++ b/schemas/groups/performance.json
@@ -7,55 +7,80 @@
   "properties": {
     "polarSpeed": {
       "description": "The current polar speed in m/s based on current polar, trueWindSpeed and truewindAngle.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "polarSpeedPercent": {
       "description": "The percentage of current speed through water to the polar speed.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Percentage (%)"
     },
+
     "velocityMadeGood": {
       "description": "The current velocity made good in m/s derived from the speed through water and appearant wind angle. A positive value is heading to upwind, negative to downwind.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "velocityMadeGoodToWaypoint": {
       "description": "The current velocity made good in m/s to the next waypoint derived from the speedOverGround, courseOverGround.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "beatAngle": {
       "description": "The true wind beat angle for the best velocity made good based on current current polar and trueWindSpeed.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Arc degrees (°)"
     },
+
     "beatAngleVelocityMadeGood": {
       "description": "The velocity made good in m/s for the beat angle.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "beatAngleTargetSpeed": {
       "description": "The target speed in m/s for the beat angle.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "gybeAngle": {
       "description": "The true wind gybe angle for the best velocity made good downwind based on current polar and trueWindSpeed.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Arc degrees (°)"
     },
+
     "gybeAngleVelocityMadeGood": {
       "description": "The velocity made good in m/s for the gybe angle",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "gybeAngleTargetSpeed": {
       "description": "The target speed in m/s for the gybe angle.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Meters per second (m/s)"
     },
+
     "leeway": {
       "description": "Current leeway in degrees.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Arc degrees (°)"
     },
+
     "tackMagnetic": {
       "description": "Magnetic heading on opposite tack.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Arc degrees (°)"
     },
+
     "tackTrue": {
       "description": "True heading on opposite tack.",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Arc degrees (°)"
     }
   }
 }

--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -6,51 +6,98 @@
   "description": "An engine, named by a unique name within this vessel",
   "properties": {
     "engineType": {
-      "type": "string",
+      "type": "object",
       "description": "The type of engine",
-      "enum": [
-        "diesel inboard",
-        "petrol inboard",
-        "petrol outboard",
-        "electric"
-      ]
+      "properties": { 
+        "value": {
+          "type": "string",
+          "enum": [
+            "diesel inboard",
+            "diesel outboard",
+            "petrol inboard",
+            "petrol outboard",
+            "electric inboard",
+            "electric outboard"
+          ]
+        },
+
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        }
+      }
     },
+
     "state": {
-      "type": "string",
+      "type": "object",
       "description": "The current state of the engine",
-      "enum": [
-        "stopped",
-        "started",
-        "unusable"
-      ]
+      "properties": {
+        "value": {
+          "type": "string",
+          "enum": [
+            "stopped",
+            "started",
+            "unusable"
+          ]
+        },
+
+        "source": {
+          "description": "Source of this data",
+          "$ref": "../definitions.json#/definitions/source"
+        },
+
+        "timestamp": {
+          "description": "timestamp of the last update to this data",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        }
+      }
     },
+
     "rpm": {
       "description": "Engine rpm",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Revolutions per minute (RPM)"
     },
+
     "engineTemperature": {
       "description": "Engine temperature in degrees C",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Degree Celcius (°C)"
     },
+
     "oilTemperature": {
       "description": "Oil temperature in degrees C",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Degree Celcius (°C)"
     },
+
     "oilPressure": {
       "description": "Oil pressure in kPa",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Kilo Pascal (kPa)"
     },
+
     "waterTemp": {
       "description": "Water temperature in degrees C",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Degree Celcius (°C)"
     },
+
     "exhaustTemp": {
       "description": "Exhaust temperature in degrees C",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Degree Celcius (°C)"
     },
+
     "fuelUsageRate": {
       "description": "Fuel usage in liters/hour",
-      "$ref": "../definitions.json#/definitions/numberValue"
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "Liters per hour (L/h)"
     }
   }
 }

--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -1,57 +1,56 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/propulsion.json#",
-    "title": "propulsion",
-    "description": "An engine, named by a unique name within this vessel",
-        "properties": {
-            "engineType": {
-                "type": "string",
-                "description": "The type of engine",
-                "enum": [
-                    "diesel inboard",
-                    "petrol inboard",
-                    "petrol outboard",
-                    "electric"
-                ]
-            },
-            "state": {
-                "type": "string",
-                "description": "The current state of the engine",
-                "enum": [
-                    "stopped",
-                    "started",
-                    "unusable"
-                ]
-            },
-            "rpm": {
-                "description": "Engine rpm",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "engineTemperature": {
-                "description": "Engine temperature in degrees C",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "oilTemperature": {
-                "description": "Oil temperature in degrees C",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "oilPressure": {
-                "description": "Oil pressure in kPa",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "waterTemp": {
-                "description": "Water temperature in degrees C",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "exhaustTemp": {
-                "description": "Exhaust temperature in degrees C",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "fuelUsageRate": {
-                "description": "Fuel usage in liters/hour",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            }
-        }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/propulsion.json#",
+  "title": "propulsion",
+  "description": "An engine, named by a unique name within this vessel",
+  "properties": {
+    "engineType": {
+      "type": "string",
+      "description": "The type of engine",
+      "enum": [
+        "diesel inboard",
+        "petrol inboard",
+        "petrol outboard",
+        "electric"
+      ]
+    },
+    "state": {
+      "type": "string",
+      "description": "The current state of the engine",
+      "enum": [
+        "stopped",
+        "started",
+        "unusable"
+      ]
+    },
+    "rpm": {
+      "description": "Engine rpm",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "engineTemperature": {
+      "description": "Engine temperature in degrees C",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "oilTemperature": {
+      "description": "Oil temperature in degrees C",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "oilPressure": {
+      "description": "Oil pressure in kPa",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "waterTemp": {
+      "description": "Water temperature in degrees C",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "exhaustTemp": {
+      "description": "Exhaust temperature in degrees C",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+    "fuelUsageRate": {
+      "description": "Fuel usage in liters/hour",
+      "$ref": "../definitions.json#/definitions/numberValue"
     }
-
+  }
+}

--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -61,43 +61,43 @@
     "rpm": {
       "description": "Engine rpm",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Revolutions per minute (RPM)"
+      "units": "RPM"
     },
 
     "engineTemperature": {
       "description": "Engine temperature in degrees C",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Degree Celcius (°C)"
+      "units": "°C"
     },
 
     "oilTemperature": {
       "description": "Oil temperature in degrees C",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Degree Celcius (°C)"
+      "units": "°C"
     },
 
     "oilPressure": {
       "description": "Oil pressure in kPa",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Kilo Pascal (kPa)"
+      "units": "kPa"
     },
 
     "waterTemp": {
       "description": "Water temperature in degrees C",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Degree Celcius (°C)"
+      "units": "°C"
     },
 
     "exhaustTemp": {
       "description": "Exhaust temperature in degrees C",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Degree Celcius (°C)"
+      "units": "°C"
     },
 
     "fuelUsageRate": {
       "description": "Fuel usage in liters/hour",
       "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "Liters per hour (L/h)"
+      "units": "l/h"
     }
   }
 }

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -92,7 +92,7 @@
             "distance": {
               "description": "Total distance from start to end, measured in meters",
               "$ref": "../definitions.json#/definitions/numberValue",
-              "units": "Meters (m)"
+              "units": "m"
             },
   
             "waypoints": {
@@ -248,7 +248,7 @@
                 "altitude": {
                   "type": "number",
                   "description": "Altitude in meters",
-                  "units": "Meters (m)"
+                  "units": "m"
                 }
               }
             },

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -237,12 +237,14 @@
 
                 "longitude": {
                   "type": "number",
-                  "description": "Longitude, in decimal notation (4.98765245)"
+                  "description": "Longitude, in decimal notation (4.98765245)",
+                  "units": "°"
                 },
 
                 "latitude": {
                   "type": "number",
-                  "description": "Latitude, in decimal notation (52.0987654)"
+                  "description": "Latitude, in decimal notation (52.0987654)",
+                  "units": "°"
                 },
 
                 "altitude": {

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -1,244 +1,275 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/resources.json#",
-    "title": "resources",
-    "description": "Resources to aid in navigation and operation of the vessel",
-    "properties": {
-        "charts": {
-            "type": "object",
-            "title": "chart",
-            "description": "A holder for charts, each named with their chart code",
-             "patternProperties": {
-		"(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-		    "type": "object",
-		    "description": "A chart",
-		    "properties": {
-			"name": {
-			    "type": "string",
-			    "description": "Chart common name"
-			},
-			"identifier": {
-			    "type": "string",
-			    "description": "Chart number"
-			},
-			"description": {
-			    "type": "string",
-			    "description": "A description of the chart"
-			},
-			"tilemapUrl": {
-			    "type": "string",
-			    "description": "A url to the tilemap of the chart for use in TMS chartplotting apps"
-			},
-			"chartUrl": {
-			    "type": "string",
-			    "description": "A url to the chart file's storage location"
-			},
-			"chartFormat": {
-			    "type": "string",
-			    "description": "The format of the chart",
-			    "enum": [
-				"gif",
-				"geotiff",
-				"kap",
-				"png",
-				"jpg",
-				"kml",
-				"wkt",
-				"topojson",
-				"geojson",
-				"gpx"
-			    ]
-			},
-			"timestamp": {
-			    "description": "timestamp of the last update to this data",
-			    "$ref": "../definitions.json#/definitions/timestamp"
-			},
-			"source": {
-			    "description": "Source of this data",
-			    "$ref": "../definitions.json#/definitions/source"
-			}
-		    }
-		}
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/resources.json#",
+  "title": "resources",
+  "description": "Resources to aid in navigation and operation of the vessel",
+  "properties": {
+    "charts": {
+      "type": "object",
+      "title": "chart",
+      "description": "A holder for charts, each named with their chart code",
+      "patternProperties": {
+        "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
+          "type": "object",
+          "description": "A chart",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Chart common name"
+            },
+          
+            "identifier": {
+              "type": "string",
+              "description": "Chart number"
+            },
+  
+            "description": {
+              "type": "string",
+              "description": "A description of the chart"
+            },
+  
+            "tilemapUrl": {
+              "type": "string",
+              "description": "A url to the tilemap of the chart for use in TMS chartplotting apps"
+            },
+  
+            "chartUrl": {
+              "type": "string",
+              "description": "A url to the chart file's storage location"
+            },
+  
+            "chartFormat": {
+              "type": "string",
+              "description": "The format of the chart",
+              "enum": [
+                "gif",
+                "geotiff",
+                "kap",
+                "png",
+                "jpg",
+                "kml",
+                "wkt",
+                "topojson",
+                "geojson",
+                "gpx"
+              ]
+            },
+  
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+  
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
             }
-        },
-        "routes": {
-            "type": "object",
-            "title": "route",
-            "description": "A holder for routes, each named with a UUID",
-            "patternProperties": {
-		"(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-		  "type": "object",
-		  "description": "A route, named with a UUID",
-		  "properties": {
-		      "name": {
-			  "type": "string",
-			  "description": "Route's common name"
-		      },
-		      "description": {
-			  "type": "string",
-			  "description": "A description of the route"
-		      },
-		      "distance": {
-			  "description": "Total distance from start to end",
-			  "$ref": "../definitions.json#/definitions/numberValue"
-		      },
-		      "waypoints": {
-			  "type": "array",
-			  "items": {
-			      "type": "string",
-			      "description": "Pointers to waypoint UUIDs"
-			  }
-		      },
-		      "timestamp": {
-			  "description": "timestamp of the last update to this data",
-			  "$ref": "../definitions.json#/definitions/timestamp"
-		      },
-		      "source": {
-			  "description": "Source of this data",
-			  "$ref": "../definitions.json#/definitions/source"
-		      }
-		  }
-		}
-            }
-        },
-        "notes": {
-            "type": "object",
-            "title": "notes",
-            "description": "A holder for notes about regions, each named with a UUID. Notes might include navigation or cruising info, images, or anything",
-
-             "patternProperties": {
-		"(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-		  "type": "object",
-		  "description": "A note about a region, named with a UUID. Notes might include navigation or cruising info, images, or anything",
-		  "properties": {
-		      "title": {
-			  "type": "string",
-			  "description": "Note's common name"
-		      },
-		      "description": {
-			  "type": "string",
-			  "description": "A textual description of the note"
-		      },
-		      "region": {
-			  "type": "string",
-			  "description": "Pointer to region UUID"
-		      },
-		      "mimeType": {
-			  "type": "string",
-			  "description": "MIME type of the note"
-		      },
-		      "url": {
-			  "type": "string",
-			  "description": "Location of the note"
-		      },
-		      "timestamp": {
-			  "description": "timestamp of the last update to this data",
-			  "$ref": "../definitions.json#/definitions/timestamp"
-		      },
-		      "source": {
-			  "description": "Source of this data",
-			  "$ref": "../definitions.json#/definitions/source"
-		      }
-		  }
-		}
-            }
-        },
-        "regions": {
-            "type": "object",
-            "title": "region",
-            "description": "A holder for regions, each named with a UUID",
-	     "patternProperties": {
-		"(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-		  "type": "object",
-		  "description": "A region of interest, named with a UUID",
-		  "properties": {
-		      "name": {
-			  "type": "string",
-			  "description": "Region's common name"
-		      },
-		      "description": {
-			  "type": "string",
-			  "description": "A description of the region"
-		      },
-		      "waypoints": {
-			  "type": "array",
-			  "description": "The set of waypoints that define the edges of the region",
-			  "items": {
-			      "type": "string",
-			      "description": "Pointer to waypoint UUID"
-			  }
-		      },
-		      "timestamp": {
-			  "description": "timestamp of the last update to this data",
-			  "$ref": "../definitions.json#/definitions/timestamp"
-		      },
-		      "source": {
-			  "description": "Source of this data",
-			  "$ref": "../definitions.json#/definitions/source"
-		      }
-		  }
-		}
-
-            }
-        },
-        "waypoints": {
-            "type": "object",
-            "title": "waypoint",
-            "description": "A holder for waypoints, each named with a UUID",
-            "patternProperties": {
-		"(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-		  "type": "object",
-		  "description": "A waypoint, named with a UUID",
-		  "properties": {
-		      "name": {
-			  "type": "string",
-			  "description": "Waypoint's common name"
-		      },
-		      "position": {
-			  "type": "object",
-			  "description": "The position of the waypoint in 3 dimensions",
-			  "properties": {
-			      "source": {
-				  "description": "Source of this data",
-				  "$ref": "../definitions.json#/definitions/source"
-			      },
-			      "timestamp": {
-				  "description": "timestamp of the last update to this data",
-				  "$ref": "../definitions.json#/definitions/timestamp"
-			      },
-			      "longitude": {
-				  "type": "number",
-				  "description": "In decimal notation (4.98765245)"
-			      },
-			      "latitude": {
-				  "type": "number",
-				  "description": "In decimal notation (52.0987654)"
-			      },
-			      "altitude": {
-				  "type": "number",
-				  "description": "In meters"
-			      }
-			  }
-		      },
-		      "description": {
-			  "type": "string",
-			  "description": "A description of the waypoint"
-		      },
-		      "type": {
-			  "type": "string",
-			  "description": "The type of waypoint",
-			  "enum": [
-			      "location",
-			      "fish",
-			      "hazard",
-			      "anchorage",
-			      "mark"
-			  ]
-		      }
-		    }
-		}
-            }
+          }
         }
+      }
+    },
+  
+    "routes": {
+      "type": "object",
+      "title": "route",
+      "description": "A holder for routes, each named with a UUID",
+      "patternProperties": {
+        "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
+          "type": "object",
+          "description": "A route, named with a UUID",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Route's common name"
+            },
+        
+            "description": {
+              "type": "string",
+              "description": "A description of the route"
+            },
+  
+            "distance": {
+              "description": "Total distance from start to end",
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+  
+            "waypoints": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Pointers to waypoint UUIDs"
+              }
+            },
+  
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+    
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            }
+          }
+        }
+      }
+    },
+  
+    "notes": {
+      "type": "object",
+      "title": "notes",
+      "description": "A holder for notes about regions, each named with a UUID. Notes might include navigation or cruising info, images, or anything",
+      "patternProperties": {
+        "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
+          "type": "object",
+          "description": "A note about a region, named with a UUID. Notes might include navigation or cruising info, images, or anything",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Note's common name"
+            },
+
+            "description": {
+              "type": "string",
+              "description": "A textual description of the note"
+            },
+
+            "region": {
+              "type": "string",
+              "description": "Pointer to region UUID"
+            },
+  
+            "mimeType": {
+              "type": "string",
+              "description": "MIME type of the note"
+            },
+  
+            "url": {
+              "type": "string",
+              "description": "Location of the note"
+            },
+ 
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+  
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            }
+          }
+        }
+      }
+    },
+    
+    "regions": {
+      "type": "object",
+      "title": "region",
+      "description": "A holder for regions, each named with a UUID",
+      "patternProperties": {
+        "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
+          "type": "object",
+          "description": "A region of interest, named with a UUID",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Region's common name"
+            },
+            
+            "description": {
+              "type": "string",
+              "description": "A description of the region"
+            },
+          
+            "waypoints": {
+              "type": "array",
+              "description": "The set of waypoints that define the edges of the region",
+              "items": {
+                "type": "string",
+                "description": "Pointer to waypoint UUID"
+              }
+            },
+    
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+    
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            }
+          }
+        }
+      }
+    },
+
+    "waypoints": {
+      "type": "object",
+      "title": "waypoint",
+      "description": "A holder for waypoints, each named with a UUID",
+      "patternProperties": {
+        "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
+          "type": "object",
+          "description": "A waypoint, named with a UUID",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Waypoint's common name"
+            },
+
+            "position": {
+              "type": "object",
+              "description": "The position of the waypoint in 3 dimensions",
+              "properties": {
+                "source": {
+                  "description": "Source of this data",
+                  "$ref": "../definitions.json#/definitions/source"
+                },
+                
+                "timestamp": {
+                  "description": "timestamp of the last update to this data",
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                },
+
+                "longitude": {
+                  "type": "number",
+                  "description": "In decimal notation (4.98765245)"
+                },
+
+                "latitude": {
+                  "type": "number",
+                  "description": "In decimal notation (52.0987654)"
+                },
+
+                "altitude": {
+                  "type": "number",
+                  "description": "In meters"
+                }
+              }
+            },
+
+            "description": {
+              "type": "string",
+              "description": "A description of the waypoint"
+            },
+    
+            "type": {
+              "type": "string",
+              "description": "The type of waypoint",
+              "enum": [
+                "location",
+                "fish",
+                "hazard",
+                "anchorage",
+                "mark"
+              ]
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -90,8 +90,9 @@
             },
   
             "distance": {
-              "description": "Total distance from start to end",
-              "$ref": "../definitions.json#/definitions/numberValue"
+              "description": "Total distance from start to end, measured in meters",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "Meters (m)"
             },
   
             "waypoints": {
@@ -236,17 +237,18 @@
 
                 "longitude": {
                   "type": "number",
-                  "description": "In decimal notation (4.98765245)"
+                  "description": "Longitude, in decimal notation (4.98765245)"
                 },
 
                 "latitude": {
                   "type": "number",
-                  "description": "In decimal notation (52.0987654)"
+                  "description": "Latitude, in decimal notation (52.0987654)"
                 },
 
                 "altitude": {
                   "type": "number",
-                  "description": "In meters"
+                  "description": "Altitude in meters",
+                  "units": "Meters (m)"
                 }
               }
             },

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -18,16 +18,18 @@
 
     "area": {
       "type": "object",
-      "description": "An object containing information about the area of the sails.",
+      "description": "An object containing information about the vessels' sails.",
       "properties": {
         "total": {
           "description": "The total area of all sails on the vessel, measured in square meters.",
-          "type": "number"
+          "type": "number",
+          "units": "Square meters (m2)"
         },
 
         "active": {
           "description": "The total area of the sails currently in use on the vessel, measured in square meters.",
-          "type": "number"
+          "type": "number",
+          "units": "Square meters (m2)"
         },
 
         "timestamp": { 

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -23,18 +23,19 @@
         "total": {
           "description": "The total area of all sails on the vessel, measured in square meters.",
           "type": "number",
-          "units": "Square meters (m2)"
+          "units": "m2"
         },
 
         "active": {
           "description": "The total area of the sails currently in use on the vessel, measured in square meters.",
           "type": "number",
-          "units": "Square meters (m2)"
+          "units": "m2"
         },
 
         "timestamp": { 
           "description":"timestamp of the last update to this data",
-          "$ref": "#/definitions/timestamp"
+          "$ref": "#/definitions/timestamp",
+          "units": "ISO-8601 (UTC)"
         },
         
         "source": { 

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -1,43 +1,45 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/sails.json#",
-    "description": "An object describing the vessels sails if the vessel is a sailboat.",
-    "title": "sails",
-    "properties": {
-        "available": {
-            "type": "object",
-            "description": "An object containing a description of each sail available to the vessel crew",
-            "patternProperties": {
-                "(^[a-zA-Z0-9]$)": {
-                    "description": "Each sail is identified by a unique name, containing only alphanumeric characters.",
-                    "$ref": "../definitions.json#/definitions/sail" 
-                }
-            }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/sails.json#",
+  "description": "An object describing the vessels sails if the vessel is a sailboat.",
+  "title": "sails",
+  "properties": {
+    "available": {
+      "type": "object",
+      "description": "An object containing a description of each sail available to the vessel crew",
+      "patternProperties": {
+        "(^[a-zA-Z0-9]$)": {
+          "description": "Each sail is identified by a unique name, containing only alphanumeric characters.",
+          "$ref": "../definitions.json#/definitions/sail" 
+        }
+      }
+    },
+
+    "area": {
+      "type": "object",
+      "description": "An object containing information about the area of the sails.",
+      "properties": {
+        "total": {
+          "description": "The total area of all sails on the vessel, measured in square meters.",
+          "type": "number"
         },
 
-        "area": {
-            "type": "object",
-            "description": "An object containing information about the area of the sails.",
-            "properties": {
-                "total": {
-                    "description": "The total area of all sails on the vessel, measured in square meters.",
-                    "type": "number"
-                },
+        "active": {
+          "description": "The total area of the sails currently in use on the vessel, measured in square meters.",
+          "type": "number"
+        },
 
-                "active": {
-                    "description": "The total area of the sails currently in use on the vessel, measured in square meters.",
-                    "type": "number"
-                },
-
-                "timestamp": { "description":"timestamp of the last update to this data",
-                    "$ref": "#/definitions/timestamp"
-                },
-                
-                "source": { "description":"Source of this data",
-                    "$ref": "#/definitions/source"
-                }
-            }
+        "timestamp": { 
+          "description":"timestamp of the last update to this data",
+          "$ref": "#/definitions/timestamp"
+        },
+        
+        "source": { 
+          "description":"Source of this data",
+          "$ref": "#/definitions/source"
         }
+      }
     }
+  }
 }

--- a/schemas/groups/sensors.json
+++ b/schemas/groups/sensors.json
@@ -1,29 +1,33 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/sensors.json#",
-    "description": "An object describing an individual sensor. It should be an object in vessel, named using a unique name or UUID",
-    "title": "sensor",
-    "properties": {
-        "name": {
-            "type": "string",
-            "description": "The common name of the sensor"
-        },
-        "sensorType": {
-            "type": "string",
-            "description": "The datamodel definition of the sensor data. FIXME - need to create a definitions lib of sensor datamodel types"
-        },
-        "sensorData": {
-            "type": "string",
-            "description": "The data of the sensor data. FIXME - need to ref the definitions of sensor types"
-        },
-        "fromBow": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "The distance in meters from the bow to the sensor location"
-        },
-        "fromCenter": {
-            "$ref": "../definitions.json#/definitions/numberValue",
-            "description": "The distance in meters from the centerline to the sensor location, -ve to starboard, +ve to port"
-        }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/sensors.json#",
+  "description": "An object describing an individual sensor. It should be an object in vessel, named using a unique name or UUID",
+  "title": "sensor",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The common name of the sensor"
+    },
+    
+    "sensorType": {
+      "type": "string",
+      "description": "The datamodel definition of the sensor data. FIXME - need to create a definitions lib of sensor datamodel types"
+    },
+
+    "sensorData": {
+      "type": "string",
+      "description": "The data of the sensor data. FIXME - need to ref the definitions of sensor types"
+    },
+
+    "fromBow": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "The distance in meters from the bow to the sensor location"
+    },
+
+    "fromCenter": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "The distance in meters from the centerline to the sensor location, -ve to starboard, +ve to port"
     }
+  }
 }

--- a/schemas/groups/steering.json
+++ b/schemas/groups/steering.json
@@ -74,13 +74,13 @@
         "targetHeadingNorth": {
           "description": "Target heading for autopilot in degrees true",
           "$ref": "../definitions.json#/definitions/numberValue", 
-          "units": "Arc degrees (°), true"
+          "units": "°"
         },
 
         "targetHeadingMagnetic": {
           "description": "Target heading for autopilot in magnetic degrees",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°), magnetic"
+          "units": "°"
         },
 
         "headingSource": {
@@ -111,13 +111,13 @@
         "deadZone": {
           "description": "Dead zone to ignore for rudder corrections (in degrees)",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
 
         "backlash": {
           "description": "Slack in the rudder drive mechanism in degrees",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees (°)"
+          "units": "°"
         },
 
         "gain": {
@@ -128,13 +128,13 @@
         "maxDriveAmps": {
           "description": "Maximum amperage to use to drive servo",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Amperage (A)"
+          "units": "A"
         },
 
         "maxDriveRate": {
           "description": "Maximum degrees/sec to turn the rudder",
           "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "Arc degrees per second (°/s)"
+          "units": "°/s"
         },
 
         "portLock": {

--- a/schemas/groups/steering.json
+++ b/schemas/groups/steering.json
@@ -1,111 +1,124 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/steering.json#",
-    "description": "Schema describing the steering child-object of a vessel.",
-    "title": "steering",
-    "properties": {
-        "rudderAngle": {
-            "description": "Current rudder angle, 0 is amidships, +ve is rudder to Starboard",
-            "$ref": "../definitions.json#/definitions/numberValue"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/steering.json#",
+  "description": "Schema describing the steering child-object of a vessel.",
+  "title": "steering",
+  "properties": {
+    "rudderAngle": {
+      "description": "Current rudder angle, 0 is amidships, +ve is rudder to Starboard",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+
+    "rudderAngleTarget": {
+      "description": "The offset the rudder should move to, in degrees, 0 is amidships, +ve is rudder to Starboard",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+
+    "autopilot": {
+      "type": "object",
+      "title": "autopilot",
+      "description": "Autopilot data",
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "Autopilot state",
+          "enum": [
+            "on",
+            "off",
+            "alarm"
+          ],
+          "source": {
+            "description": "Source of this data",
+            "$ref": "../definitions.json#/definitions/source"
+          },
+          "timestamp": {
+            "description": "timestamp of the last update to this data",
+            "$ref": "../definitions.json#/definitions/timestamp"
+          }
         },
-        "rudderAngleTarget": {
-            "description": "The offset the rudder should move to, in degrees, 0 is amidships, +ve is rudder to Starboard",
-            "$ref": "../definitions.json#/definitions/numberValue"
+
+        "mode": {
+          "type": "string",
+          "description": "Operational mode",
+          "enum": [
+            "powersave",
+            "normal",
+            "accurate"
+          ],
+          "source": {
+            "description": "Source of this data",
+            "$ref": "../definitions.json#/definitions/source"
+          },
+          "timestamp": {
+            "description": "timestamp of the last update to this data",
+            "$ref": "../definitions.json#/definitions/timestamp"
+          }
         },
-        "autopilot": {
-            "type": "object",
-            "title": "autopilot",
-            "description": "Autopilot data",
-            "properties": {
-                "state": {
-                    "type": "string",
-                    "description": "Autopilot state",
-                    "enum": [
-                        "on",
-                        "off",
-                        "alarm"
-                    ],
-                    "source": {
-                        "description": "Source of this data",
-                        "$ref": "../definitions.json#/definitions/source"
-                    },
-                    "timestamp": {
-                        "description": "timestamp of the last update to this data",
-                        "$ref": "../definitions.json#/definitions/timestamp"
-                    }
-                },
-                "mode": {
-                    "type": "string",
-                    "description": "Operational mode",
-                    "enum": [
-                        "powersave",
-                        "normal",
-                        "accurate"
-                    ],
-                    "source": {
-                        "description": "Source of this data",
-                        "$ref": "../definitions.json#/definitions/source"
-                    },
-                    "timestamp": {
-                        "description": "timestamp of the last update to this data",
-                        "$ref": "../definitions.json#/definitions/timestamp"
-                    }
-                },
-                "targetHeadingNorth": {
-                    "description": "Target heading for autopilot in degrees true",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "targetHeadingMagnetic": {
-                    "description": "Target heading for autopilot in magnetic degrees",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "headingSource": {
-                    "type": "string",
-                    "description": "Current source of heading information",
-                    "enum": [
-                        "compass",
-                        "wind",
-                        "gps"
-                    ],
-                    "source": {
-                        "description": "Source of this data",
-                        "$ref": "../definitions.json#/definitions/source"
-                    },
-                    "timestamp": {
-                        "description": "timestamp of the last update to this data",
-                        "$ref": "../definitions.json#/definitions/timestamp"
-                    }
-                },
-                "deadZone": {
-                    "description": "Dead zone to ignore for rudder corrections (in degrees)",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "backlash": {
-                    "description": "Slack in the rudder drive mechanism in degrees",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "gain": {
-                    "description": "Autohelm gain, higher number equals more rudder movement for a given turn",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "maxDriveAmps": {
-                    "description": "Maximum amperage to use to drive servo",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "maxDriveRate": {
-                    "description": "Maximum degrees/sec to turn the rudder",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "portLock": {
-                    "description": "Position of servo on port lock",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                },
-                "starboardLock": {
-                    "description": "Position of servo on starboard lock",
-                    "$ref": "../definitions.json#/definitions/numberValue"
-                }
-            }
+
+        "targetHeadingNorth": {
+          "description": "Target heading for autopilot in degrees true",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "targetHeadingMagnetic": {
+          "description": "Target heading for autopilot in magnetic degrees",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "headingSource": {
+          "type": "string",
+          "description": "Current source of heading information",
+          "enum": [
+            "compass",
+            "wind",
+            "gps"
+          ],
+          "source": {
+            "description": "Source of this data",
+            "$ref": "../definitions.json#/definitions/source"
+          },
+          "timestamp": {
+            "description": "timestamp of the last update to this data",
+            "$ref": "../definitions.json#/definitions/timestamp"
+          }
+        },
+
+        "deadZone": {
+          "description": "Dead zone to ignore for rudder corrections (in degrees)",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "backlash": {
+          "description": "Slack in the rudder drive mechanism in degrees",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "gain": {
+          "description": "Autohelm gain, higher number equals more rudder movement for a given turn",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "maxDriveAmps": {
+          "description": "Maximum amperage to use to drive servo",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "maxDriveRate": {
+          "description": "Maximum degrees/sec to turn the rudder",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "portLock": {
+          "description": "Position of servo on port lock",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "starboardLock": {
+          "description": "Position of servo on starboard lock",
+          "$ref": "../definitions.json#/definitions/numberValue"
         }
+      }
     }
+  }
 }

--- a/schemas/groups/steering.json
+++ b/schemas/groups/steering.json
@@ -21,77 +21,103 @@
       "description": "Autopilot data",
       "properties": {
         "state": {
-          "type": "string",
+          "type": "object",
           "description": "Autopilot state",
-          "enum": [
-            "on",
-            "off",
-            "alarm"
-          ],
-          "source": {
-            "description": "Source of this data",
-            "$ref": "../definitions.json#/definitions/source"
-          },
-          "timestamp": {
-            "description": "timestamp of the last update to this data",
-            "$ref": "../definitions.json#/definitions/timestamp"
+          
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": [
+                "on",
+                "off",
+                "alarm"
+              ]
+            },
+
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            },
+
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            }
           }
         },
 
         "mode": {
-          "type": "string",
+          "type": "object",
           "description": "Operational mode",
-          "enum": [
-            "powersave",
-            "normal",
-            "accurate"
-          ],
-          "source": {
-            "description": "Source of this data",
-            "$ref": "../definitions.json#/definitions/source"
-          },
-          "timestamp": {
-            "description": "timestamp of the last update to this data",
-            "$ref": "../definitions.json#/definitions/timestamp"
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": [
+                "powersave",
+                "normal",
+                "accurate"
+              ]
+            },
+
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            },
+
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            }
           }
         },
 
         "targetHeadingNorth": {
           "description": "Target heading for autopilot in degrees true",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue", 
+          "units": "Arc degrees (°), true"
         },
 
         "targetHeadingMagnetic": {
           "description": "Target heading for autopilot in magnetic degrees",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°), magnetic"
         },
 
         "headingSource": {
-          "type": "string",
+          "type": "object",
           "description": "Current source of heading information",
-          "enum": [
-            "compass",
-            "wind",
-            "gps"
-          ],
-          "source": {
-            "description": "Source of this data",
-            "$ref": "../definitions.json#/definitions/source"
-          },
-          "timestamp": {
-            "description": "timestamp of the last update to this data",
-            "$ref": "../definitions.json#/definitions/timestamp"
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": [
+                "compass",
+                "wind",
+                "gps"
+              ]
+            },
+
+            "source": {
+              "description": "Source of this data",
+              "$ref": "../definitions.json#/definitions/source"
+            },
+            
+            "timestamp": {
+              "description": "timestamp of the last update to this data",
+              "$ref": "../definitions.json#/definitions/timestamp"
+            }
           }
         },
 
         "deadZone": {
           "description": "Dead zone to ignore for rudder corrections (in degrees)",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
 
         "backlash": {
           "description": "Slack in the rudder drive mechanism in degrees",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees (°)"
         },
 
         "gain": {
@@ -101,12 +127,14 @@
 
         "maxDriveAmps": {
           "description": "Maximum amperage to use to drive servo",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Amperage (A)"
         },
 
         "maxDriveRate": {
           "description": "Maximum degrees/sec to turn the rudder",
-          "$ref": "../definitions.json#/definitions/numberValue"
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Arc degrees per second (°/s)"
         },
 
         "portLock": {

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -26,13 +26,13 @@
 
     "capacity": {
       "description": "Total tank capacity in liters",
-      "units": "Liters (l)",
+      "units": "l",
       "$ref": "../definitions.json#/definitions/numberValue"
     },
 
     "level": {
       "description": "Current tank contents in liters",
-      "units": "Liters (l)",
+      "units": "l",
       "$ref": "../definitions.json#/definitions/numberValue"
     }
   }

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -1,30 +1,37 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/groups/tanks.json#",
-    "description": "a tank, named by a unique name within this vessel",
-    "title": "tank",
-    "properties": {
-            "tankType": {
-                "type": "string",
-                "description": "The type of waypoint",
-                "enum": [
-                    "petrol",
-                    "water",
-                    "holding",
-                    "lpg",
-                    "diesil",
-                    "rum"
-                ]
-            },
-            "capacity": {
-                "description": "total tank capacity in liters",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            },
-            "level": {
-                "description": "current tank contents in liters",
-                "$ref": "../definitions.json#/definitions/numberValue"
-            }
-        }
-    }
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/groups/tanks.json#",
+  "description": "A tank, named by a unique identifier",
+  "title": "tank",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the tank. Useful if multiple tanks of a certain type are on board"
+    },
 
+    "type": {
+      "type": "string",
+      "description": "The type of tank",
+      "enum": [
+        "petrol",
+        "fresh water",
+        "greywater",
+        "holding",
+        "lpg",
+        "diesel",
+        "rum"
+      ]
+    },
+
+    "capacity": {
+      "description": "Total tank capacity in liters",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    },
+
+    "level": {
+      "description": "Current tank contents in liters",
+      "$ref": "../definitions.json#/definitions/numberValue"
+    }
+  }
+}

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -26,11 +26,13 @@
 
     "capacity": {
       "description": "Total tank capacity in liters",
+      "units": "Liters (l)",
       "$ref": "../definitions.json#/definitions/numberValue"
     },
 
     "level": {
       "description": "Current tank contents in liters",
+      "units": "Liters (l)",
       "$ref": "../definitions.json#/definitions/numberValue"
     }
   }

--- a/schemas/messages/subscribe.json
+++ b/schemas/messages/subscribe.json
@@ -1,94 +1,102 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "/",
-    "type": "object",
-    "title": "Subscribe schema.",
-    "description": "A message to allow a client to subscribe for data updates from a signalk server",
-    "name": "/",
-    "properties": {
-        "context": {
-            "id": "context",
-            "type": "string",
-            "title": "Context Path.",
-            "description": "The root path for all subsequent paths, usually a vessel's path.",
-            "name": "context",
-            "example": "vessels.230099999"
-        },
-        "websocket.connectionkey": {
-            "id": "websocket.connectionkey",
-            "type": "string",
-            "title": "Websocket.connectionkey.",
-            "description": "An optional session key that is used in STOMP and MQTT messages where there are no session facilities",
-            "name": "websocket.connectionkey",
-            "example": "d2f691ac-a5ed-4cb7-b361-9072a24ce6bc"
-        },
-        "reply-to": {
-            "id": "reply-to",
-            "type": "string",
-            "title": "Reply-to.",
-            "description": "A reply queue that is used in STOMP and MQTT messages where there are no session facilities.",
-            "name": "reply-to",
-            "example": "signalk.3202a939-1681-4a74-ad4b-3a90212e4f33.vessels.motu.navigation"
-        },
-        "subscribe": {
-            "id": "subscribe",
-            "type": "array",
-            "title": "Subscribe.",
-            "description": "An array of paths to subscribe to, with optional criteria",
-            "name": "subscribe",
-            "items": [
-                {
-                    "type": "object",
-                    "title": "Path object.",
-                    "description": "A path object with optional criteria to control output",
-                    "properties": {
-                        "path": {
-                            "id": "path",
-                            "type": "string",
-                            "title": "Path.",
-                            "description": "The path to subscribe to.",
-                            "name": "path",
-                            "example": "navigation.speedThroughWater"
-                        },
-                        "period": {
-                            "id": "period",
-                            "type": "integer",
-                            "title": "Period.",
-                            "description": "The subscription will be sent every period millisecs.",
-                            "name": "period",
-                            "default": 1000
-                        },
-                        "format": {
-                            "id": "format",
-                            "type": "string",
-                            "title": "Format.",
-                            "description": "The signal K format to use (full/delta) for the message.",
-                            "name": "format",
-                            "default": "delta"
-                        },
-                        "policy": {
-                            "id": "policy",
-                            "type": "string",
-                            "title": "Policy schema.",
-                            "description": "The policy for sending messages (instant/ideal/fixed).",
-                            "name": "policy",
-                            "default": "ideal"
-                        },
-                        "minPeriod": {
-                            "id": "minPeriod",
-                            "type": "integer",
-                            "title": "MinPeriod.",
-                            "description": "If policy=immediate or ideal, consequetive messages will be buffered until minPeriod has expired so the reciever is not swamped.",
-                            "name": "minPeriod",
-                            "default": 200
-                        }
-                    }
-                }
-            ]
-        }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "/",
+  "type": "object",
+  "title": "Subscribe schema.",
+  "description": "A message to allow a client to subscribe for data updates from a signalk server",
+  "name": "/",
+  "properties": {
+    "context": {
+      "id": "context",
+      "type": "string",
+      "title": "Context Path.",
+      "description": "The root path for all subsequent paths, usually a vessel's path.",
+      "name": "context",
+      "example": "vessels.230099999"
     },
-    "required": [
-        "context",
-        "subscribe"
-    ]
+
+    "websocket.connectionkey": {
+      "id": "websocket.connectionkey",
+      "type": "string",
+      "title": "Websocket.connectionkey.",
+      "description": "An optional session key that is used in STOMP and MQTT messages where there are no session facilities",
+      "name": "websocket.connectionkey",
+      "example": "d2f691ac-a5ed-4cb7-b361-9072a24ce6bc"
+    },
+
+    "reply-to": {
+      "id": "reply-to",
+      "type": "string",
+      "title": "Reply-to.",
+      "description": "A reply queue that is used in STOMP and MQTT messages where there are no session facilities.",
+      "name": "reply-to",
+      "example": "signalk.3202a939-1681-4a74-ad4b-3a90212e4f33.vessels.motu.navigation"
+    },
+
+    "subscribe": {
+      "id": "subscribe",
+      "type": "array",
+      "title": "Subscribe.",
+      "description": "An array of paths to subscribe to, with optional criteria",
+      "name": "subscribe",
+      "items": [
+        {
+          "type": "object",
+          "title": "Path object.",
+          "description": "A path object with optional criteria to control output",
+          "properties": {
+            "path": {
+              "id": "path",
+              "type": "string",
+              "title": "Path.",
+              "description": "The path to subscribe to.",
+              "name": "path",
+              "example": "navigation.speedThroughWater"
+            },
+
+            "period": {
+              "id": "period",
+              "type": "integer",
+              "title": "Period.",
+              "description": "The subscription will be sent every period millisecs.",
+              "name": "period",
+              "default": 1000
+            },
+
+            "format": {
+              "id": "format",
+              "type": "string",
+              "title": "Format.",
+              "description": "The signal K format to use (full/delta) for the message.",
+              "name": "format",
+              "default": "delta"
+            },
+
+            "policy": {
+              "id": "policy",
+              "type": "string",
+              "title": "Policy schema.",
+              "description": "The policy for sending messages (instant/ideal/fixed).",
+              "name": "policy",
+              "default": "ideal"
+            },
+            
+            "minPeriod": {
+              "id": "minPeriod",
+              "type": "integer",
+              "title": "MinPeriod.",
+              "description": "If policy=immediate or ideal, consequetive messages will be buffered until minPeriod has expired so the reciever is not swamped.",
+              "name": "minPeriod",
+              "default": 200
+            }
+          }
+        }
+      ]
+    }
+  },
+
+  "required": [
+    "context",
+    "subscribe"
+  ]
 }

--- a/schemas/messages/unsubscribe.json
+++ b/schemas/messages/unsubscribe.json
@@ -1,94 +1,102 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "/",
-    "type": "object",
-    "title": "Unsubscribe schema.",
-    "description": "A message to allow a client to unsubscribe from data updates from a signalk server",
-    "name": "/",
-    "properties": {
-        "context": {
-            "id": "context",
-            "type": "string",
-            "title": "Context Path.",
-            "description": "The root path for all subsequent paths, usually a vessel's path.",
-            "name": "context",
-            "example": "vessels.230099999"
-        },
-        "websocket.connectionkey": {
-            "id": "websocket.connectionkey",
-            "type": "string",
-            "title": "Websocket.connectionkey.",
-            "description": "An optional session key that is used in STOMP and MQTT messages where there are no session facilities",
-            "name": "websocket.connectionkey",
-            "example": "d2f691ac-a5ed-4cb7-b361-9072a24ce6bc"
-        },
-        "reply-to": {
-            "id": "reply-to",
-            "type": "string",
-            "title": "Reply-to.",
-            "description": "A reply queue that is used in STOMP and MQTT messages where there are no session facilities.",
-            "name": "reply-to",
-            "example": "signalk.3202a939-1681-4a74-ad4b-3a90212e4f33.vessels.motu.navigation"
-        },
-        "unsubscribe": {
-            "id": "unsubscribe",
-            "type": "array",
-            "title": "Unsubscribe.",
-            "description": "An array of paths to unsubscribe from.",
-            "name": "unsubscribe",
-            "items": [
-                {
-                    "type": "object",
-                    "title": "Path object.",
-                    "description": "A path object with optional criteria to control output",
-                    "properties": {
-                        "path": {
-                            "id": "path",
-                            "type": "string",
-                            "title": "Path.",
-                            "description": "The path to subscribe to.",
-                            "name": "path",
-                            "example": "navigation.speedThroughWater"
-                        },
-                        "period": {
-                            "id": "period",
-                            "type": "integer",
-                            "title": "Period.",
-                            "description": "The subscription will be sent every period millisecs.",
-                            "name": "period",
-                            "default": 1000
-                        },
-                        "format": {
-                            "id": "format",
-                            "type": "string",
-                            "title": "Format.",
-                            "description": "The signal K format to use (full/delta) for the message.",
-                            "name": "format",
-                            "default": "delta"
-                        },
-                        "policy": {
-                            "id": "policy",
-                            "type": "string",
-                            "title": "Policy schema.",
-                            "description": "The policy for sending messages (instant/ideal/fixed).",
-                            "name": "policy",
-                            "default": "ideal"
-                        },
-                        "minPeriod": {
-                            "id": "minPeriod",
-                            "type": "integer",
-                            "title": "MinPeriod.",
-                            "description": "If policy=immediate or ideal, consequetive messages will be buffered until minPeriod has expired so the reciever is not swamped.",
-                            "name": "minPeriod",
-                            "default": 200
-                        }
-                    }
-                }
-            ]
-        }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "/",
+  "type": "object",
+  "title": "Unsubscribe schema.",
+  "description": "A message to allow a client to unsubscribe from data updates from a signalk server",
+  "name": "/",
+  "properties": {
+    "context": {
+      "id": "context",
+      "type": "string",
+      "title": "Context Path.",
+      "description": "The root path for all subsequent paths, usually a vessel's path.",
+      "name": "context",
+      "example": "vessels.230099999"
     },
-    "required": [
-        "context",
-        "unsubscribe"
-    ]
+
+    "websocket.connectionkey": {
+      "id": "websocket.connectionkey",
+      "type": "string",
+      "title": "Websocket.connectionkey.",
+      "description": "An optional session key that is used in STOMP and MQTT messages where there are no session facilities",
+      "name": "websocket.connectionkey",
+      "example": "d2f691ac-a5ed-4cb7-b361-9072a24ce6bc"
+    },
+
+    "reply-to": {
+      "id": "reply-to",
+      "type": "string",
+      "title": "Reply-to.",
+      "description": "A reply queue that is used in STOMP and MQTT messages where there are no session facilities.",
+      "name": "reply-to",
+      "example": "signalk.3202a939-1681-4a74-ad4b-3a90212e4f33.vessels.motu.navigation"
+    },
+
+    "unsubscribe": {
+      "id": "unsubscribe",
+      "type": "array",
+      "title": "Unsubscribe.",
+      "description": "An array of paths to unsubscribe from.",
+      "name": "unsubscribe",
+      "items": [
+        {
+          "type": "object",
+          "title": "Path object.",
+          "description": "A path object with optional criteria to control output",
+          "properties": {
+            "path": {
+              "id": "path",
+              "type": "string",
+              "title": "Path.",
+              "description": "The path to subscribe to.",
+              "name": "path",
+              "example": "navigation.speedThroughWater"
+            },
+            
+            "period": {
+              "id": "period",
+              "type": "integer",
+              "title": "Period.",
+              "description": "The subscription will be sent every period millisecs.",
+              "name": "period",
+              "default": 1000
+            },
+            
+            "format": {
+              "id": "format",
+              "type": "string",
+              "title": "Format.",
+              "description": "The signal K format to use (full/delta) for the message.",
+              "name": "format",
+              "default": "delta"
+            },
+            
+            "policy": {
+              "id": "policy",
+              "type": "string",
+              "title": "Policy schema.",
+              "description": "The policy for sending messages (instant/ideal/fixed).",
+              "name": "policy",
+              "default": "ideal"
+            },
+            
+            "minPeriod": {
+              "id": "minPeriod",
+              "type": "integer",
+              "title": "MinPeriod.",
+              "description": "If policy=immediate or ideal, consequetive messages will be buffered until minPeriod has expired so the reciever is not swamped.",
+              "name": "minPeriod",
+              "default": 200
+            }
+          }
+        }
+      ]
+    }
+  },
+
+  "required": [
+    "context",
+    "unsubscribe"
+  ]
 }

--- a/schemas/signalk.json
+++ b/schemas/signalk.json
@@ -1,31 +1,35 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/signalk.json#",
-    "title": "SignalK",
-    "description": "Root schema of Signal K. Contains the list of vessels plus a reference to the local boat (also contained in the vessels list).",
-    "properties": {
-        "self": {
-            "type": "string",
-            "description": "This holds the key (MMSI or other unique ID) of this vessel, the actual data is in the vessels array.",
-            "required": true
-        },
-        "vessels": {
-            "type": "object",
-            "required": true,
-            "description": "A wrapper object for vessel objects, each describing vessels in range, including this vessel.",
-            "patternProperties": {
-                "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
-                    "description": "This regex pattern is used for validation of an MMSI or UUID identifier for the vessel",
-                    "$ref": "vessel.json#" }
-            }
-        },
-        "resources": {
-            "description": "resources to aid in navigation and operation of the vessel",
-            "$ref": "groups/resources.json#"
-        },
-        "version": {
-            "$ref": "definitions.json#/definitions/version"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/signalk.json#",
+  "title": "SignalK",
+  "description": "Root schema of Signal K. Contains the list of vessels plus a reference to the local boat (also contained in the vessels list).",
+  "properties": {
+    "self": {
+      "type": "string",
+      "description": "This holds the key (MMSI or other unique ID) of this vessel, the actual data is in the vessels array.",
+      "required": true
+    },
+  
+    "vessels": {
+      "type": "object",
+      "required": true,
+      "description": "A wrapper object for vessel objects, each describing vessels in range, including this vessel.",
+      "patternProperties": {
+        "(^[2-7][0-9]{8,8}$|^[A-F0-9]{8,8}$)": {
+          "description": "This regex pattern is used for validation of an MMSI or UUID identifier for the vessel",
+          "$ref": "vessel.json#" 
         }
+      }
+    },
+  
+    "resources": {
+      "description": "resources to aid in navigation and operation of the vessel",
+      "$ref": "groups/resources.json#"
+    },
+      
+    "version": {
+      "$ref": "definitions.json#/definitions/version"
     }
+  }
 }

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -7,12 +7,14 @@
   "properties": {
     "mmsi": {
       "description": "MMSI number of the vessel, if available.",
-      "$ref": "definitions.json#/definitions/mmsi"
+      "$ref": "definitions.json#/definitions/mmsi",
+      "units": "MMSI"
     },
 
     "uuid": {
       "description": "A unique ID in UUID v4 format if a MMSI isn't available.",
-      "$ref": "definitions.json#/definitions/uuid"
+      "$ref": "definitions.json#/definitions/uuid",
+      "units": "UUIDv4"
     },
 
     "name": {

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -1,107 +1,120 @@
 {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "https://signalk.github.io/specification/schemas/vessel.json#",
-    "description": "An object describing an individual vessel. It should be an object in vessels, named using MMSI or a UUID",
-    "title": "vessel",
-    "properties": {
-        "mmsi": {
-            "description": "MMSI number of the vessel, if available.",
-            "$ref": "definitions.json#/definitions/mmsi"
-        },
-        "uuid": {
-            "description": "A unique ID in UUID v4 format if a MMSI isn't available.",
-            "$ref": "definitions.json#/definitions/uuid"
-        },
-        "name": {
-            "type": "string",
-            "description": "The common name of the vessel"
-        },
-        "communication": {
-            "description": "Communication data",
-            "$ref": "groups/communication.json#"
-        },
-        "environment": {
-            "description": "Environmental data",
-            "$ref": "groups/environment.json#"
-        },
-        "navigation": {
-            "description": "Navigation data",
-            "$ref": "groups/navigation.json#"
-        },
-        "propulsion": {
-            "type": "object",
-            "id": "https://signalk.github.io/specification/schemas/groups/propulsion.json#",
-            "title": "propulsion",
-            "description": "Engine data",
-            "required": false,
-            "patternProperties": {
-                "(^[A-Za-z0-9]+$)": {
-                    "description": "This regex pattern is used for validation UUID identifier for the tank",
-                    "$ref": "groups/propulsion.json#"
-                }
-            }
-        },
-        "electrical": {
-            "type": "object",
-            "description": "Electrical data",
-            "properties": {
-                "ac": {
-                    "description": "AC electrical data",
-                    "$ref": "groups/electrical_ac.json#"
-                }
-            }
-        },
-        "alarms": {
-            "type": "object",
-            "id": "https://signalk.github.io/specification/schemas/groups/alarms.json#",
-            "title": "alarms",
-            "description": "Alarms currently raised",
-            "required": false,
-            "patternProperties": {
-                "(^[A-Za-z0-9]+$)": {
-                    "description": "This regex pattern is used for validation of the path of the alarm",
-                    "$ref": "groups/alarms.json#"
-                }
-            }
-        },
-        "steering": {
-            "description": "Vessel steering data",
-            "$ref": "groups/steering.json#"
-        },
-        "tanks": {
-            "type": "object",
-            "id": "https://signalk.github.io/specification/schemas/groups/tanks.json#",
-            "title": "tanks",
-            "description": "Tanks on this vessel",
-            "required": false,
-            "patternProperties": {
-                "(^[A-Za-z0-9]+$)": {
-                    "description": "This regex pattern is used for validation UUID identifier for the tank",
-                    "$ref": "groups/tanks.json#"
-                }
-            }
-        },
-        "design": {
-            "description": "Design data of this vessel",
-            "$ref": "groups/design.json#"
-        },
-        "sensors": {
-            "type": "object",
-            "id": "https://signalk.github.io/specification/schemas/groups/sensors.json#",
-            "title": "sensors",
-            "description": "Sensors, their state, and data.",
-            "required": false,
-            "patternProperties": {
-                "(^[A-Za-z0-9]+$)": {
-                    "description": "This regex pattern is used for validation UUID identifier for the sensor",
-                    "$ref": "groups/sensors.json#"
-                }
-            }
-        },
-        "performance": {
-            "description": "Performance data",
-            "$ref": "groups/performance.json#"
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/vessel.json#",
+  "description": "An object describing an individual vessel. It should be an object in vessels, named using MMSI or a UUID",
+  "title": "vessel",
+  "properties": {
+    "mmsi": {
+      "description": "MMSI number of the vessel, if available.",
+      "$ref": "definitions.json#/definitions/mmsi"
+    },
+
+    "uuid": {
+      "description": "A unique ID in UUID v4 format if a MMSI isn't available.",
+      "$ref": "definitions.json#/definitions/uuid"
+    },
+
+    "name": {
+      "type": "string",
+      "description": "The common name of the vessel"
+    },
+
+    "communication": {
+      "description": "Communication data",
+      "$ref": "groups/communication.json#"
+    },
+
+    "environment": {
+        "description": "Environmental data",
+        "$ref": "groups/environment.json#"
+    },
+    
+    "navigation": {
+      "description": "Navigation data",
+      "$ref": "groups/navigation.json#"
+    },
+
+    "propulsion": {
+      "type": "object",
+      "id": "https://signalk.github.io/specification/schemas/groups/propulsion.json#",
+      "title": "propulsion",
+      "description": "Engine data",
+      "required": false,
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "description": "This regex pattern is used for validation UUID identifier for the tank",
+          "$ref": "groups/propulsion.json#"
         }
+      }
+    },
+
+    "electrical": {
+      "type": "object",
+      "description": "Electrical data",
+      "properties": {
+        "ac": {
+          "description": "AC electrical data",
+          "$ref": "groups/electrical_ac.json#"
+        }
+      }
+    },
+
+    "alarms": {
+      "type": "object",
+      "id": "https://signalk.github.io/specification/schemas/groups/alarms.json#",
+      "title": "alarms",
+      "description": "Alarms currently raised",
+      "required": false,
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "description": "This regex pattern is used for validation of the path of the alarm",
+          "$ref": "groups/alarms.json#"
+        }
+      }
+    },
+
+    "steering": {
+      "description": "Vessel steering data",
+      "$ref": "groups/steering.json#"
+    },
+
+    "tanks": {
+      "type": "object",
+      "id": "https://signalk.github.io/specification/schemas/groups/tanks.json#",
+      "title": "tanks",
+      "description": "Tanks on this vessel",
+      "required": false,
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "description": "This regex pattern is used for validation UUID identifier for the tank",
+          "$ref": "groups/tanks.json#"
+        }
+      }
+    },
+
+    "design": {
+      "description": "Design data of this vessel",
+      "$ref": "groups/design.json#"
+    },
+
+    "sensors": {
+      "type": "object",
+      "id": "https://signalk.github.io/specification/schemas/groups/sensors.json#",
+      "title": "sensors",
+      "description": "Sensors, their state, and data.",
+      "required": false,
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "description": "This regex pattern is used for validation UUID identifier for the sensor",
+          "$ref": "groups/sensors.json#"
+        }
+      }
+    },
+
+    "performance": {
+      "description": "Performance data",
+      "$ref": "groups/performance.json#"
     }
+  }
 }


### PR DESCRIPTION
Major cleanup of all existing schemas:
- Moved "units" from descriptions to a separate key (to improve documentation)
- Cleaned up indentation differences
- Small changes to various descriptions (mostly related to consistency)
- Fixes in various schemas where they didn't comply with JSONSchema standard or contained JSON parsing errors. 
- Includes changes to "tanks" suggested by @MariusVolkhart 
