### PR TITLE
Tank Senders only provide tank level value

### DIFF
--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -34,8 +34,14 @@
               "units": "m3"
             },
 
+            "currentLevel": {
+              "description": "Level of fluid in tank 0-100%",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "ratio"
+            },
+            
             "currentVolume": {
-              "description": "Amount of fluid in tank",
+              "description": "Volume of fluid in tank",
               "units": "m3",
               "$ref": "../definitions.json#/definitions/numberValue"
             }


### PR DESCRIPTION
We need a Level field as at the moment we only have a Current Volume field which is a derived value only available if you know the capacity of the tank - tank senders only send a level value 0-100