### PR TITLE
Changed plain "string" type properties to reference stringType

### DIFF
--- a/schemas/groups/communication.json
+++ b/schemas/groups/communication.json
@@ -6,53 +6,53 @@
   "title": "communication",
   "properties": {
     "callsignVhf": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Callsign for VHF communication",
       "example": "ZL1234"
     },
 
     "callsignHf": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Callsign for HF communication",
       "example": "ZL3RTH"
     },
 
     "phoneNumber": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Phone number of skipper",
       "example": "+64xxxxxx"
     },
 
     "emailHf": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Email address to be used for HF email (Winmail, Airmail, Sailmail)",
       "example": "motu@xxx.co.nz"
     },
 
     "email": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Regular email for the skipper",
       "example": "robert@xxx.co.nz"
     },
 
     "satPhoneNumber": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Satellite phone number for vessel.",
       "example": "+64xxxxxx"
     },
 
     "skipperName": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Full name of the skipper of the vessel.",
       "example": "Fabian Tollenaar"
     },
-    
+
     "crewNames": {
       "type": "array",
       "description": "Array with the names of the crew",
       "additionalProperties": [
         {
-          "$ref": "definitions.json#/definitions/stringValue",
+          "$ref": "../definitions.json#/definitions/stringValue",
           "description": "Name of a crew member of the vessel.",
           "example": "Catherine"
         }

--- a/schemas/groups/communication.json
+++ b/schemas/groups/communication.json
@@ -6,43 +6,43 @@
   "title": "communication",
   "properties": {
     "callsignVhf": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Callsign for VHF communication",
       "example": "ZL1234"
     },
 
     "callsignHf": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Callsign for HF communication",
       "example": "ZL3RTH"
     },
 
     "phoneNumber": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Phone number of skipper",
       "example": "+64xxxxxx"
     },
 
     "emailHf": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Email address to be used for HF email (Winmail, Airmail, Sailmail)",
       "example": "motu@xxx.co.nz"
     },
 
     "email": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Regular email for the skipper",
       "example": "robert@xxx.co.nz"
     },
 
     "satPhoneNumber": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Satellite phone number for vessel.",
       "example": "+64xxxxxx"
     },
 
     "skipperName": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Full name of the skipper of the vessel.",
       "example": "Fabian Tollenaar"
     },
@@ -52,7 +52,7 @@
       "description": "Array with the names of the crew",
       "additionalProperties": [
         {
-          "type": "string",
+          "$ref": "definitions.json#/definitions/stringValue",
           "description": "Name of a crew member of the vessel.",
           "example": "Catherine"
         }

--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -6,7 +6,7 @@
   "description": "An engine, named by a unique name within this vessel",
   "properties": {
     "label": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "Human readable label for the propulsion unit"
     },
 

--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -6,7 +6,7 @@
   "description": "An engine, named by a unique name within this vessel",
   "properties": {
     "label": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "Human readable label for the propulsion unit"
     },
 

--- a/schemas/groups/sensors.json
+++ b/schemas/groups/sensors.json
@@ -6,17 +6,17 @@
   "title": "sensor",
   "properties": {
     "name": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The common name of the sensor"
     },
     
     "sensorType": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The datamodel definition of the sensor data. FIXME - need to create a definitions lib of sensor datamodel types"
     },
 
     "sensorData": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The data of the sensor data. FIXME - need to ref the definitions of sensor types"
     },
 

--- a/schemas/groups/sensors.json
+++ b/schemas/groups/sensors.json
@@ -6,17 +6,17 @@
   "title": "sensor",
   "properties": {
     "name": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "The common name of the sensor"
     },
     
     "sensorType": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "The datamodel definition of the sensor data. FIXME - need to create a definitions lib of sensor datamodel types"
     },
 
     "sensorData": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "The data of the sensor data. FIXME - need to ref the definitions of sensor types"
     },
 

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -6,22 +6,43 @@
   "title": "tank",
   "properties": {
     "name": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The name of the tank. Useful if multiple tanks of a certain type are on board"
     },
 
     "type": {
-      "type": "string",
+      "type": "object",
       "description": "The type of tank",
-      "enum": [
-        "petrol",
-        "fresh water",
-        "greywater",
-        "holding",
-        "lpg",
-        "diesel",
-        "rum"
-      ]
+      "properties": {
+        "value": {
+          "type": "string",
+          "enum": [
+            "petrol",
+            "fresh water",
+            "greywater",
+            "holding",
+            "lpg",
+            "diesel",
+            "rum"
+          ]
+        },
+        
+        "timestamp": {
+          "$ref": "#/definitions/timestamp"
+        },
+    
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+    
+        "_attr": {
+          "$ref": "#/definitions/_attr"
+        },
+    
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      }
     },
 
     "capacity": {

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -6,7 +6,7 @@
   "title": "tank",
   "properties": {
     "name": {
-      "$ref": "definitions.json#/definitions/stringValue",
+      "$ref": "../definitions.json#/definitions/stringValue",
       "description": "The name of the tank. Useful if multiple tanks of a certain type are on board"
     },
 

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -27,18 +27,18 @@
     },
 
     "name": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The common name of the vessel"
     },
 
     "flag": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The country of ship registration, or flag state of the vessel",
       "example": "NZ"
     },
 
     "port": {
-      "type": "string",
+      "$ref": "definitions.json#/definitions/stringValue",
       "description": "The home port of the vessel",
       "example": "Nelson"
     },
@@ -129,17 +129,14 @@
       }
     },
 
-
-
-
     "communication": {
       "description": "Communication data",
       "$ref": "groups/communication.json#"
     },
 
     "environment": {
-        "description": "Environmental data",
-        "$ref": "groups/environment.json#"
+      "description": "Environmental data",
+      "$ref": "groups/environment.json#"
     },
 
     "navigation": {

--- a/test/data/propulsion.json
+++ b/test/data/propulsion.json
@@ -2,7 +2,9 @@
   "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
   "propulsion": {
     "instance0": {
-      "label": "Main Engine - The Olde Faithful",
+      "label": {
+        "value": "Main Engine - The Olde Faithful"
+      },
       "drive": {
         "type": "outboard",
         "trimState": {


### PR DESCRIPTION
This PR fixes #156 and applies the same resolution throughout the specification. 

Properties of plain `type: "string"` have been moved to `$ref` `stringValue` which includes `source`, `timestamp`, `meta` & `_attr` just as `numberValue` and such. 