### PR TITLE
Added agnostic target speed and target angle

### DIFF
--- a/schemas/groups/performance.json
+++ b/schemas/groups/performance.json
@@ -64,6 +64,18 @@
       "$ref": "../definitions.json#/definitions/numberValue",
       "units": "m/s"
     },
+    
+    "targetAngle": {
+      "description": "The true wind gybe or beat angle for the best velocity made good downwind based on current polar and trueWindSpeed.",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "rad"
+    },    
+    
+    "targetSpeed": {
+      "description": "The target speed for the beat angle or gybe angle, which ever is applicable.",
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "units": "m/s"
+    },
 
     "leeway": {
       "description": "Current leeway",

--- a/schemas/groups/performance.json
+++ b/schemas/groups/performance.json
@@ -66,7 +66,7 @@
     },
     
     "targetAngle": {
-      "description": "The true wind gybe or beat angle for the best velocity made good downwind based on current polar and trueWindSpeed.",
+      "description": "The true wind gybe or beat angle for the best velocity made good downwind or upwind based on current polar diagram and trueWindSpeed.",
       "$ref": "../definitions.json#/definitions/numberValue",
       "units": "rad"
     },    


### PR DESCRIPTION
Some instruments and equipment will give an NMEA value as target boat speed. Meaning if you are sailing too close hauled, you have lost speed and need to fall off and vice versa. This is taken from the polar diagram, but does not distinguish between beat or gybe.