### PR TITLE
Add schema and tests for endpoint discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 # FS stuff
 .DS_Store
 thumbs.db
+
+# IDE Stuff
+*.iml

--- a/index.js
+++ b/index.js
@@ -122,6 +122,15 @@ function chaiAsPromised(chai, utils) {
       , 'expected #{this} to not be valid SignalK unsubscribe message'
       );
   });
+  Assertion.addProperty('validDiscovery', function () {
+    var result = validateWithSchema(this._obj, 'discovery');
+    var message = result.error ? result.error.message + ':' + result.error.dataPath : '';
+    this.assert(
+      result.valid
+      , message
+      , 'expected #{this} to not be valid SignalK discovery document'
+      );
+  });
 }
 
 

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -229,8 +229,7 @@
 
     "url": {
       "type": "string",
-      "description": "A valid URL.",
-      "pattern": "^(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
+      "description": "A location of a resource, potentially relative. For hierarchical schemes (like http), applications must resolve relative URIs (e.g. './v1/api/'). Implementations should support the following schemes: http:, https:, mailto:, tel:, and ws:."
     },
 
     "sail": {

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -25,8 +25,22 @@
             "signalk-ws": {
               "description": "The URL of a WebSocket streaming endpoint e.g. http://localhost/signalk/v1/stream",
               "$ref": "definitions.json#/definitions/url"
-            }
-          }
+            },
+            "signalk-tcp": {
+              "description": "The host and port of a tcp socket streaming endpoint e.g. localhost:55555",
+              "type": "object",
+              "required": ["host","port"],
+              "properties": {
+                "host": {
+                  "description": "The host, fqdns or IP address.",
+                  "type": "string"
+                },
+                "port": {
+                  "description": "The tcp port",
+                  "type": "integer"
+                }
+              }
+            }          }
         }
       }
     }

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -27,20 +27,10 @@
               "$ref": "definitions.json#/definitions/url"
             },
             "signalk-tcp": {
-              "description": "The host and port of a tcp socket streaming endpoint e.g. localhost:55555",
-              "type": "object",
-              "required": ["host","port"],
-              "properties": {
-                "host": {
-                  "description": "The host, fqdns or IP address.",
-                  "type": "string"
-                },
-                "port": {
-                  "description": "The tcp port",
-                  "type": "integer"
-                }
-              }
-            }          }
+              "description": "The URL of a tcp socket streaming endpoint e.g. tcp://localhost:55555",
+              "$ref": "definitions.json#/definitions/url"
+            }
+          }
         }
       }
     }

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -1,0 +1,34 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-03/schema",
+  "id": "https://signalk.github.io/specification/schemas/discovery.json#",
+  "title": "SignalK Discovery",
+  "description": "Schema for SignalK discovery resources used to locate server endpoints.",
+  "properties": {
+    "endpoints": {
+      "type": "object",
+      "description": "The set of endpoints known to this server",
+      "patternProperties": {
+        ".*": {
+          "description": "The name of a group of endpoints at the same version level",
+          "type": "object",
+          "required": ["version"],
+          "properties": {
+            "version": {
+              "description": "The version this group supports",
+              "$ref": "definitions.json#/definitions/version"
+            },
+            "signalk-http": {
+              "description": "The URL of a HTTP(s) REST API endpoint e.g. http://localhost/signalk/v1/api/",
+              "$ref": "definitions.json#/definitions/url"
+            },
+            "signalk-ws": {
+              "description": "The URL of a WebSocket streaming endpoint e.g. http://localhost/signalk/v1/stream",
+              "$ref": "definitions.json#/definitions/url"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/endpoints.json
+++ b/test/data/endpoints.json
@@ -4,10 +4,7 @@
       "version": "1.1.2",
       "signalk-http": "http://192.168.1.2/signalk/v1/api/",
       "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream",
-      "signalk-tcp": {
-        "host": "localhost",
-        "port": 55555
-      }
+      "signalk-tcp": "tcp://localhost:55555"
     },
     "v3": {
       "version": "3.0",

--- a/test/data/endpoints.json
+++ b/test/data/endpoints.json
@@ -1,0 +1,14 @@
+{
+  "endpoints": {
+    "v1": {
+      "version": "1.1.2",
+      "signalk-http": "http://192.168.1.2/signalk/v1/api/",
+      "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
+    },
+    "v3": {
+      "version": "3.0",
+      "signalk-http": "http://192.168.1.2/signalk/v3/api/",
+      "signalk-ws": "ws://192.168.1.2/signalk/v3/stream"
+    }
+  }
+}

--- a/test/data/endpoints.json
+++ b/test/data/endpoints.json
@@ -3,7 +3,11 @@
     "v1": {
       "version": "1.1.2",
       "signalk-http": "http://192.168.1.2/signalk/v1/api/",
-      "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
+      "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream",
+      "signalk-tcp": {
+        "host": "localhost",
+        "port": 55555
+      }
     },
     "v3": {
       "version": "3.0",

--- a/test/endpoints.js
+++ b/test/endpoints.js
@@ -1,7 +1,6 @@
 var chai = require('chai');
 chai.Should();
 chai.use(require('../index.js').chaiModule);
-var _ = require('lodash')
 
 describe('Endpoint Discovery', function() {
   it("should be valid", function() {

--- a/test/endpoints.js
+++ b/test/endpoints.js
@@ -1,0 +1,10 @@
+var chai = require('chai');
+chai.Should();
+chai.use(require('../index.js').chaiModule);
+var _ = require('lodash')
+
+describe('Endpoint Discovery', function() {
+  it("should be valid", function() {
+    require('./data/endpoints.json').should.be.validDiscovery;
+  });
+});


### PR DESCRIPTION
Added a schema for the endpoint discovery document.
Added simple validation test.
Relaxed definition of what will be accepted for a URL to allow for relative locations and arbitrary protocols.