### PR TITLE
Convert zone in meta to an object

### DIFF
--- a/samples/signalk-depth-meta-attr.json
+++ b/samples/signalk-depth-meta-attr.json
@@ -22,7 +22,7 @@
                     "zones": [
                         {"lower":0.0,"upper":1.5,"state":"alarm", "message":"Running aground!"},
                         {"lower":1.5,"upper":3.0,"state":"warn", "message":"Shallow water!"},
-                        {"lower":3.0,"upper":9999.9,"state":"normal", "message":""}
+                        {"lower":3.0, "state":"normal"}
                     ]
                 }
             }

--- a/samples/signalk-depth-meta-attr.json
+++ b/samples/signalk-depth-meta-attr.json
@@ -20,9 +20,9 @@
                     "warnMethod": ["visual"],
                     "alarmMethod": ["sound"],
                     "zones": [
-                        [0.0,1.5,"alarm", "Running aground!"],
-                        [1.5,3.0,"warn" , "Shallow water!"],
-                        [3.0,9999.9,"normal",""]
+                        {"lower":0.0,"upper":1.5,"state":"alarm", "message":"Running aground!"},
+                        {"lower":1.5,"upper":3.0,"state":"warn", "message":"Shallow water!"},
+                        {"lower":3.0,"upper":9999.9,"state":"normal", "message":""}
                     ]
                 }
             }

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -523,40 +523,40 @@
           "description": "The zones defining the range of values for this signalk value.",
           "items": [
             {
-              "type": "array",
+              "type": "object",
               "title": "zone",
               "description": "A zone used to define the display and alarm state when the value is in between bottom and top.",
-              "items": [
-                {
-                  "id": "bottom",
+              "properties": {
+                "lower":{
+                  "id": "lower",
                   "type": "number",
-                  "title": "Bottom",
+                  "title": "Lower",
                   "description": "The lowest number in this zone",
-                  "name": "bottom",
+                  "name": "lower",
                   "example": 3500
                 },
 
-                {
-                  "id": "top",
+                "upper":{
+                  "id": "upper",
                   "type": "number",
-                  "title": "top",
+                  "title": "Upper",
                   "description": "The highest value in this zone",
-                  "name": "1",
+                  "name": "upper",
                   "example": 4000
                 },
 
-                {
+                "state":{
                   "$ref":"#/definitions/alarmState"
                 },
 
-                {
+                "message":{
                   "id": "message",
                   "type": "string",
                   "title": "message",
                   "description": "The message to display for the alarm.",
                   "default": "Warning"
                 }
-              ]
+              }
             }
           ]
         }

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -526,6 +526,7 @@
               "type": "object",
               "title": "zone",
               "description": "A zone used to define the display and alarm state when the value is in between bottom and top.",
+              "required": ["state"],
               "properties": {
                 "lower":{
                   "id": "lower",


### PR DESCRIPTION
As teppo pointed out the zones in meta is an array of arrays.The zone definitions are better described by objects as they have fixed formats
This converts the zones array of arrays to an array of objects