### PR TITLE
Rework and extend the navigation.activeRoute into navigation.course

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -331,7 +331,7 @@
         "source": {
           "$ref": "#/definitions/source"
         },
-        
+
         "_attr": {
           "$ref": "#/definitions/_attr"
         },
@@ -356,11 +356,11 @@
         "source": {
           "$ref": "#/definitions/source"
         },
-        
+
         "_attr": {
           "$ref": "#/definitions/_attr"
         },
-        
+
         "meta": {
           "$ref": "#/definitions/meta"
         }
@@ -639,6 +639,25 @@
           }
         }
       }
+    },
+    "geoposition": {
+        "description": "A single position",
+        "type": "array",
+        "minItems": 2,
+        "items": [ { "type": "number" }, { "type": "number" } ],
+        "additionalItems": false
+    },
+    "positionArray": {
+        "description": "An array of positions",
+        "type": "array",
+        "items": { "$ref": "#/definitions/geoposition" }
+    },
+    "lineString": {
+        "description": "An array of two or more positions",
+        "allOf": [
+            { "$ref": "#/definitions/positionArray" },
+            { "minItems": 2 }
+        ]
     }
   }
 }

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -72,7 +72,7 @@
         },
         "geometry": {
           "title": "LineString",
-          "description": "The GeoJSON LineString that defines the course between the last and next waypoints.",
+          "description": "The GeoJSON LineString that defines the course between the last and next waypoints. When null, use a straight line",
           "properties": {
             "type": {
               "enum": [
@@ -80,17 +80,32 @@
               ]
             },
             "coordinates": {
-              "$ref": "#/definitions/lineString"
+              "$ref": "../definitions.json#/definitions/lineString"
+            },
+            "timestamp": {
+              "$ref": "../definitions.json#/definitions/timestamp"
+            },
+
+            "source": {
+              "$ref": "../definitions.json#/definitions/source"
+            },
+
+            "_attr": {
+              "$ref": "../definitions.json#/definitions/_attr"
+            },
+
+            "meta": {
+              "$ref": "../definitions.json#/definitions/meta"
             }
           }
         },
         "nextMark": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Number of next mark"
+          "description": "Array position (zero-based) of next mark in the geometry LineString"
         },
         "lastMark": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Number of last mark"
+          "description": "Array position (zero-based) of last mark in the geometry LineString"
         },
         "vmg": {
           "$ref": "../definitions.json#/definitions/numberValue",
@@ -122,23 +137,23 @@
           "description": "The estimated time of arrival at the end of the current leg of the route",
           "properties": {
             "value": {
-              "$ref": "#/definitions/timestamp"
+              "$ref": "../definitions.json#/definitions/timestamp"
             },
 
             "timestamp": {
-              "$ref": "#/definitions/timestamp"
+              "$ref": "../definitions.json#/definitions/timestamp"
             },
 
             "source": {
-              "$ref": "#/definitions/source"
+              "$ref": "../definitions.json#/definitions/source"
             },
 
             "_attr": {
-              "$ref": "#/definitions/_attr"
+              "$ref": "../definitions.json#/definitions/_attr"
             },
 
             "meta": {
-              "$ref": "#/definitions/meta"
+              "$ref": "../definitions.json#/definitions/meta"
             }
           }
         },

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -37,12 +37,10 @@
             "mine clearance"
           ]
         },
-
         "source": {
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
-
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
@@ -54,109 +52,171 @@
       "$ref": "../definitions.json#/definitions/numberValue",
       "units": "rad"
     },
-
     "courseOverGroundTrue": {
       "description": "Course over ground (true)",
       "$ref": "../definitions.json#/definitions/numberValue",
       "units": "rad"
     },
