### PR TITLE
add unitOfMeasure to sensors schema

### DIFF
--- a/schemas/groups/sensors.json
+++ b/schemas/groups/sensors.json
@@ -19,6 +19,11 @@
       "type": "string",
       "description": "The data of the sensor data. FIXME - need to ref the definitions of sensor types"
     },
+		
+		"unitOfMeasure": {
+			"type": "string",
+			"description": "The unit of measurement for the sensor data"
+		},
 
     "fromBow": {
       "$ref": "../definitions.json#/definitions/numberValue",


### PR DESCRIPTION
There should probably be a unit of measure for the sensor data so that the sensorData element can contain a simple value e.g. thinking about an XDR sentence

$YXXDR,C,7,C*54

C == sensorType (temperature)
7 ==  sensorData
C == unitOfMeasure (Celcius)

