### PR TITLE
Make tank capacity numberValue

### DIFF
--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -30,7 +30,7 @@
 
             "capacity": {
               "description": "Total capacity",
-              "type": "number",
+              "$ref": "../definitions.json#/definitions/numberValue",
               "units": "m3"
             },
 
@@ -39,7 +39,7 @@
               "$ref": "../definitions.json#/definitions/numberValue",
               "units": "ratio"
             },
-            
+
             "currentVolume": {
               "description": "Volume of fluid in tank",
               "units": "m3",

--- a/test/data/tanks.json
+++ b/test/data/tanks.json
@@ -3,7 +3,11 @@
   "tanks": {
     "freshWater": {
       "main": {
-        "capacity": 0.12,
+        "capacity": {
+          "value": 31.7,
+          "$source": "foo.bar",
+          "timestamp": "2014-08-15-19:00:15.402"
+        },
         "currentVolume": {
           "value": 0.0887,
           "$source": "foo.bar",


### PR DESCRIPTION
Tank capacity should be a Signal K numberValue (with value/values/timestamp/source info) instead of a regular number, because it can be updated from for example PGN 127505. 

See also https://github.com/SignalK/n2k-signalk/pull/32