### PR TITLE
Add GC/RL distinction

### DIFF
--- a/keyswithmetadata.json
+++ b/keyswithmetadata.json
@@ -55,47 +55,91 @@
     "description": "Course over ground (true)",
     "units": "rad"
   },
-  "navigation.course.crossTrackError": {
+  "navigation.courseRhumbline.crossTrackError": {
     "description": "The distance from the vessel's present position to the closest point on a line (track) between previousPoint and nextPoint. A negative number indicates that the vessel is currently to the left of this line (and thus must steer right to compensate), a positive number means the vessel is to the right of the line (steer left to compensate).",
     "units": "m"
   },
-  "navigation.course.bearingTrackTrue": {
+  "navigation.courseRhumbline.bearingTrackTrue": {
     "description": "The bearing of a line between previousPoint and nextPoint, relative to true north.",
     "units": "rad"
   },
-  "navigation.course.bearingTrackMagnetic": {
+  "navigation.courseRhumbline.bearingTrackMagnetic": {
     "description": "The bearing of a line between previousPoint and nextPoint, relative to magnetic north.",
     "units": "rad"
   },
-  "navigation.course.activeRoute.estimatedTimeOfArrival.$ref": {
+  "navigation.courseRhumbline.activeRoute.estimatedTimeOfArrival.$ref": {
     "description": "ISO-8601 (UTC) string representing date and time.",
     "units": "ISO-8601 (UTC)"
   },
-  "navigation.course.activeRoute.startTime.$ref": {
+  "navigation.courseRhumbline.activeRoute.startTime.$ref": {
     "description": "ISO-8601 (UTC) string representing date and time.",
     "units": "ISO-8601 (UTC)"
   },
-  "navigation.course.nextPoint.distance": {
+  "navigation.courseRhumbline.nextPoint.distance": {
     "description": "The distance in meters between the vessel's present position and the nextPoint",
     "units": "m"
   },
-  "navigation.course.nextPoint.bearingTrue": {
+  "navigation.courseRhumbline.nextPoint.bearingTrue": {
     "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north",
     "units": "rad"
   },
-  "navigation.course.nextPoint.bearingMagnetic": {
+  "navigation.courseRhumbline.nextPoint.bearingMagnetic": {
     "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north",
     "units": "rad"
   },
-  "navigation.course.nextPoint.velocityMadeGood": {
+  "navigation.courseRhumbline.nextPoint.velocityMadeGood": {
     "description": "The velocity component of the vessel towards the nextPoint",
     "units": "m/s"
   },
-  "navigation.course.nextPoint.timeToGo": {
+  "navigation.courseRhumbline.nextPoint.timeToGo": {
     "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction",
     "units": "s"
   },
-  "navigation.course.previousPoint.distance": {
+  "navigation.courseRhumbline.previousPoint.distance": {
+    "description": "The distance in meters between previousPoint and the vessel's present position",
+    "units": "m"
+  },
+  "navigation.courseGreatCircle.crossTrackError": {
+    "description": "The distance from the vessel's present position to the closest point on a line (track) between previousPoint and nextPoint. A negative number indicates that the vessel is currently to the left of this line (and thus must steer right to compensate), a positive number means the vessel is to the right of the line (steer left to compensate).",
+    "units": "m"
+  },
+  "navigation.courseGreatCircle.bearingTrackTrue": {
+    "description": "The bearing of a line between previousPoint and nextPoint, relative to true north.",
+    "units": "rad"
+  },
+  "navigation.courseGreatCircle.bearingTrackMagnetic": {
+    "description": "The bearing of a line between previousPoint and nextPoint, relative to magnetic north.",
+    "units": "rad"
+  },
+  "navigation.courseGreatCircle.activeRoute.estimatedTimeOfArrival.$ref": {
+    "description": "ISO-8601 (UTC) string representing date and time.",
+    "units": "ISO-8601 (UTC)"
+  },
+  "navigation.courseGreatCircle.activeRoute.startTime.$ref": {
+    "description": "ISO-8601 (UTC) string representing date and time.",
+    "units": "ISO-8601 (UTC)"
+  },
+  "navigation.courseGreatCircle.nextPoint.distance": {
+    "description": "The distance in meters between the vessel's present position and the nextPoint",
+    "units": "m"
+  },
+  "navigation.courseGreatCircle.nextPoint.bearingTrue": {
+    "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north",
+    "units": "rad"
+  },
+  "navigation.courseGreatCircle.nextPoint.bearingMagnetic": {
+    "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north",
+    "units": "rad"
+  },
+  "navigation.courseGreatCircle.nextPoint.velocityMadeGood": {
+    "description": "The velocity component of the vessel towards the nextPoint",
+    "units": "m/s"
+  },
+  "navigation.courseGreatCircle.nextPoint.timeToGo": {
+    "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction",
+    "units": "s"
+  },
+  "navigation.courseGreatCircle.previousPoint.distance": {
     "description": "The distance in meters between previousPoint and the vessel's present position",
     "units": "m"
   },

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -4,6 +4,146 @@
   "id": "https://signalk.github.io/specification/schemas/groups/navigation.json#",
   "description": "Schema describing the navigation child-object of a Vessel.",
   "title": "navigation",
+
+  "definitions": {
+    "course": {
+      "type": "object",
+      "title": "Course",
+      "description": "The currently active course (can be a route, or just a point one is navigating towards)",
+      "properties": {
+        "crossTrackError": {
+          "description": "The distance from the vessel's present position to the closest point on a line (track) between previousPoint and nextPoint. A negative number indicates that the vessel is currently to the left of this line (and thus must steer right to compensate), a positive number means the vessel is to the right of the line (steer left to compensate).",
+          "units": "m",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "bearingTrackTrue": {
+          "description": "The bearing of a line between previousPoint and nextPoint, relative to true north.",
+          "units": "rad",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "bearingTrackMagnetic": {
+          "description": "The bearing of a line between previousPoint and nextPoint, relative to magnetic north.",
+          "units": "rad",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+
+        "activeRoute": {
+          "type": "object",
+          "properties": {
+            "href": {
+              "description": "A reference (URL) to the presently active route, in resources.",
+              "example": "/resources/routes/urn:mrn:signalk:uuid:3dd34dcc-36bf-4d61-ba80-233799b25672",
+              "type": "string"
+            },
+            "estimatedTimeOfArrival": {
+              "$ref": "../definitions.json#/definitions/timestamp",
+              "description": "The estimated time of arrival at the end of the current route"
+            },
+
+            "startTime": {
+              "$ref": "../definitions.json#/definitions/timestamp",
+              "description": "The time this route was activated"
+            }
+          }
+        },
+
+        "nextPoint": {
+          "type": "object",
+          "description": "The point on earth the vessel's presently navigating towards",
+          "allOf": [{
+            "$ref": "../definitions.json#/definitions/commonValueFields"
+          }, {
+            "properties": {
+              "type": {
+                "description": "The type of the next point (e.g. Waypoint, POI, Race Mark, etc)",
+                "type": "string"
+              },
+              "href": {
+                "description": "A reference (URL) to an object (under resources) this point is related to",
+                "type": "string"
+              },
+              "distance": {
+                "description": "The distance in meters between the vessel's present position and the nextPoint",
+                "units": "m",
+                "type": "number"
+              },
+              "bearingTrue": {
+                "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north",
+                "units": "rad",
+                "type": "number"
+              },
+              "bearingMagnetic": {
+                "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north",
+                "units": "rad",
+                "type": "number"
+              },
+              "velocityMadeGood": {
+                "description": "The velocity component of the vessel towards the nextPoint",
+                "units": "m/s",
+                "type": "number"
+              },
+              "timeToGo": {
+                "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction",
+                "units": "s",
+                "type": "number"
+              },
+              "position": {
+                "type": "object",
+                "description": "The position of nextPoint in two dimensions",
+                "properties": {
+                  "latitude": {
+                    "type": "number"
+                  },
+                  "longitude": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }]
+        },
+
+        "previousPoint": {
+          "type": "object",
+          "description": "The point on earth the vessel's presently navigating from",
+          "allOf": [{
+            "$ref": "../definitions.json#/definitions/commonValueFields"
+          }, {
+            "properties": {
+              "type": {
+                "description": "The type of the previous point (e.g. Waypoint, POI, Race Mark, etc)",
+                "type": "string"
+              },
+              "href": {
+                "description": "A reference (URL) to an object (under resources) this point is related to",
+                "type": "string"
+              },
+              "distance": {
+                "description": "The distance in meters between previousPoint and the vessel's present position",
+                "units": "m",
+                "type": "number"
+              },
+              "position": {
+                "type": "object",
+                "description": "The position of lastPoint in two dimensions",
+                "properties": {
+                  "latitude": {
+                    "type": "number"
+                  },
+                  "longitude": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }]
+        }
+      }
+    }
+  },
+
   "properties": {
     "lights": {
       "type": "object",
@@ -62,204 +202,70 @@
       "units": "rad"
     },
 
-    "course": {
-      "type": "object",
-      "title": "Course",
-      "description": "The currently active course (can be a route, or just a point one is navigating towards)",
-      "properties": {
-        "crossTrackError": {
-          "description": "The distance from the vessel's present position to the closest point on a line (track) between previousPoint and nextPoint. A negative number indicates that the vessel is currently to the left of this line (and thus must steer right to compensate), a positive number means the vessel is to the right of the line (steer left to compensate).",
-          "units": "m",
-          "$ref": "../definitions.json#/definitions/numberValue"
-        },
-
-        "bearingTrackTrue": {
-          "description": "The bearing of a line between previousPoint and nextPoint, relative to true north.",
-          "units": "rad",
-          "$ref": "../definitions.json#/definitions/numberValue"
-        },
-
-        "bearingTrackMagnetic": {
-          "description": "The bearing of a line between previousPoint and nextPoint, relative to magnetic north.",
-          "units": "rad",
-          "$ref": "../definitions.json#/definitions/numberValue"
-        },
-
-        "activeRoute": {
-          "type": "object",
-          "properties": {
-            "href": {
-              "description": "A reference (URL) to the presently active route, in resources.",
-              "example": "/resources/routes/urn:mrn:signalk:uuid:3dd34dcc-36bf-4d61-ba80-233799b25672",
-              "type": "string"
-            },
-            "estimatedTimeOfArrival": {
-              "$ref": "../definitions.json#/definitions/timestamp",
-              "description": "The estimated time of arrival at the end of the current route"
-            },
-
-            "startTime": {
-              "$ref": "../definitions.json#/definitions/timestamp",
-              "description": "The time this route was activated"
-            }
-          }
-        },
-
-        "nextPoint": {
-          "type": "object",
-          "description": "The point on earth the vessel's presently navigating towards",
-          "allOf": [
-            {
-              "$ref": "../definitions.json#/definitions/commonValueFields"
-            },
-            {
-              "properties": {
-                "type": {
-                  "description": "The type of the next point (e.g. Waypoint, POI, Race Mark, etc)",
-                  "type": "string"
-                },
-                "href": {
-                  "description": "A reference (URL) to an object (under resources) this point is related to",
-                  "type": "string"
-                },
-                "distance": {
-                  "description": "The distance in meters between the vessel's present position and the nextPoint",
-                  "units": "m",
-                  "type": "number"
-                },
-                "bearingTrue": {
-                  "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north",
-                  "units": "rad",
-                  "type": "number"
-                },
-                "bearingMagnetic": {
-                  "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north",
-                  "units": "rad",
-                  "type": "number"
-                },
-                "velocityMadeGood": {
-                  "description": "The velocity component of the vessel towards the nextPoint",
-                  "units": "m/s",
-                  "type": "number"
-                },
-                "timeToGo": {
-                  "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction",
-                  "units": "s",
-                  "type": "number"
-                },
-                "position": {
-                  "type": "object",
-                  "description": "The position of nextPoint in two dimensions",
-                  "properties": {
-                    "latitude": {
-                      "type": "number"
-                    },
-                    "longitude": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
-
-        "previousPoint": {
-          "type": "object",
-          "description": "The point on earth the vessel's presently navigating from",
-          "allOf": [
-            {
-              "$ref": "../definitions.json#/definitions/commonValueFields"
-            },
-            {
-              "properties": {
-                "type": {
-                  "description": "The type of the previous point (e.g. Waypoint, POI, Race Mark, etc)",
-                  "type": "string"
-                },
-                "href": {
-                  "description": "A reference (URL) to an object (under resources) this point is related to",
-                  "type": "string"
-                },
-                "distance": {
-                  "description": "The distance in meters between previousPoint and the vessel's present position",
-                  "units": "m",
-                  "type": "number"
-                },
-                "position": {
-                  "type": "object",
-                  "description": "The position of lastPoint in two dimensions",
-                  "properties": {
-                    "latitude": {
-                      "type": "number"
-                    },
-                    "longitude": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        }
-      }
+    "courseRhumbline": {
+      "description": "Course information computed with Rhumbline",
+      "$ref": "#/definitions/course"
+    },
+    "courseGreatCircle": {
+      "description": "Course information computed with Great Circle",
+      "$ref": "#/definitions/course"
     },
 
-  	"racing" :{
-  		"type": "object",
-  		"properties": {
-  			"startLineStb" :{
-  				"waypoint": {
-  					"description": "UUID of waypoint for starboard start mark",
-  					"type": "string"
-  				}
-  			},
-  			"startLinePort" :{
-  				"waypoint": {
-  					"description": "UUID of waypoint for port start mark",
-  					"type": "string"
-  				}
-  			},
-  			"distanceStartline": {
-  				"type": "number",
-  				"description": "The current distance to the start line",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "m"
-  			},
-  			"timeToStart": {
-  				"description": "Time left before start",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "s"
-  			},
-  			"timePortDown": {
-  				"description": "Time to arrive at the start line on port, turning downwind",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "s"
-  			},
-  			"timePortUp": {
-  				"description": "Time to arrive at the start line on port, turning upwind",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "s"
-  			},
-  			"timeStbdDown": {
-  				"description": "Time to arrive at the start line on starboard, turning downwind",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "s"
-  			},
-  			"timeStbdUp": {
-  				"description": "Time to arrive at the start line on starboard, turning upwind",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "s"
-  			},
-  			"distanceLayline": {
-  				"type": "number",
-  				"description": "The current distance to the layline",
-  				"$ref": "../definitions.json#/definitions/numberValue",
-  				"units": "m"
-  			}
+    "racing": {
+      "type": "object",
+      "properties": {
+        "startLineStb": {
+          "waypoint": {
+            "description": "UUID of waypoint for starboard start mark",
+            "type": "string"
+          }
+        },
+        "startLinePort": {
+          "waypoint": {
+            "description": "UUID of waypoint for port start mark",
+            "type": "string"
+          }
+        },
+        "distanceStartline": {
+          "type": "number",
+          "description": "The current distance to the start line",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "m"
+        },
+        "timeToStart": {
+          "description": "Time left before start",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "s"
+        },
+        "timePortDown": {
+          "description": "Time to arrive at the start line on port, turning downwind",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "s"
+        },
+        "timePortUp": {
+          "description": "Time to arrive at the start line on port, turning upwind",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "s"
+        },
+        "timeStbdDown": {
+          "description": "Time to arrive at the start line on starboard, turning downwind",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "s"
+        },
+        "timeStbdUp": {
+          "description": "Time to arrive at the start line on starboard, turning upwind",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "s"
+        },
+        "distanceLayline": {
+          "type": "number",
+          "description": "The current distance to the layline",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "m"
+        }
 
-  		}
-  	},
+      }
+    },
 
     "magneticVariation": {
       "$ref": "../definitions.json#/definitions/numberValue",

--- a/test/data/course.json
+++ b/test/data/course.json
@@ -13,7 +13,59 @@
       },
 
       "navigation": {
-        "course": {
+        "courseGreatCircle": {
+          "crossTrackError": {
+            "value": -8.67,
+            "timestamp": "(...)",
+            "$source": "(...)"
+          },
+
+          "bearingTrackTrue": {
+            "value": 0.9162978572970231,
+            "timestamp": "(...)",
+            "$source": "(...)"
+          },
+
+          "bearingTrackMagnetic": {
+            "value": 1.1986521,
+            "timestamp": "(...)",
+            "$source": "(...)"
+          },
+
+          "activeRoute": {
+            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/routes/urn:mrn:signalk:uuid:3dd34dcc-36bf-4d61-ba80-233799b25672",
+            "estimatedTimeOfArrival": "2016-04-24T06:24:18.632Z",
+            "startTime": "2016-04-24T05:14:18.632Z"
+          },
+
+          "nextPoint": {
+            "type": "Waypoint",
+            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:4fe4ff38-879a-46ed-9a7d-7caeea475241",
+            "distance": 2407.6000020320143,
+            "bearingTrue": 0.9162978572970231,
+            "velocityMadeGood": 0.2572222873852017,
+            "timeToGo": 9628,
+            "position": {
+              "latitude": 49.287333333333336,
+              "longitude": -123.1595
+            },
+            "timestamp": "(...)",
+            "$source": "(...)"
+          },
+
+          "previousPoint": {
+            "type": "Waypoint",
+            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:dd4a4c06-0c1d-4b5e-90c3-963649ee5e6d",
+            "position": {
+              "latitude": 49.287333333333336,
+              "longitude": -123.1595
+            },
+            "timestamp": "(...)",
+            "$source": "(...)"
+          }
+        },
+
+        "courseRhumbline": {
           "crossTrackError": {
             "value": -8.67,
             "timestamp": "(...)",


### PR DESCRIPTION
Create two course subtrees, one for Great Circle calculated values and
the other for Rhumbline calculated ones.

Fixes #219 