-
-    "activeRoute": {
+    "course": {
       "type": "object",
-      "title": "Active Route",
-      "description": "The currently active route",
+      "title": "Course to next mark",
+      "description": "The current leg of the planned course or route",
       "properties": {
-        "timestamp": {
-          "$ref": "../definitions.json#/definitions/timestamp",
-          "description": "Time of last update to active route"
+        "lastWaypoint": {
+          "description": "The position of the last waypoint in 3 dimensions",
+          "$ref": "../definitions.json#/definitions/position"
         },
-
-        "source": {
-          "$ref": "../definitions.json#/definitions/source",
-          "description": "Source of last update to active route"
+        "nextWaypoint": {
+          "description": "The position of the next waypoint in 3 dimensions",
+          "$ref": "../definitions.json#/definitions/position"
         },
-
-        "bearingActual": {
-          "type": "number",
-          "description": "The current bearing of the next waypoint relative to true North",
-          "units": "rad"
+        "nextMark": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Number of next mark"
         },
-
-        "distanceActual": {
-          "type": "number",
-          "description": "The current distance to the next waypoint",
-          "units": "m"
+        "lastMark": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Number of last mark"
         },
-
-        "bearingDirect": {
-          "type": "number",
-          "description": "The bearing relative to true North from last waypoint to the next waypoint",
-          "units": "rad"
+        "vmg": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The velocity made good towards the next waypoint",
+          "units": "m/s"
         },
-
-        "courseRequired": {
-          "type": "number",
+        "courseRequiredTrue": {
+          "$ref": "../definitions.json#/definitions/numberValue",
           "description": "The course relative to true North towards the next waypoint",
           "units": "rad"
         },
-
+        "courseRequiredMagnetic": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The course relative to magnetic North towards the next waypoint",
+          "units": "rad"
+        },
+        "timeToGo": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Time to Go in seconds before we reach the next waypoint",
+          "units": "s"
+        },
+        "xte": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "Cross track error",
+          "units": "m"
+        },
         "eta": {
-          "$ref": "../definitions.json#/definitions/timestamp",
-          "description": "The estimated time of arrival at the end of the current route"
-        },
-
-        "route": {
-          "type": "string",
-          "description": "UUID of the current route, found in the routes list"
-        },
-
-        "startTime": {
-          "$ref": "../definitions.json#/definitions/timestamp",
-          "description": "The time this route was activated"
-        },
-
-        "waypoint": {
           "type": "object",
-          "title": "waypoint",
-          "description": "The last and next waypoints data",
+          "description": "The estimated time of arrival at the end of the current leg of the route",
           "properties": {
-            "lastTime": {
-              "$ref": "../definitions.json#/definitions/timestamp",
-              "description": "The time the last waypoint was reached"
+            "value": {
+              "$ref": "#/definitions/timestamp"
             },
 
-            "last": {
-              "type": "string",
-              "description": "UUID of the last waypoint, found in the waypoints list"
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
             },
 
-            "nextEta": {
-              "$ref": "../definitions.json#/definitions/timestamp",
-              "description": "Estimated time of arrival at the next waypoint",
-              "example": "2014-03-24T00:15:41Z"
+            "source": {
+              "$ref": "#/definitions/source"
             },
 
-            "next": {
-              "type": "string",
-              "description": "UUID to the next waypoint, found in the waypoints list"
+            "_attr": {
+              "$ref": "#/definitions/_attr"
             },
 
-            "xte": {
-              "type": "number",
-              "description": "Cross track error",
+            "meta": {
+              "$ref": "#/definitions/meta"
+            }
+          }
+        },
+        "startTime": {
+          "type": "object",
+          "description": "The time this leg of the route was activated",
+          "properties": {
+            "value": {
+              "$ref": "#/definitions/timestamp"
+            },
+
+            "timestamp": {
+              "$ref": "#/definitions/timestamp"
+            },
+
+            "source": {
+              "$ref": "#/definitions/source"
+            },
+
+            "_attr": {
+              "$ref": "#/definitions/_attr"
+            },
+
+            "meta": {
+              "$ref": "#/definitions/meta"
+            }
+          }
+        },
+        "bearingToNextMarkTrue": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The current bearing to the next mark relative to true North",
+          "units": "rad"
+        },
+        "bearingToNextMarkMagnetic": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The current bearing to the next mark relative to magnetic North",
+          "units": "rad"
+        },
+        "distanceToNextMark": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The current distance to the next mark",
+          "units": "m"
+        },
+        "bearingDirectTrue": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The bearing relative to true North from last mark to the next mark",
+          "units": "rad"
+        },
+        "bearingDirectMagnetic": {
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "description": "The bearing relative to magnetic North from last mark to the next mark",
+          "units": "rad"
+        },
+        "greatCircle": {
+          "type": "object",
+          "title": "Great Circle data",
+          "description": "Data based on great circle calculations",
+          "properties": {
+            "distanceToNextMark": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The current distance to the next mark (Great Circle)",
               "units": "m"
+            },
+            "bearingToNextMarkTrue": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The current bearing to the next mark relative to true North (Great Circle)",
+              "units": "rad"
+            },
+            "bearingToNextMarkMagnetic": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The current bearing to the next mark relative to magnetic North (Great Circle)",
+              "units": "rad"
+            },
+            "bearingDirectTrue": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The bearing relative to true North from last mark to the next mark (Great Circle)",
+              "units": "rad"
+            },
+            "bearingDirectMagnetic": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The bearing relative to magnetic North from last mark to the next mark (Great Circle)",
+              "units": "rad"
             }
           }
         }
       }
     },
-
     "magneticVariation": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "The magnetic variation (declination) at the current position",
       "units": "rad"
     },
-
     "destination": {
       "title": "destination",
       "description": "The intended destination of this trip",
@@ -165,24 +225,20 @@
         "eta": {
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-
         "source": {
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
-
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-
         "waypoint": {
           "description": "UUID of destination waypoint",
           "type": "string"
         }
       }
     },
-
     "gnss": {
       "type": "object",
       "title": "gnss",
@@ -192,12 +248,10 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
-
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-
         "methodQuality": {
           "type": "object",
           "description": "Quality of the satellite fix",
@@ -219,7 +273,6 @@
             }
           }
         },
-
         "integrity": {
           "type": "object",
           "description": "Integrity of the satellite fix",
@@ -235,65 +288,52 @@
             }
           }
         },
-
         "satellites": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Number of satellites"
         },
-
         "antennaAltitude": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Altitude of antenna",
           "units": "m"
         },
-
         "horizontalDilution": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Horizontal Dilution of Precision"
         },
-
         "positionDilution": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Positional Dilution of Precision"
         },
-
         "geoidalSeparation": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Difference between WGS84 earth ellipsoid and mean sea level"
         },
-
         "differentialAge": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Age of DGPS data",
           "units": "s"
         },
-
         "differentialReference": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "ID of DGPS base station"
         }
       }
     },
-
     "headingMagnetic": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Current magnetic heading of the vessels",
       "units": "rad"
     },
-
     "headingTrue": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "The current true heading of the vessel",
       "units": "rad"
     },
-
     "position": {
       "description": "The position of the vessel in 3 dimensions",
       "$ref": "../definitions.json#/definitions/position"
     },
-
-
-
     "attitude": {
       "type": "object",
       "title": "Attitude",
@@ -304,61 +344,51 @@
           "description": "Vessel roll, +ve is list to starboard",
           "units": "rad"
         },
-
         "pitch": {
           "type": "number",
           "description": "Pitch, +ve is bow up",
           "units": "rad"
         },
-
         "yaw": {
           "type": "number",
           "description": "Yaw, +ve is heading change to starboard",
           "units": "rad"
         },
-
         "source": {
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
-
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         }
       }
     },
-
     "rateOfTurn": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Rate of turn",
       "units": "rad/s"
     },
-
     "speedOverGround": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Vessel speed over ground",
       "units": "m/s"
     },
-
     "speedThroughWater": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Vessel speed through the water",
       "units": "m/s"
     },
-
     "log": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Log value",
       "units": "m"
     },
-
     "logTrip": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Trip log value",
       "units": "m"
     },
-
     "state": {
       "type": "object",
       "title": "state",
@@ -368,12 +398,10 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
-
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-
         "value": {
           "type": "string",
           "enum": [
@@ -403,7 +431,6 @@
         }
       }
     },
-
     "anchor": {
       "type": "object",
       "title": "anchor",
@@ -413,32 +440,26 @@
           "description": "Source of this data",
           "$ref": "../definitions.json#/definitions/source"
         },
