### PR TITLE
add time reference and make $source optional

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -276,9 +276,43 @@
                 "$ref": "#/definitions/valuesNumberValue"
               }
             }
+          },
+          "historic": {
+              "$ref": "#/definitions/valuesTimeValue"
+          },
+          "last24h": {
+              "$ref": "#/definitions/valuesTimeValue"
           }
         }
       }]
+    },
+
+    "valuesTimeValue": {
+      "type": "object",
+      "patternProperties": {
+        "description": "ISO-8601 (UTC) string representing date and time.",
+        ".*": {
+          "properties": {
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        "max": {
+          "properties": {
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        "min": {
+          "properties": {
+            "value": {
+              "type": "number"
+            }
+          }
+        }
+      }
     },
 
     "valuesNumberValue": {

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -233,7 +233,7 @@
 
     "commonValueFields": {
       "type": "object",
-      "required": ["timestamp", "$source"],
+      "required": ["timestamp"],
       "properties": {
         "timestamp": {
           "$ref": "#/definitions/timestamp"


### PR DESCRIPTION
1. Make $source optional 

It can be empty anyway. Not every system provides the source which also contains a lot of overhead.

2. Allowing to use a time reference to fetch "historic" data with the full format. 

There would be two options
i) use an array "historic": [{"value":3.7, "timestamp":"..."}]
ii) make a path-able reference as in this commit, this will allow for mostly everything discussed in wiki's RFC  [time reference model](https://github.com/SignalK/specification/wiki/RFC---time-reference-model)

There might be more elegant JSON schema ways to express the same thing.

I also propose to use parameters ?startAfter=<timestamp>&endBefore=<timestamp>&limit=100 in order to request historic data. This would work for GET and ws. 

The delta format has the possibility for delivering historic data since values are delivered in an array. 