### PR TITLE
Added chart scale, and some new charts types

### DIFF
--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -42,6 +42,10 @@
               "type": "string",
               "description": "A url to the chart file's storage location"
             },
+            "scale": {
+              "type": "integer",
+              "description": "The scale of the chart, the larger number from 1:200000"
+            },
             "chartFormat": {
               "type": "string",
               "description": "The format of the chart",
@@ -55,7 +59,12 @@
                 "wkt",
                 "topojson",
                 "geojson",
-                "gpx"
+                "gpx",
+                "tms",
+                "S-57",
+                "S-63",
+                "svg",
+                "other"
               ]
             },
             "timestamp": {


### PR DESCRIPTION
Ive been working on my web chartplotter and I can store and retrieve charts nicely, but I cant easily derive the scale of the chart. This means I cant arrange the layer stack on screen and hi-res charts hide under low-res charts, etc

Adding scale fixes this.