-
         "timestamp": {
           "description": "timestamp of the last update to this data",
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-
         "maxRadius": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Radius of anchor alarm boundary. The distance from anchor to the center of the boat",
           "units": "m"
         },
-
         "currentRadius": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Current distance to anchor",
           "units": "m"
         },
-
         "position": {
           "description": "The actual anchor position of the vessel in 3 dimensions, probably an estimate at best",
           "$ref": "../definitions.json#/definitions/position"
-
         }
       }
     },
-
     "datetime": {
       "type": "object",
       "properties": {
@@ -463,7 +484,6 @@
         "timestamp": {
           "$ref": "../definitions.json#/definitions/timestamp"
         },
-
         "source": {
           "$ref": "../definitions.json#/definitions/source"
         }

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -186,6 +186,11 @@
               "description": "Cross track error to the next mark",
               "units": "m"
             },
+            "arrivalRadius": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The distance before next mark to raise arrival warnings",
+              "units": "m"
+            },
             "eta": {
               "type": "object",
               "description": "The estimated time of arrival at the next mark",
@@ -198,49 +203,7 @@
                 }
               }
               
-            },
-             "greatCircle": {
-                "type": "object",
-                "title": "Great Circle data",
-                "description": "Data based on great circle calculations to the next mark",
-                "properties": {
-                  "distance": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The current distance to the next mark (Great Circle)",
-                    "units": "m"
-                  },
-                  "bearingTrue": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The current bearing to the next mark relative to true North (Great Circle)",
-                    "units": "rad"
-                  },
-                  "bearingMagnetic": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The current bearing to the next mark relative to magnetic North (Great Circle)",
-                    "units": "rad"
-                  },
-                  "bearingDirectTrue": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The bearing relative to true North from last mark to the next mark (Great Circle)",
-                    "units": "rad"
-                  },
-                  "bearingDirectMagnetic": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The bearing relative to magnetic North from last mark to the next mark (Great Circle)",
-                    "units": "rad"
-                  },
-                  "courseRequiredTrue": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The bearing required  relative to true North from last mark to the next mark (Great Circle)",
-                    "units": "rad"
-                  },
-                  "courseRequiredMagnetic": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "The bearing required relative to magnetic North from last mark to the next mark (Great Circle)",
-                    "units": "rad"
-                  }
-                }
-              }
+            }
           }
           
         },

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -70,6 +70,20 @@
           "description": "The position of the next waypoint in 3 dimensions",
           "$ref": "../definitions.json#/definitions/position"
         },
+        "geometry": {
+          "title": "LineString",
+          "description": "The GeoJSON LineString that defines the course between the last and next waypoints.",
+          "properties": {
+            "type": {
+              "enum": [
+                "LineString"
+              ]
+            },
+            "coordinates": {
+              "$ref": "#/definitions/lineString"
+            }
+          }
+        },
         "nextMark": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Number of next mark"

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -57,12 +57,58 @@
       "description": "The current leg of the planned course or route",
       "properties": {
         "lastWaypoint": {
-          "description": "The position of the last waypoint in 3 dimensions",
-          "$ref": "../definitions.json#/definitions/position"
+          "type": "object",
+          "title": "Last Waypoint",
+          "description": "the last waypoint passed on the planned course or route",
+          "properties": {
+            "position":{
+              "description": "The position of the last waypoint in 3 dimensions",
+              "$ref": "../definitions.json#/definitions/position"
+            },
+            "arrivalTime": {
+              "type": "object",
+              "description": "The arrival time at the last waypoint",
+              "allOf": [{
+                    "$ref": "../definitions.json#/definitions/commonValueFields"
+                }],
+              "properties":{
+                "value": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                }
+              }  
+            }
+          }
+         
         },
         "nextWaypoint": {
-          "description": "The position of the next waypoint in 3 dimensions",
-          "$ref": "../definitions.json#/definitions/position"
+          "type": "object",
+          "title": "Next Waypoint",
+          "description": "the next waypoint on the planned course or route",
+          "properties": {
+            "position":{
+              "description": "The position of the next waypoint in 3 dimensions",
+              "$ref": "../definitions.json#/definitions/position"
+            },
+            
+            "timeToGo": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "Time to Go in seconds before we reach the next waypoint",
+              "units": "s"
+            },
+            
+            "eta": {
+              "type": "object",
+              "description": "The estimated time of arrival at the next waypoint of the route",
+              "allOf": [{
+                    "$ref": "../definitions.json#/definitions/commonValueFields"
+                }],
+              "properties":{
+                "value": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                }
+              }
+            }
+          }
         },
         "geometry": {
           "title": "LineString",
@@ -82,121 +128,147 @@
           }
         },
         "nextMark": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Array position (zero-based) of next mark in the geometry LineString"
