### PR TITLE
Remove alarm uuid from path as its not needed.

### DIFF
--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -180,6 +180,48 @@
       "title": "alarms",
       "description": "Alarms currently raised",
       "required": false,
+      "properties":{
+        "mob": {
+          "description": "Man overboard",
+          "$ref": "groups/alarms.json#"
+        },
+        "fire": {
+          "description": "Fire onboard",
+          "$ref": "groups/alarms.json#"
+        },
+        "sinking": {
+          "description": "Vessel is sinking",
+          "$ref": "groups/alarms.json#"
+        },
+        "flooding": {
+          "description": "Vessel is flooding",
+          "$ref": "groups/alarms.json#"
+        },
+        "collision": {
+          "description": "In collision with another vessel or object",
+          "$ref": "groups/alarms.json#"
+        },
+        "grounding": {
+          "description": "Vessel grounding",
+          "$ref": "groups/alarms.json#"
+        },
+        "listing": {
+          "description": "Vessel is listing",
+          "$ref": "groups/alarms.json#"
+        },
+        "adrift": {
+          "description": "Vessel is adrift",
+          "$ref": "groups/alarms.json#"
+        },
+        "piracy": {
+          "description": "Under attack or danger from pirates",
+          "$ref": "groups/alarms.json#"
+        },
+        "abandon": {
+          "description": "Abandon ship",
+          "$ref": "groups/alarms.json#"
+        }
+      },
       "patternProperties": {
         "(^[A-Za-z0-9-]+$)": {
           "description": "This regex pattern is used for validation of the path of the alarm",

--- a/test/data/alarms-deep.json
+++ b/test/data/alarms-deep.json
@@ -5,7 +5,7 @@
       "alarms": {
         "navigation":{
           "position":{
-            "c0d79334-4e25-4245-8892-54e8ccc80223": {
+           
               "message": "Position is more than 5 minutes old",
               "timestamp": "2014-04-10T08:33:53Z",
               "source": {
@@ -15,7 +15,7 @@
               "state": "alert",
               "method" : ["visual"]
             }
-          }
+    
         }
       }
     }

--- a/test/data/alarms-invalid1.json
+++ b/test/data/alarms-invalid1.json
@@ -3,8 +3,8 @@
     "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
       "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
       "alarms": {
-        "navigation":{
-          "c0d79334-4e25-4245-8892-54e8ccc80223": {
+        "mob":{
+     
             "message": "MOB",
             "timestamp": "2014-04-10T08:33:53Z",
             "source": {
@@ -15,7 +15,7 @@
             "method" : ["sound"]
           }
         }
-      }
+      
     }
   }
 }

--- a/test/data/alarms-invalid2.json
+++ b/test/data/alarms-invalid2.json
@@ -3,8 +3,8 @@
     "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
       "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
       "alarms": {
-        "navigation":{
-          "c0d79334-4e25-4245-8892-54e8ccc80223": {
+        "mob":{
+          
             "message": "MOB",
             "timestamp": "2014-04-10T08:33:53Z",
             "source": {
@@ -14,7 +14,7 @@
             "state": "warn",
             "method" : ["squeak"]
           }
-        }
+        
       }
     }
   }

--- a/test/data/alarms.json
+++ b/test/data/alarms.json
@@ -3,8 +3,8 @@
     "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
       "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
       "alarms": {
-        "navigation":{
-          "c0d79334-4e25-4245-8892-54e8ccc80223": {
+        "mob":{
+          
             "message": "MOB",
             "timestamp": "2014-04-10T08:33:53Z",
             "source": {
@@ -15,7 +15,7 @@
             "method" : ["visual","sound"]
           }
         }
-      }
+      
     }
   }
 }


### PR DESCRIPTION
Ive updated the alarms wiki page, and removed the uuid per alarm as I dont think its needed. The only use case where there could be problems is if we have an alarm at `...alarms.navigation.position{}` and another alarm comes in `alarms{}` which overwrites the navigation object with the new alarm object. 

The java server will throw an exception and not update, but that loses the incoming alarm. So its really an implementation thing to be sure not to loose alarms? 