### PR TITLE
Add datetime with source information to the Signal K model

### DIFF
--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -190,20 +190,20 @@
             }
           }
         },
-        
+
         "integrity": {
           "type": "object",
           "description": "Integrity of the satellite fix",
           "properties": {
             "value": {
-            "type": "string",
-            "enum": [
-              "no Integrity checking",
-              "Safe",
-              "Caution",
-              "Unsafe"
+              "type": "string",
+              "enum": [
+                "no Integrity checking",
+                "Safe",
+                "Caution",
+                "Unsafe"
               ]
-            }  
+            }
           }
         },
 
@@ -376,7 +376,7 @@
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-        
+
         "value": {
           "type": "string",
           "enum": [
@@ -409,19 +409,19 @@
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-        
+
         "maxRadius": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Radius of anchor alarm boundary. The distance from anchor to the center of the boat",
           "units": "m"
         },
-        
+
         "currentRadius": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Current distance to anchor",
           "units": "m"
         },
-        
+
         "position": {
           "type": "object",
           "title": "position",
@@ -436,27 +436,64 @@
               "description": "timestamp of the last update to this data",
               "$ref": "../definitions.json#/definitions/timestamp"
             },
-            
+
             "longitude": {
               "type": "number",
               "description": "Longitude of the anchor",
               "units": "deg",
               "example": 4.98765245
             },
-            
+
             "latitude": {
               "type": "number",
               "description": "Latitude of the anchor",
               "units": "deg",
               "example": 52.0987654
             },
-            
+
             "altitude": {
               "type": "number",
               "description": "Altitude of the anchor",
               "units": "m"
             }
           }
+        }
+      }
+    },
+
+    "datetime": {
+      "type": "object",
+      "pproperties": {
+        "value": {
+          "type": "string",
+          "description": "GNSS Time and Date in ISO8601 format",
+          "exmple": "2015-12-05T13:11:59Z"
+        },
+        "gnssTimeSource": {
+          "type": "object",
+          "description": "Source of GNSS Date and Time",
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": [
+                "GPS",
+                "GLONASS",
+                "Galileo",
+                "Beidou",
+                "IRNSS",
+                "Radio Signal",
+                "Internet",
+                "Local clock"
+              ]
+            }
+          }
+        },
+        "timestamp": {
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+
+        "source": {
+          "$ref": "../definitions.json#/definitions/source"
         }
       }
     }

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -463,30 +463,24 @@
 
     "datetime": {
       "type": "object",
-      "pproperties": {
+      "properties": {
         "value": {
           "type": "string",
           "description": "GNSS Time and Date in ISO8601 format",
           "exmple": "2015-12-05T13:11:59Z"
         },
         "gnssTimeSource": {
-          "type": "object",
           "description": "Source of GNSS Date and Time",
-          "properties": {
-            "value": {
-              "type": "string",
-              "enum": [
-                "GPS",
-                "GLONASS",
-                "Galileo",
-                "Beidou",
-                "IRNSS",
-                "Radio Signal",
-                "Internet",
-                "Local clock"
-              ]
-            }
-          }
+          "enum": [
+            "GPS",
+            "GLONASS",
+            "Galileo",
+            "Beidou",
+            "IRNSS",
+            "Radio Signal",
+            "Internet",
+            "Local clock"
+          ]
         },
         "timestamp": {
           "$ref": "../definitions.json#/definitions/timestamp"

--- a/test/data/datetime.json
+++ b/test/data/datetime.json
@@ -1,0 +1,13 @@
+{
+  "vessels": {
+    "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
+      "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+      "navigation": {
+        "datetime": {
+          "value": "2015-12-05T13:11:59Z",
+          "gnssTimeSource": "GPS"
+        }
+      }
+    }
+  }
+}

--- a/test/datetime.js
+++ b/test/datetime.js
@@ -1,0 +1,10 @@
+var chai = require('chai');
+chai.Should();
+chai.use(require('../index.js').chaiModule);
+var _ = require('lodash')
+
+describe('Datetime in the full tree', function() {
+  it("should be valid", function() {
+    require('./data/datetime.json').should.be.validSignalK;
+  });
+});


### PR DESCRIPTION
This adds a place in the Signal K data model for datetime information from GNSS, usually GPS.

This is essentially the same as #122 with the value & source grouped in one object and added timestamp & source to be in line with all other values.