### PR TITLE
Validate missing schema references & fix missing references

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,12 @@ function getTv4() {
   for (var schema in subSchemas) {
     tv4.addSchema('https://signalk.github.io/specification/schemas/groups/' + schema + '.json', subSchemas[schema]);
   }
+
+  // HACK! two different IDs should not point to the same schema
+  var externalGeometry = require('./schemas/external/geojson/geometry.json');
+  tv4.addSchema('https://signalk.github.io/specification/schemas/external/geojson/geometry.json', externalGeometry);
+  tv4.addSchema('http://json-schema.org/geojson/geometry.json', externalGeometry);
+
   return tv4;
 }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "JSONStream": "^0.7.4",
     "chai": "^1.9.2",
     "debug": "^2.2.0",
+    "json-schema-ref-parser": "^3.1.2",
     "lodash": "^3.10.1",
     "tv4": "^1.2.7"
   },

--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -405,7 +405,7 @@
                 },
 
                 "$source": {
-                  "$ref": "../definitions.json#/definitions/$source"
+                  "$ref": "../definitions.json#/definitions/sourceRef"
                 }
               }
             }

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -136,7 +136,7 @@
                       ]
                     },
                     "coordinates": {
-                      "$ref": "#/definitions/lineString"
+                      "$ref": "../external/geojson/geometry.json#/definitions/lineString"
                     }
                   }
                 },
@@ -252,7 +252,7 @@
                           ]
                         },
                         "coordinates": {
-                          "$ref": "#/definitions/polygon"
+                          "$ref": "../external/geojson/geometry.json#/definitions/polygon"
                         }
                       }
                     },
@@ -267,7 +267,7 @@
                         "coordinates": {
                           "type": "array",
                           "items": {
-                            "$ref": "#/definitions/polygon"
+                            "$ref": "../external/geojson/geometry.json#/definitions/polygon"
                           }
                         }
                       }

--- a/schemas/groups/sources.json
+++ b/schemas/groups/sources.json
@@ -21,7 +21,7 @@
                   "type": "object",
                   "patternProperties": {
                     "^[A-Z][A-Z][A-Z]$": {
-                      "$ref": "#/definitions/timestamp"
+                      "$ref": "../definitions.json#/definitions/timestamp"
                     }
                   }
                 },
@@ -37,7 +37,7 @@
                       "description": "NMEA 2000 pgn number",
                       "patternProperties": {
                         "[0-9]*": {
-                          "$ref": "#/definitions/timestamp"
+                          "$ref": "../definitions.json#/definitions/timestamp"
                         }
                       }
                     },

--- a/test/schemaReferences.js
+++ b/test/schemaReferences.js
@@ -1,6 +1,8 @@
 var assert = require('chai').assert
 
 var signalk = require('../');
+var RefParser = require('json-schema-ref-parser');
+var path = require('path');
 
 describe('Schema references', function() {
   it('missing files are not referenced', function() {
@@ -9,5 +11,15 @@ describe('Schema references', function() {
 
     tv4.validate({}, signalkSchema);
     assert.lengthOf(tv4.getMissingUris(), 0, 'There should be no missing schema uris, but found ' + tv4.getMissingUris());
+  })
+
+  it('all references are valid', function(done) {
+    RefParser.dereference(path.join(__dirname, '../schemas/signalk.json'), function(err, schema) {
+      if (err) {
+        done(err);
+      } else {
+        done();
+      }
+    });
   })
 });

--- a/test/schemaReferences.js
+++ b/test/schemaReferences.js
@@ -3,7 +3,7 @@ var assert = require('chai').assert
 var signalk = require('../');
 
 describe('Schema references', function() {
-  it('all references are valid', function() {
+  it('missing files are not referenced', function() {
     var signalkSchema = require('../schemas/signalk.json');
     var tv4 = signalk.getTv4();
 


### PR DESCRIPTION
These changes add a test for missing schema references. The already existing test actually didn't try to resolve the reference key paths, it was only concerned about files. The changeset also includes fixes for missing schema references.

The fixes include some trivial changes and one that is largely in progress. The trivial ones are:
1. accidentally referring to `$source` instead of `sourceRef`
2. lacking `../definitions.json`

The more WIP one is the handling of `lineString` and `polygon` references in `groups/resources.json`. Do you have any input @rob42? Right now I just reference the `external/geojson/geometry.json` using relative links. This however leads to certain issues as the ID of the `geometry.json` schema is `http://json-schema.org/geojson/geometry.json` (which BTW is a 404). One way would be to bring the external schemas under Signal K related ID. 