### PR TITLE
Use wildcard context in example, mention wildcard

### DIFF
--- a/gitbook-docs/subscription_protocol.md
+++ b/gitbook-docs/subscription_protocol.md
@@ -36,11 +36,11 @@ By default a Signal K server will provide a new WebSocket client with a delta st
 
 This can be a lot of messages, many you may not need, especially if `vessel.self` has many sensors, or other data sources. Generally you will want to subscribe to a much smaller range of data.
 
-First you will want to unsubscribe from the current default (or you may have already connected with `ws://hostname/signalk/v1/stream?subscribe=none`). To unsubscribe all create an `unsubscribe` message and send the message over the websocket connection:
+First you will want to unsubscribe from the current default (or you may have already connected with `ws://hostname/signalk/v1/stream?subscribe=none`). To unsubscribe all create an `unsubscribe` message with wildcards and send the message over the websocket connection:
 
 ```json
 {
-  "context": "vessels.self",
+  "context": "*",
   "unsubscribe": [
     {
       "path": "*"


### PR DESCRIPTION
As I am in the middle of implementing subscriptions I am reading the spec and it is pretty unclear in places. The text says `To unsubscribe all` but the example unsubscribe has `vessels.self` context.

This update makes this part a bit more clear and updates the example unsubscribe message to actually unsubscribe all.