### PR TITLE
RFC0004 :Replace JsonPath with wildcard in subscription paths

### DIFF
--- a/gitbook-docs/subscription_protocol.md
+++ b/gitbook-docs/subscription_protocol.md
@@ -69,8 +69,8 @@ To subscribe to the required criteria send a suitable subscribe message:
 }
 ```
 
-* `path=[path.to.key]` is appended to the context to specify subsets of the context. The path value can use jsonPath
-  syntax.
+* `path=[path.to.key]` is appended to the context to specify subsets of the context.
+The path value can use the wildcard `*`. A wildcard in the middle of a path (`propulsion/*/oilTemperature`) allows any value for that part and a wildcard at the end (`propulsion/port/*`) matches all paths beginning with the specified prefix.
 
 The following are optional, included above only for example as it uses defaults anyway:
 


### PR DESCRIPTION
# Summary
[summary]: #summary

This RFC proposes replacing the [JsonPath](http://goessner.net/articles/JsonPath/) expression specified in the subscription protocol with simple wildcards.


# Motivation
[motivation]: #motivation

Current subscription protocol specifies that the path expression can be JsonPath expressions.

I believe that JsonPath is needlessly complex here.

Subscriptions can be expressed sufficiently with the use of a simple wildcard, making server implementation considerably easier.

# Detailed design
[design]: #detailed-design

See diff in this pull request. 

The specification change is mainly in the documentation. Subscription message schema could be enhanced with a regexp.

# Drawbacks

We lose the expressiveness of JsonPath.

# Alternatives
[alternatives]: #alternatives

We could specify the JsonPath support as optional and wildcard support as part of minimal subscription support, but then we would have to deal with complexity of informing the client about which parts the server supports.

# Unresolved questions
[unresolved]: #unresolved-questions