-        },
-        "lastMark": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Array position (zero-based) of last mark in the geometry LineString"
-        },
-        "vmg": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The velocity made good towards the next waypoint",
-          "units": "m/s"
-        },
-        "courseRequiredTrue": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The course relative to true North towards the next waypoint",
-          "units": "rad"
-        },
-        "courseRequiredMagnetic": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The course relative to magnetic North towards the next waypoint",
-          "units": "rad"
-        },
-        "timeToGo": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Time to Go in seconds before we reach the next waypoint",
-          "units": "s"
-        },
-        "xte": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Cross track error",
-          "units": "m"
-        },
-        "eta": {
           "type": "object",
-          "description": "The estimated time of arrival at the end of the current leg of the route",
-          "allOf": [{
-                "$ref": "../definitions.json#/definitions/commonValueFields"
-            }],
-          "properties":{
-            "value": {
-              "$ref": "../definitions.json#/definitions/timestamp"
-            }
-           }
-          
-        },
-        "startTime": {
-          "type": "object",
-          "description": "The time this leg of the route was activated",
-          "allOf": [{
-                "$ref": "../definitions.json#/definitions/commonValueFields"
-            }],
-          "properties":{
-            "value": {
-              "$ref": "../definitions.json#/definitions/timestamp"
-            }
-           }
-          
-        },
-        "bearingToNextMarkTrue": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The current bearing to the next mark relative to true North",
-          "units": "rad"
-        },
-        "bearingToNextMarkMagnetic": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The current bearing to the next mark relative to magnetic North",
-          "units": "rad"
-        },
-        "distanceToNextMark": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The current distance to the next mark",
-          "units": "m"
-        },
-        "bearingDirectTrue": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The bearing relative to true North from last mark to the next mark",
-          "units": "rad"
-        },
-        "bearingDirectMagnetic": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "The bearing relative to magnetic North from last mark to the next mark",
-          "units": "rad"
-        },
-        "greatCircle": {
-          "type": "object",
-          "title": "Great Circle data",
-          "description": "Data based on great circle calculations",
+          "title": "Next Mark",
+          "description": "the next mark on this leg between last and next waypoints",
           "properties": {
-            "distanceToNextMark": {
+            "index":{
               "$ref": "../definitions.json#/definitions/numberValue",
-              "description": "The current distance to the next mark (Great Circle)",
+              "description": "Array position (zero-based) of next mark in the geometry LineString"
+            },
+            "bearingTrue": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The current bearing to the next mark relative to true North",
+              "units": "rad"
+            },
+            "bearingMagnetic": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The current bearing to the next mark relative to magnetic North",
+              "units": "rad"
+            },
+            "distance": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The current distance to the next mark",
               "units": "m"
-            },
-            "bearingToNextMarkTrue": {
-              "$ref": "../definitions.json#/definitions/numberValue",
-              "description": "The current bearing to the next mark relative to true North (Great Circle)",
-              "units": "rad"
-            },
-            "bearingToNextMarkMagnetic": {
-              "$ref": "../definitions.json#/definitions/numberValue",
-              "description": "The current bearing to the next mark relative to magnetic North (Great Circle)",
-              "units": "rad"
             },
             "bearingDirectTrue": {
               "$ref": "../definitions.json#/definitions/numberValue",
-              "description": "The bearing relative to true North from last mark to the next mark (Great Circle)",
+              "description": "The bearing relative to true North from last mark to the next mark",
               "units": "rad"
             },
             "bearingDirectMagnetic": {
               "$ref": "../definitions.json#/definitions/numberValue",
-              "description": "The bearing relative to magnetic North from last mark to the next mark (Great Circle)",
+              "description": "The bearing relative to magnetic North from last mark to the next mark",
               "units": "rad"
+            },
+            "courseRequiredTrue": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The bearing required  relative to true North from last mark to the next mark",
+              "units": "rad"
+            },
+            "courseRequiredMagnetic": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The bearing required relative to magnetic North from last mark to the next mark",
+              "units": "rad"
+            },
+            "vmg": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "The velocity made good towards the next mark",
+              "units": "m/s"
+            },
+            "timeToGo": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "Time to Go in seconds before we reach the next mark",
+              "units": "s"
+            },
+            "xte": {
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "Cross track error to the next mark",
+              "units": "m"
+            },
+            "eta": {
+              "type": "object",
+              "description": "The estimated time of arrival at the next mark",
+              "allOf": [{
+                    "$ref": "../definitions.json#/definitions/commonValueFields"
+                }],
+              "properties":{
+                "value": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                }
+              }
+              
+            },
+             "greatCircle": {
+                "type": "object",
+                "title": "Great Circle data",
+                "description": "Data based on great circle calculations to the next mark",
+                "properties": {
+                  "distance": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The current distance to the next mark (Great Circle)",
+                    "units": "m"
+                  },
+                  "bearingTrue": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The current bearing to the next mark relative to true North (Great Circle)",
+                    "units": "rad"
+                  },
+                  "bearingMagnetic": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The current bearing to the next mark relative to magnetic North (Great Circle)",
+                    "units": "rad"
+                  },
+                  "bearingDirectTrue": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The bearing relative to true North from last mark to the next mark (Great Circle)",
+                    "units": "rad"
+                  },
+                  "bearingDirectMagnetic": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The bearing relative to magnetic North from last mark to the next mark (Great Circle)",
+                    "units": "rad"
+                  },
+                  "courseRequiredTrue": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The bearing required  relative to true North from last mark to the next mark (Great Circle)",
+                    "units": "rad"
+                  },
+                  "courseRequiredMagnetic": {
+                    "$ref": "../definitions.json#/definitions/numberValue",
+                    "description": "The bearing required relative to magnetic North from last mark to the next mark (Great Circle)",
+                    "units": "rad"
+                  }
+                }
+              }
+          }
+          
+        },
+        "lastMark": {
+          "type": "object",
+          "title": "Next Mark",
+          "description": "the next mark on this leg between last and next waypoints",
+          "properties": {
+            "index":{
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "description": "Array position (zero-based) of last mark in the geometry LineString"
+            },
+            "arrivalTime": {
+              "type": "object",
+              "description": "The arrival time at the last mark",
+              "allOf": [{
+                    "$ref": "../definitions.json#/definitions/commonValueFields"
+                }],
+              "properties":{
+                "value": {
+                  "$ref": "../definitions.json#/definitions/timestamp"
+                }
+              }
+          
             }
           }
         }
+       
       }
     },
     "magneticVariation": {

--- a/test/course.js
+++ b/test/course.js
@@ -13,3 +13,9 @@ describe('Partial course in the full tree', function() {
     require('./data/course-partial.json').should.be.validSignalK;
   });
 });
+
+describe('Bad linestring in the full tree', function() {
+  it("should be invalid", function() {
+    require('./data/course-bad-linestring.json').should.not.be.validSignalK;
+  });
+});

--- a/test/course.js
+++ b/test/course.js
@@ -1,0 +1,15 @@
+var chai = require('chai');
+chai.Should();
+chai.use(require('../index.js').chaiModule);
+
+describe('Course in the full tree', function() {
+  it("should be valid", function() {
+    require('./data/course.json').should.be.validSignalK;
+  });
+});
+
+describe('Partial course in the full tree', function() {
+  it("should be valid", function() {
+    require('./data/course-partial.json').should.be.validSignalK;
+  });
+});

