### PR TITLE
Replace last use of floatValue with numberValue

### DIFF
--- a/schemas/def_loader.json
+++ b/schemas/def_loader.json
@@ -10,8 +10,8 @@
       "$ref": "definitions.json#/definitions/stringValue" 
     },
     
-    "floatValue": { 
-      "$ref": "definitions.json#/definitions/floatValue" 
+    "numberValue": {
+      "$ref": "definitions.json#/definitions/numberValue"
     },
     
     "nullValue": { 

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -362,32 +362,6 @@
       }
     },
 
-    "floatValue": {
-      "type": "object",
-      "description": "Data should be of type float/double.",
-      "properties": {
-        "value": {
-          "type": "number"
-        },
-  
-        "timestamp": {
-          "$ref": "#/definitions/timestamp"
-        },
-  
-        "source": {
-          "$ref": "#/definitions/source"
-        },
-
-        "_attr": {
-          "$ref": "#/definitions/_attr"
-        },
-    
-        "meta": {
-          "$ref": "#/definitions/meta"
-        }
-      }
-    },
-
     "nullValue": {
       "type": "object",
       "description": "Data should be of type NULL.",


### PR DESCRIPTION
`floatValue` appears to be equivalent to `numberValue` and I only found one reference to it in the schemas. This changes `def_loader.json` to use `numberValue` and removes the declaration.