### PR TITLE
Add Transverse Water Speed and Leeway Angle

### DIFF
--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -432,17 +432,17 @@
     },
     "speedThroughWater": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Vessel speed through the water",
+      "description": "Vessel speed through the water (longitudinal)",
       "units": "m/s"
     },
-    "speedTransverseWater": {
+    "speedThroughWaterTransverse": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Transverse speed through the water (Leeway)",
       "units": "m/s"
     },
     "leewayAngle": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Leeway Angle derived from transverse speed through the water",
+      "description": "Leeway Angle derived from the longitudinal and transverse speeds through the water",
       "units": "rad"
     },
     "log": {

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -435,6 +435,16 @@
       "description": "Vessel speed through the water",
       "units": "m/s"
     },
+    "speedTransverseWater": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Transverse speed through the water (Leeway)",
+      "units": "m/s"
+    },
+    "leewayAngle": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Leeway Angle derived from transverse speed through the water",
+      "units": "rad"
+    },
     "log": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Log value",

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -432,12 +432,17 @@
     },
     "speedThroughWater": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Vessel speed through the water (longitudinal)",
+      "description": "Vessel speed through the water",
       "units": "m/s"
     },
     "speedThroughWaterTransverse": {
       "$ref": "../definitions.json#/definitions/numberValue",
       "description": "Transverse speed through the water (Leeway)",
+      "units": "m/s"
+    },
+     "speedThroughWaterLongitudinal": {
+      "$ref": "../definitions.json#/definitions/numberValue",
+      "description": "Longitudinal speed through the water (outside boundary layer)",
       "units": "m/s"
     },
     "leewayAngle": {


### PR DESCRIPTION
A new generation of electro magnetic transducers that can measure the boat's speed through the water both longitudinal and transverse will provide a view of the boat's "Leeway" that was previously difficult to accurately calculate. Signal K needs to support these new transducers which will output the VBW sentence or PGN 130578.