### PR TITLE
Tidying up Propulsion Group

### DIFF
--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -35,7 +35,7 @@
       "units": "Hz"
     },
 
-    "temperature": {
+    "engineTemperature": {
       "description": "Engine temperature",
       "$ref": "../definitions.json#/definitions/numberValue",
       "units": "K"
@@ -63,18 +63,6 @@
       "description": "Total running time for engine",
       "$ref": "../definitions.json#/definitions/numberValue",
       "units": "s"
-    },
-
-    "oilTemperature": {
-      "description": "Engine temperature",
-      "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "K"
-    },
-
-    "coolantTemperature": {
-      "description": "Engine temperature",
-      "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "K"
     },
 
     "coolantPressure": {
@@ -194,24 +182,6 @@
           "units": "m3/s"
         }
       }
-    },
-
-    "waterTemperature": {
-      "description": "Water temperature",
-      "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "K"
-    },
-
-    "exhaustTemperature": {
-      "description": "Exhaust temperature",
-      "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "K"
-    },
-
-    "fuelRate": {
-      "description": "Fuel consumption rate",
-      "$ref": "../definitions.json#/definitions/numberValue",
-      "units": "m3/s"
     }
   }
 }


### PR DESCRIPTION
Too many temperatures in the propulsion group as Coolant and Exhaust Temp will be handled by the new Environment Temp object. Only include the specific temperatures where there are dedicated Propulsion PGN Fields; Engine Temp, Oil Temp and Trans Oil Temp, 

Fuel Rate was also repeated when it is included very well in the new Fuel Object level.