--- a/test/course.js
+++ b/test/course.js
@@ -19,3 +19,9 @@ describe('Bad linestring in the full tree', function() {
     require('./data/course-bad-linestring.json').should.not.be.validSignalK;
   });
 });
+
+describe('Course in delta format', function() {
+  it("should be valid", function() {
+    require('./data/course-delta.json').should.be.validSignalKDelta;
+  });
+});

--- a/test/data/course-bad-linestring.json
+++ b/test/data/course-bad-linestring.json
@@ -1,0 +1,116 @@
+{
+  "vessels": {
+    "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
+      "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+      "navigation": {
+        "course": {
+          "nextMark": {
+            "value": 4,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "lastMark": {
+            "value": 3,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [[173.1693,-41.156426],[-41.156426],[173.1693,-41.156426]],
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "vmg": {
+            "value": 10.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "courseRequiredTrue": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "courseRequiredMagnetic": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "timeToGo": {
+            "value": 3114,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "xte": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "eta": {
+            "value": "2014-04-10T08:33:53Z",
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "startTime": {
+            "value": "2014-04-10T08:33:53Z",
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "bearingToNextMarkTrue": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "bearingToNextMarkMagnetic": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "distanceToNextMark": {
+            "value": 1114,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/course-bad-linestring.json
+++ b/test/data/course-bad-linestring.json
@@ -4,111 +4,134 @@
       "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
       "navigation": {
         "course": {
-          "nextMark": {
-            "value": 4,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
+            "lastWaypoint": {
+              "position":{
+                  "timestamp": "2015-03-06T16:57:53.643+13:00",
+                  "$source":"sourceLabel.160",
+                  "longitude": 173.1693,
+                  "latitude": -41.156426,
+                  "altitude": 0
+                }
+            },
+            "nextWaypoint": {
+              "position":{
+                  "timestamp": "2015-03-06T16:57:53.643+13:00",
+                  "$source":"sourceLabel.160",
+                  "longitude": 173.1693,
+                  "latitude": -41.156426,
+                  "altitude": 0
+                }
+            },
+            "nextMark": {
+              "index":{
+                "value": 4,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "distance": {
+                "value": 1114,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingDirectTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingDirectMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "vmg": {
+                "value": 10.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "courseRequiredTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "courseRequiredMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "timeToGo": {
+                "value": 3114,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "xte": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "eta": {
+                "value": "2014-04-10T08:33:53Z",
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "greatCircle": {
+
+                "distance": {
+                  "value": 1124,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "$source": "sourceLabel.160"
+                },
+                "bearingTrue": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "$source": "sourceLabel.160"
+                },
+                "bearingMagnetic": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "$source": "sourceLabel.160"
+                },
+                "bearingDirectTrue": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "$source": "sourceLabel.160"
+                },
+                "bearingDirectMagnetic": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "$source": "sourceLabel.160"
+                }
+              
             }
-          },
-          "lastMark": {
-            "value": 3,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "geometry": {
+            },
+            "lastMark": {
+              "index":{
+                "value": 3,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "arrivalTime": {
+                "value": "2014-04-10T08:33:53Z",
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              }
+            },
+            "geometry": {
             "type": "LineString",
             "coordinates": [[173.1693,-41.156426],[-41.156426],[173.1693,-41.156426]],
             "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "vmg": {
-            "value": 10.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "courseRequiredTrue": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "courseRequiredMagnetic": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "timeToGo": {
-            "value": 3114,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "xte": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "eta": {
-            "value": "2014-04-10T08:33:53Z",
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "startTime": {
-            "value": "2014-04-10T08:33:53Z",
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "bearingToNextMarkTrue": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "bearingToNextMarkMagnetic": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
-          },
-          "distanceToNextMark": {
-            "value": 1114,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "source": {
-              "label": "mode",
-              "type": "self"
-            }
+            "$source": "sourceLabel.160"
           }
+           
         }
       }
     }

--- a/test/data/course-delta.json
+++ b/test/data/course-delta.json
@@ -6,43 +6,43 @@
       "timestamp": "2014-04-10T08:33:53Z",
       "values": [
         {
-          "path": "navigation.course.xte",
+          "path": "navigation.course.nextMark.xte",
           "value": 3.14
         },
         {
-          "path": "navigation.course.distanceToNextMark",
+          "path": "navigation.course.nextMark.distance",
           "value": 1114
         },
         {
-          "path": "navigation.course.courseRequiredTrue",
+          "path": "navigation.course.nextMark.courseRequiredTrue",
           "value": 3.14
         },
         {
-          "path": "navigation.course.lastMark",
+          "path": "navigation.course.lastMark.index",
           "value": 3
         },
         {
-          "path": "navigation.course.bearingToNextMarkTrue",
+          "path": "navigation.course.nextMark.bearingTrue",
           "value": 3.14
         },
         {
-          "path": "navigation.course.bearingToNextMarkMagnetic",
+          "path": "navigation.course.nextMark.bearingMagnetic",
           "value": 3.14
         },
         {
-          "path": "navigation.course.eta.timestamp",
+          "path": "navigation.course.nextMark.eta.timestamp",
           "value": "2014-04-10T08:33:53Z"
         },
         {
-          "path": "navigation.course.courseRequiredMagnetic",
+          "path": "navigation.course.nextMark.courseRequiredMagnetic",
           "value": 3.14
         },
         {
-          "path": "navigation.course.vmg",
+          "path": "navigation.course.nextMark.vmg",
           "value": 10.14
         },
         {
-          "path": "navigation.course.timeToGo",
+          "path": "navigation.course.nextMark.timeToGo",
           "value": 3114
         }
       ],
@@ -55,7 +55,7 @@
       "timestamp": "2015-03-06T16:57:53.643+13:00",
       "values": [
         {
-          "path": "navigation.course.nextWaypoint",
+          "path": "navigation.course.nextWaypoint.position",
           "value": {
             "longitude": 173.1693,
             "latitude": -41.156426,
@@ -74,39 +74,39 @@
       "timestamp": "2014-04-10T08:33:53Z",
       "values": [
         {
-          "path": "navigation.course.bearingDirectMagnetic",
+          "path": "navigation.course.nextMark.bearingDirectMagnetic",
           "value": 3.14
         },
         {
-          "path": "navigation.course.greatCircle.distanceToNextMark",
+          "path": "navigation.course.nextMark.greatCircle.distance",
           "value": 1124
         },
         {
-          "path": "navigation.course.greatCircle.bearingToNextMarkTrue",
+          "path": "navigation.course.nextMark.greatCircle.bearingTrue",
           "value": 3.14
         },
         {
-          "path": "navigation.course.greatCircle.bearingToNextMarkMagnetic",
+          "path": "navigation.course.nextMark.greatCircle.bearingMagnetic",
           "value": 3.14
         },
         {
-          "path": "navigation.course.greatCircle.bearingDirectMagnetic",
+          "path": "navigation.course.nextMark.greatCircle.bearingDirectMagnetic",
           "value": 3.14
         },
         {
-          "path": "navigation.course.greatCircle.bearingDirectTrue",
+          "path": "navigation.course.nextMark.greatCircle.bearingDirectTrue",
           "value": 3.14
         },
         {
-          "path": "navigation.course.nextMark",
+          "path": "navigation.course.nextMark.index",
           "value": 4
         },
         {
-          "path": "navigation.course.startTime.timestamp",
+          "path": "navigation.course.lastMark.arrivalTime.timestamp",
           "value": "2014-04-10T08:33:53Z"
         },
         {
-          "path": "navigation.course.bearingDirectTrue",
+          "path": "navigation.course.nextMark.bearingDirectTrue",
           "value": 3.14
         }
       ],
@@ -119,7 +119,7 @@
       "timestamp": "2015-03-06T16:57:53.643+13:00",
       "values": [
         {
-          "path": "navigation.course.lastWaypoint",
+          "path": "navigation.course.lastWaypoint.position",
           "value": {
             "longitude": 173.1693,
             "latitude": -41.156426,

--- a/test/data/course-delta.json
+++ b/test/data/course-delta.json
@@ -34,6 +34,10 @@
           "value": "2014-04-10T08:33:53Z"
         },
         {
+          "path": "navigation.course.nextMark.arrivalRadius",
+          "value": 3.14
+        },
+        {
           "path": "navigation.course.nextMark.courseRequiredMagnetic",
           "value": 3.14
         },
@@ -70,51 +74,7 @@
         "type": "NMEA0183"
       }
     },
-    {
-      "timestamp": "2014-04-10T08:33:53Z",
-      "values": [
-        {
-          "path": "navigation.course.nextMark.bearingDirectMagnetic",
-          "value": 3.14
-        },
-        {
-          "path": "navigation.course.nextMark.greatCircle.distance",
-          "value": 1124
-        },
-        {
-          "path": "navigation.course.nextMark.greatCircle.bearingTrue",
-          "value": 3.14
-        },
-        {
-          "path": "navigation.course.nextMark.greatCircle.bearingMagnetic",
-          "value": 3.14
-        },
-        {
-          "path": "navigation.course.nextMark.greatCircle.bearingDirectMagnetic",
-          "value": 3.14
-        },
-        {
-          "path": "navigation.course.nextMark.greatCircle.bearingDirectTrue",
-          "value": 3.14
-        },
-        {
-          "path": "navigation.course.nextMark.index",
-          "value": 4
-        },
-        {
-          "path": "navigation.course.lastMark.arrivalTime.timestamp",
-          "value": "2014-04-10T08:33:53Z"
-        },
-        {
-          "path": "navigation.course.nextMark.bearingDirectTrue",
-          "value": 3.14
-        }
-      ],
-      "source": {
-        "label": "mode",
-        "type": "self"
-      }
-    },
+
     {
       "timestamp": "2015-03-06T16:57:53.643+13:00",
       "values": [

--- a/test/data/course-delta.json
+++ b/test/data/course-delta.json
@@ -1,0 +1,138 @@
+{
+  "context": "vessels.urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "updates": [
+
+    {
+      "timestamp": "2014-04-10T08:33:53Z",
+      "values": [
+        {
+          "path": "navigation.course.xte",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.distanceToNextMark",
+          "value": 1114
+        },
+        {
+          "path": "navigation.course.courseRequiredTrue",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.lastMark",
+          "value": 3
+        },
+        {
+          "path": "navigation.course.bearingToNextMarkTrue",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.bearingToNextMarkMagnetic",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.eta.timestamp",
+          "value": "2014-04-10T08:33:53Z"
+        },
+        {
+          "path": "navigation.course.courseRequiredMagnetic",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.vmg",
+          "value": 10.14
+        },
+        {
+          "path": "navigation.course.timeToGo",
+          "value": 3114
+        }
+      ],
+      "source": {
+        "label": "mode",
+        "type": "self"
+      }
+    },
+    {
+      "timestamp": "2015-03-06T16:57:53.643+13:00",
+      "values": [
+        {
+          "path": "navigation.course.nextWaypoint",
+          "value": {
+            "longitude": 173.1693,
+            "latitude": -41.156426,
+            "altitude": 0
+          }
+        }
+      ],
+      "source": {
+        "label": "position",
+        "sentence": "RMC",
+        "talker": "GP",
+        "type": "NMEA0183"
+      }
+    },
+    {
+      "timestamp": "2014-04-10T08:33:53Z",
+      "values": [
+        {
+          "path": "navigation.course.bearingDirectMagnetic",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.greatCircle.distanceToNextMark",
+          "value": 1124
+        },
+        {
+          "path": "navigation.course.greatCircle.bearingToNextMarkTrue",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.greatCircle.bearingToNextMarkMagnetic",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.greatCircle.bearingDirectMagnetic",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.greatCircle.bearingDirectTrue",
+          "value": 3.14
+        },
+        {
+          "path": "navigation.course.nextMark",
+          "value": 4
+        },
+        {
+          "path": "navigation.course.startTime.timestamp",
+          "value": "2014-04-10T08:33:53Z"
+        },
+        {
+          "path": "navigation.course.bearingDirectTrue",
+          "value": 3.14
+        }
+      ],
+      "source": {
+        "label": "mode",
+        "type": "self"
+      }
+    },
+    {
+      "timestamp": "2015-03-06T16:57:53.643+13:00",
+      "values": [
+        {
+          "path": "navigation.course.lastWaypoint",
+          "value": {
+            "longitude": 173.1693,
+            "latitude": -41.156426,
+            "altitude": 0
+          }
+        }
+      ],
+      "source": {
+        "label": "position",
+        "sentence": "RMC",
+        "talker": "GP",
+        "type": "NMEA0183"
+      }
+    }
+  ]
+}

--- a/test/data/course-partial.json
+++ b/test/data/course-partial.json
@@ -4,74 +4,72 @@
       "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
       "navigation": {
         "course": {
-          "nextMark": {
-            "value": 4,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "lastMark": {
-            "value": 3,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "geometry": {
-            "type": "LineString",
-            "coordinates": [[173.1693,-41.156426],[173.1693,-41.156426],[173.1693,-41.156426]],
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "vmg": {
-            "value": 10.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "courseRequiredTrue": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "courseRequiredMagnetic": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "timeToGo": {
-            "value": 3114,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "xte": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "eta": {
-            "value": "2014-04-10T08:33:53Z",
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "startTime": {
-            "value": "2014-04-10T08:33:53Z",
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "bearingToNextMarkTrue": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "bearingToNextMarkMagnetic": {
-            "value": 3.14,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
-          },
-          "distanceToNextMark": {
-            "value": 1114,
-            "timestamp": "2014-04-10T08:33:53Z",
-            "$source": "sourceLabel.160"
+            "lastWaypoint": {
+              "position":{
+                  "timestamp": "2015-03-06T16:57:53.643+13:00",
+                  "$source":"sourceLabel.160",
+                  "longitude": 173.1693,
+                  "latitude": -41.156426,
+                  "altitude": 0
+                }
+            },
+            "nextWaypoint": {
+              "position":{
+                  "timestamp": "2015-03-06T16:57:53.643+13:00",
+                  "$source":"sourceLabel.160",
+                  "longitude": 173.1693,
+                  "latitude": -41.156426,
+                  "altitude": 0
+                }
+            },
+            "nextMark": {
+              "index":{
+                "value": 4,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "distance": {
+                "value": 1114,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingDirectTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingDirectMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              }
+            },
+            "lastMark": {
+              "index":{
+                "value": 3,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "arrivalTime": {
+                "value": "2014-04-10T08:33:53Z",
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              }
+            }
           }
+           
         }
       }
     }
   }
-}
+

--- a/test/data/course-partial.json
+++ b/test/data/course-partial.json
@@ -20,6 +20,15 @@
               "type": "self"
             }
           },
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [[173.1693,-41.156426],[173.1693,-41.156426],[173.1693,-41.156426]],
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
           "vmg": {
             "value": 10.14,
             "timestamp": "2014-04-10T08:33:53Z",

--- a/test/data/course-partial.json
+++ b/test/data/course-partial.json
@@ -1,0 +1,107 @@
+{
+  "vessels": {
+    "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
+      "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+      "navigation": {
+        "course": {
+          "nextMark": {
+            "value": 4,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "lastMark": {
+            "value": 3,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "vmg": {
+            "value": 10.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "courseRequiredTrue": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "courseRequiredMagnetic": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "timeToGo": {
+            "value": 3114,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "xte": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "eta": {
+            "value": "2014-04-10T08:33:53Z",
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "startTime": {
+            "value": "2014-04-10T08:33:53Z",
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "bearingToNextMarkTrue": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "bearingToNextMarkMagnetic": {
+            "value": 3.14,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          },
+          "distanceToNextMark": {
+            "value": 1114,
+            "timestamp": "2014-04-10T08:33:53Z",
+            "source": {
+              "label": "mode",
+              "type": "self"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/course.json
+++ b/test/data/course.json
@@ -1,0 +1,182 @@
+{
+  "vessels": {
+    "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
+      "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+      "navigation": {
+        "course": {
+            "lastWaypoint": {
+              "timestamp": "2015-03-06T16:57:53.643+13:00",
+              "source": {
+                "label": "position",
+                "type": "NMEA0183",
+                "talker": "GP",
+                "sentence": "RMC"
+              },
+              "longitude": 173.1693,
+              "latitude": -41.156426,
+              "altitude": 0
+            },
+            "nextWaypoint": {
+              "timestamp": "2015-03-06T16:57:53.643+13:00",
+              "source": {
+                "label": "position",
+                "type": "NMEA0183",
+                "talker": "GP",
+                "sentence": "RMC"
+              },
+              "longitude": 173.1693,
+              "latitude": -41.156426,
+              "altitude": 0
+            },
+            "nextMark": {
+              "value": 4,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "lastMark": {
+              "value": 3,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "vmg": {
+              "value": 10.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "courseRequiredTrue": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "courseRequiredMagnetic": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "timeToGo": {
+              "value": 3114,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "xte": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "eta": {
+              "timestamp": "2014-04-10T08:33:53Z"
+            },
+            "startTime": {
+              "timestamp": "2014-04-10T08:33:53Z"
+            },
+            "bearingToNextMarkTrue": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "bearingToNextMarkMagnetic": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "distanceToNextMark": {
+              "value": 1114,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "bearingDirectTrue": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "bearingDirectMagnetic": {
+              "value": 3.14,
+              "timestamp": "2014-04-10T08:33:53Z",
+              "source": {
+                "label": "mode",
+                "type": "self"
+              }
+            },
+            "greatCircle": {
+
+                "distanceToNextMark": {
+                  "value": 1124,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "source": {
+                    "label": "mode",
+                    "type": "self"
+                  }
+                },
+                "bearingToNextMarkTrue": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "source": {
+                    "label": "mode",
+                    "type": "self"
+                  }
+                },
+                "bearingToNextMarkMagnetic": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "source": {
+                    "label": "mode",
+                    "type": "self"
+                  }
+                },
+                "bearingDirectTrue": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "source": {
+                    "label": "mode",
+                    "type": "self"
+                  }
+                },
+                "bearingDirectMagnetic": {
+                  "value": 3.14,
+                  "timestamp": "2014-04-10T08:33:53Z",
+                  "source": {
+                    "label": "mode",
+                    "type": "self"
+                  }
+                }
+              
+            }
+
+        }
+      }
+    }
+  }
+}

--- a/test/data/course.json
+++ b/test/data/course.json
@@ -73,6 +73,11 @@
                 "timestamp": "2014-04-10T08:33:53Z",
                 "$source": "sourceLabel.160"
               },
+              "arrivalRadius": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
               "xte": {
                 "value": 3.14,
                 "timestamp": "2014-04-10T08:33:53Z",
@@ -82,36 +87,8 @@
                 "value": "2014-04-10T08:33:53Z",
                 "timestamp": "2014-04-10T08:33:53Z",
                 "$source": "sourceLabel.160"
-              },
-              "greatCircle": {
-
-                "distance": {
-                  "value": 1124,
-                  "timestamp": "2014-04-10T08:33:53Z",
-                  "$source": "sourceLabel.160"
-                },
-                "bearingTrue": {
-                  "value": 3.14,
-                  "timestamp": "2014-04-10T08:33:53Z",
-                  "$source": "sourceLabel.160"
-                },
-                "bearingMagnetic": {
-                  "value": 3.14,
-                  "timestamp": "2014-04-10T08:33:53Z",
-                  "$source": "sourceLabel.160"
-                },
-                "bearingDirectTrue": {
-                  "value": 3.14,
-                  "timestamp": "2014-04-10T08:33:53Z",
-                  "$source": "sourceLabel.160"
-                },
-                "bearingDirectMagnetic": {
-                  "value": 3.14,
-                  "timestamp": "2014-04-10T08:33:53Z",
-                  "$source": "sourceLabel.160"
-                }
+              }
               
-            }
             },
             "lastMark": {
               "index":{

--- a/test/data/course.json
+++ b/test/data/course.json
@@ -5,102 +5,97 @@
       "navigation": {
         "course": {
             "lastWaypoint": {
-              "timestamp": "2015-03-06T16:57:53.643+13:00",
-              "$source":"sourceLabel.160",
-              "longitude": 173.1693,
-              "latitude": -41.156426,
-              "altitude": 0
+              "position":{
+                  "timestamp": "2015-03-06T16:57:53.643+13:00",
+                  "$source":"sourceLabel.160",
+                  "longitude": 173.1693,
+                  "latitude": -41.156426,
+                  "altitude": 0
+                }
             },
             "nextWaypoint": {
-              "timestamp": "2015-03-06T16:57:53.643+13:00",
-              "$source": "sourceLabel.160",
-              "longitude": 173.1693,
-              "latitude": -41.156426,
-              "altitude": 0
+              "position":{
+                  "timestamp": "2015-03-06T16:57:53.643+13:00",
+                  "$source":"sourceLabel.160",
+                  "longitude": 173.1693,
+                  "latitude": -41.156426,
+                  "altitude": 0
+                }
             },
             "nextMark": {
-              "value": 4,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "lastMark": {
-              "value": 3,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "vmg": {
-              "value": 10.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "courseRequiredTrue": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "courseRequiredMagnetic": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "timeToGo": {
-              "value": 3114,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "xte": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "eta": {
-              "value": "2014-04-10T08:33:53Z",
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "startTime": {
-              "value": "2014-04-10T08:33:53Z",
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "bearingToNextMarkTrue": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "bearingToNextMarkMagnetic": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "distanceToNextMark": {
-              "value": 1114,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "bearingDirectTrue": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "bearingDirectMagnetic": {
-              "value": 3.14,
-              "timestamp": "2014-04-10T08:33:53Z",
-              "$source": "sourceLabel.160"
-            },
-            "greatCircle": {
+              "index":{
+                "value": 4,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "distance": {
+                "value": 1114,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingDirectTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "bearingDirectMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "vmg": {
+                "value": 10.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "courseRequiredTrue": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "courseRequiredMagnetic": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "timeToGo": {
+                "value": 3114,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "xte": {
+                "value": 3.14,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "eta": {
+                "value": "2014-04-10T08:33:53Z",
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "greatCircle": {
 
-                "distanceToNextMark": {
+                "distance": {
                   "value": 1124,
                   "timestamp": "2014-04-10T08:33:53Z",
                   "$source": "sourceLabel.160"
                 },
-                "bearingToNextMarkTrue": {
+                "bearingTrue": {
                   "value": 3.14,
                   "timestamp": "2014-04-10T08:33:53Z",
                   "$source": "sourceLabel.160"
                 },
-                "bearingToNextMarkMagnetic": {
+                "bearingMagnetic": {
                   "value": 3.14,
                   "timestamp": "2014-04-10T08:33:53Z",
                   "$source": "sourceLabel.160"
@@ -117,9 +112,29 @@
                 }
               
             }
-
+            },
+            "lastMark": {
+              "index":{
+                "value": 3,
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              },
+              "arrivalTime": {
+                "value": "2014-04-10T08:33:53Z",
+                "timestamp": "2014-04-10T08:33:53Z",
+                "$source": "sourceLabel.160"
+              }
+            },
+            "geometry": {
+            "type": "LineString",
+            "coordinates": [[173.1693,-41.156426],[173.1693,-41.156426],[173.1693,-41.156426]],
+            "timestamp": "2014-04-10T08:33:53Z",
+            "$source": "sourceLabel.160"
+            }
+          }
+           
         }
       }
     }
   }
-}
+

--- a/test/data/resource-position.json
+++ b/test/data/resource-position.json
@@ -15,7 +15,6 @@
           "position": {
             "timestamp": "2015-03-06T16:57:53.643+13:00",
             "$source": "nmea2.II",
-            "sentence": "RMC",
             "longitude": 173.1693,
             "latitude": -41.156426,
             "altitude": 0


### PR DESCRIPTION
Replaces #167 
Changes the `activeRoute` object to `course` and adds support for missing data including great circle values