### PR TITLE
Introduction of raw TCP rules

### DIFF
--- a/gitbook-docs/README.md
+++ b/gitbook-docs/README.md
@@ -11,7 +11,7 @@ version.
 ## What is Signal K?
 
 **Signal K** is a modern and open data format for marine use. It is an Internet friendly standard built on standard web
-technologies, such as JSON and WebSockets. Signal K is Free and Open Source software. This document is licensed under
+technologies. Signal K is Free and Open Source software. This document is licensed under
 the Creative Commons [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/) license. All Signal K source code is
 licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). Signal K is developed in
 the open with help from the marine community. Your ideas and feedback are valuable and welcome.
@@ -48,7 +48,7 @@ understood by existing devices without the need for firmware upgrades.
 
 Signal K does not define the transport or wire protocol. Signal K messages are JSON text and can be sent over almost any
 transport layer. However, we do provide guidance on how to make an initial connection, handle negotiation,
-subscription, and disconnection for a given transport (e.g. TCP/IP or serial).
+subscription, and disconnection for a range of transports (e.g. TCP/IP or serial).
 
 Where possible we use well established standards like HTTPS, REST, WebSockets, MQTT, STOMP, etc. But within each method
 there are always many options in message addressing, formating, or transfer (GET, POST), etc.

--- a/gitbook-docs/SUMMARY.md
+++ b/gitbook-docs/SUMMARY.md
@@ -12,7 +12,7 @@
 * [API]()
   * [Ports, Urls and Versioning](urls_etc.md)
   * [REST API](rest_api.md)
-  * [Streaming WebSocket API](streaming_api.md)
+  * [Streaming API (TCP sockets and Websockets)](streaming_api.md)
   * [Discovery & Connection Establishment](connection.md)
   * [Subscription Protocol](subscription_protocol.md)
 * [Background and Design Rationale](design_notes.md)

--- a/gitbook-docs/connection.md
+++ b/gitbook-docs/connection.md
@@ -1,3 +1,4 @@
+
 # Discovery and Connection Establishment
 
 #### Service Discovery
@@ -56,6 +57,7 @@ Using the information above a web client or http capable device can discover and
             "version": "1.1.2",
             "signalk-http": "http://192.168.1.2/signalk/v1/api/",
             "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
+            "signalk-tcp": "tcp://192.168.1.2:3858"
         }
      }
  }

--- a/gitbook-docs/connection.md
+++ b/gitbook-docs/connection.md
@@ -1,4 +1,3 @@
-
 # Discovery and Connection Establishment
 
 #### Service Discovery
@@ -56,7 +55,7 @@ Using the information above a web client or http capable device can discover and
         "v1": {
             "version": "1.1.2",
             "signalk-http": "http://192.168.1.2/signalk/v1/api/",
-            "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
+            "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream",
             "signalk-tcp": "tcp://192.168.1.2:3858"
         }
      }

--- a/gitbook-docs/connection.md
+++ b/gitbook-docs/connection.md
@@ -6,6 +6,7 @@ A Signal K server SHOULD advertise its services over mDNS/Bonjour. The server MU
 
 * `_signalk-http._tcp` for http API
 * `_signalk-ws._tcp` for WebSocket
+* `_signalk-tcp._tcp` for raw TCP socket
 * `_signalk-https._tcp` for HTTPS API
 * `_signalk-wss._tcp` for secure WebSocket
 

--- a/gitbook-docs/service_discovery.md
+++ b/gitbook-docs/service_discovery.md
@@ -4,6 +4,7 @@ A Signal K server SHOULD advertise its services over mDNS/Bonjour. The server MU
 
 * `_signalk-http._tcp` for http API
 * `_signalk-ws._tcp` for WebSocket
+* `_signalk-tcp._tcp` for raw TCP socket
 * `_signalk-https._tcp` for HTTPS API
 * `_signalk-wss._tcp` for secure WebSocket
 

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -23,3 +23,17 @@ Upon connection a 'hello' message is sent as follows:
   "self": "123456789"
 }
 ```
+
+#### Streaming: raw TCP sockets
+
+A signalk server MAY stream signalk-delta over a raw TCP socket.
+
+When signalk-delta is streamed over a raw TCP socket:
+
+1. The first character of each signalk-delta message MUST be the openning curly bracke (char(123), '{').
+2. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent after the final closing curly bracket (char(125), '}').
+3. The server SHOULD send signalk-delta in a compact manner with any unnessesary white space removed.
+4. The server MAY also send sentences for other protocals (e.g. NMEA0183) interleaved with the signalk-delta messages provided that sentences of the other protocal:
+  a) Can not start with a curly bracket first character and 
+  b) Are terminated by a carriage retrun and new line (char(10) + char(13), '\r\n')
+5. The client MUST not assume that only signalk-delta will be sent over the socket.

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -26,10 +26,12 @@ Upon connection a 'hello' message is sent as follows:
 
 #### Streaming: TCP sockets
 
-A Signal K server MAY stream signalk-delta over a TCP socket.
+A network node MAY stream signalk-delta over a TCP socket.
 
-When signalk-delta is streamed over a TCP socket:
+When a hello or signalk-delta message is sent over a TCP socket:
 
-1. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}'). Note: It is common for the APIs for Ethernet and WiFi devices to close a TCP packet when a line feed ( char(13) ) is received.
-2. The first character of each signalk-delta message SHOULD be the openning curly bracket (char(123), '{').
-3. The server SHOULD send signalk-delta in a compact manner with any unnessesary white space removed.
+1. Each message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}').
+2. The first character of each message SHOULD be the openning curly bracket (char(123), '{').
+3. The message SHOULD be sent with any unnessesary white space removed.
+
+Note on hardware implementation: The serial APIs for ethernet and wifi modules often close a TCP or UDP packet on receipt of a new line ( char(13) ). Please check the data sheet and ensure the new line character is still sent.

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -1,4 +1,4 @@
-#### Streaming WebSocket API: /signalk/v1/stream
+ #### Streaming WebSocket API: /signalk/v1/stream
 
 Initiates a WebSocket connection that will start streaming the server's updates as Signal K delta messages. You can specify the contents of the stream by using a specific URL:
 
@@ -30,6 +30,6 @@ A Signal K server MAY stream signalk-delta over a TCP socket.
 
 When signalk-delta is streamed over a TCP socket:
 
-1. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}').
+1. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}'). Note: It is common for the APIs for Ethernet and WiFi devices to close a TCP packet when a line feed ( char(13) ) is received.
 2. The first character of each signalk-delta message SHOULD be the openning curly bracket (char(123), '{').
 3. The server SHOULD send signalk-delta in a compact manner with any unnessesary white space removed.

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -1,4 +1,4 @@
- #### Streaming WebSocket API: /signalk/v1/stream
+3 #### Streaming WebSocket API: /signalk/v1/stream
 
 Initiates a WebSocket connection that will start streaming the server's updates as Signal K delta messages. You can specify the contents of the stream by using a specific URL:
 
@@ -30,8 +30,8 @@ A network node MAY stream signalk-delta over a TCP socket.
 
 When a hello or signalk-delta message is sent over a TCP socket:
 
-1. Each message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}').
+1. Each message MUST be terminated by a carriage return and new line (char(13) + char(10), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}').
 2. The first character of each message SHOULD be the openning curly bracket (char(123), '{').
 3. The message SHOULD be sent with any unnessesary white space removed.
 
-Note on hardware implementation: The serial APIs for ethernet and wifi modules often close a TCP or UDP packet on receipt of a new line ( char(13) ). Please check the data sheet and ensure the new line character is still sent.
+Note on hardware implementation: The serial APIs for ethernet and wifi modules often close a TCP or UDP packet on receipt of a new line ( char(10) ). Please check the data sheet and ensure the new line character is still sent.

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -26,14 +26,10 @@ Upon connection a 'hello' message is sent as follows:
 
 #### Streaming: TCP sockets
 
-A signalk server MAY stream signalk-delta over a TCP socket.
+A Signal K server MAY stream signalk-delta over a TCP socket.
 
 When signalk-delta is streamed over a TCP socket:
 
-1. The first character of each signalk-delta message MUST be the openning curly bracket (char(123), '{').
-2. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent after the final closing curly bracket (char(125), '}').
+1. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent immediatly after the final closing curly bracket (char(125), '}').
+2. The first character of each signalk-delta message SHOULD be the openning curly bracket (char(123), '{').
 3. The server SHOULD send signalk-delta in a compact manner with any unnessesary white space removed.
-4. The server MAY also send sentences for other protocals (e.g. NMEA0183) interleaved with the signalk-delta messages provided that sentences of the other protocal:
-  a) Can not start with a curly bracket first character and 
-  b) Are terminated by a carriage retrun and new line (char(10) + char(13), '\r\n')
-5. The client MUST not assume that only signalk-delta will be sent over the socket.

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -24,13 +24,13 @@ Upon connection a 'hello' message is sent as follows:
 }
 ```
 
-#### Streaming: raw TCP sockets
+#### Streaming: TCP sockets
 
-A signalk server MAY stream signalk-delta over a raw TCP socket.
+A signalk server MAY stream signalk-delta over a TCP socket.
 
-When signalk-delta is streamed over a raw TCP socket:
+When signalk-delta is streamed over a TCP socket:
 
-1. The first character of each signalk-delta message MUST be the openning curly bracke (char(123), '{').
+1. The first character of each signalk-delta message MUST be the openning curly bracket (char(123), '{').
 2. Each signalk-delta message MUST be terminated by a carriage return and new line (char(10) + char(13), '\r\n') sent after the final closing curly bracket (char(125), '}').
 3. The server SHOULD send signalk-delta in a compact manner with any unnessesary white space removed.
 4. The server MAY also send sentences for other protocals (e.g. NMEA0183) interleaved with the signalk-delta messages provided that sentences of the other protocal:

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -70,7 +70,7 @@ See [Subscription Protocol](subscription_protocol.html) for more details.
 
 #### Streaming Connection "Hello"
 
-Upon accepting a connection a server MUST send a 'hello' message before any other communicaiton is sent. The format of the 'hello' message is as follows:
+Before a node sends any signalk-delta messages over a streaming connection it MUST send a 'hello' message. The format of the 'hello' message is as follows:
 
 ```json
 {
@@ -80,9 +80,9 @@ Upon accepting a connection a server MUST send a 'hello' message before any othe
 }
 ```
 
-"version" - The 'hello' message MUST contain a "version" property which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will be sent by the server.
+"version" - The 'hello' message MUST contain a "version" property which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will follow.
 
-"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the server that the 'hello' mesage was sent at. The client SHOULD compare the timestamp to the local time at the client at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the server.
+"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the sending node.
 
 "self" - The 'hello' massege MAY contain a "self" property which MUST have a string value that identifies the vessle the message pertains to.
 

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -75,21 +75,14 @@ Upon accepting a connection a server MUST send a 'hello' message before any othe
 ```json
 {
   "version": "1.1.2",
-  "source": "actisense.ngw-1.1234567",
   "timestamp": "2015-04-13T01:13:50.524Z",
   "self": "123456789"
 }
 ```
 
-"version" - The 'hello' message MUST contain a "version" element which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will be sent by the server.
+"version" - The 'hello' message MUST contain a "version" property which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will be sent by the server.
 
-"source" - The 'hello' message MUST contain a "source" element which MUST have a string value that identifies the server as follows: manufacturer/publisher.device/application.uuid, where:
-* maufacturer is the name of a manufacturer or publisher in the list maintained in this repository
-* device is the name of a device or software application made by the manufacturer or publisher in the list maintained in this repository
-* uuid is a uneque identifier attributed to the physical device or installation of the application by the manufacturer/publisher
-When a source is not provided in a signalk-delta message the client SHOULD take the source from the 'hello' as a default.
+"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the server that the 'hello' mesage was sent at. The client SHOULD compare the timestamp to the local time at the client at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the server.
 
-"timestamp" - The 'hello' message SHOULD contain a "timestamp" element which MUST have a string value representing the date and time at the server that the 'hello' mesage was sent at. The client SHOULD compare the timestamp to the local time at the client at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the server.
-
-"self" - The 'hello' massege MAY contain a "self" element whcih MUST have a string value that identifies the vessle the message pertains to.
+"self" - The 'hello' massege MAY contain a "self" property which MUST have a string value that identifies the vessle the message pertains to.
 

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -65,7 +65,7 @@ See [Subscription Protocol](subscription_protocol.html) for more details.
 
 #### Streaming Connection "Hello"
 
-Before a node sends any signalk-delta messages over a streaming connection it MUST send a 'hello' message. The format of the 'hello' message is as follows:
+Before a node sends any signalk-delta messages over a Web Socket or TCP connection it MUST send a 'hello' message. The format of the 'hello' message is as follows:
 
 ```json
 {

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -3,7 +3,7 @@
 ### Short Names
 
 - `self` refers to the current vessel. Normally used in `vessels.self...`.
--### Ports
+### Ports
 
 The Signal K HTTP and WebSocket services SHOULD be found on the usual HTTP/S ports (80 or 443). The services SHOULD be
 found on the same port, but may be configured for independent ports and MAY be configured for ports other than HTTP/S.
@@ -13,7 +13,7 @@ A Signal K server MAY offer Signal K over TCP or UDP, these services SHOULD be o
 If an alternate port is needed it SHOULD be an arbitrary high port in the range 49152&ndash;65535[[2]](#fn_2).
 
 ### URL Prefix
-Tihe Signal K applications start from the `/signalk` root. This provides some protection against name collisions with
+aTihe Signal K applications start from the `/signalk` root. This provides some protection against name collisions with
 other applications on the same server. Therefore the Signal K entry point will always be found by loading
 `http(s)://«host»:«port»/signalk`.
 
@@ -23,8 +23,7 @@ The version(s) of the Signal K API that a server supports SHALL be available as 
 ```json
 {
     "endpoints": {        "v1": {
-            "version": "1.1.2",            "signalk-http": "http://192.168.1.2/signalk/v1/api/",
-            "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
+            "version": "1.1.2",            "signalk-http": "http://192.168.1.2/signalk/v1/api/",            "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
         },
         "v3": {
             "version": "3.0",
@@ -80,5 +79,5 @@ Before a node sends any signalk-delta messages over a streaming connection it MU
 
 "timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages received from the sending node.
 
-"self" - The 'hello' massege MAY contain a "self" property which MUST have a string value that identifies the vessle the message pertains to.
+"self" - The 'hello' massage MAY contain a "self" property which MUST have a string value that identifies the vessel the message pertains to.
 

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -22,7 +22,6 @@ other applications on the same server. Therefore the Signal K entry point will a
 ### Versioning
 
 The version(s) of the Signal K API that a server supports SHALL be available as a JSON object available at `/signalk`:
-
 ```json
 {
     "endpoints": {
@@ -69,14 +68,28 @@ If a server does not support some streaming options listed in here it must respo
 
 See [Subscription Protocol](subscription_protocol.html) for more details.
 
-##### Connection Hello
+#### Streaming Connection "Hello"
 
-Upon connection a 'hello' message is sent as follows:
+Upon accepting a connection a server MUST send a 'hello' message before any other communicaiton is sent. The format of the 'hello' message is as follows:
 
 ```json
 {
   "version": "1.1.2",
+  "source": "actisense.ngw-1.1234567",
   "timestamp": "2015-04-13T01:13:50.524Z",
   "self": "123456789"
 }
 ```
+
+"version" - The 'hello' message MUST contain a "version" element which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will be sent by the server.
+
+"source" - The 'hello' message MUST contain a "source" element which MUST have a string value that identifies the server as follows: manufacturer/publisher.device/application.uuid, where:
+* maufacturer is the name of a manufacturer or publisher in the list maintained in this repository
+* device is the name of a device or software application made by the manufacturer or publisher in the list maintained in this repository
+* uuid is a uneque identifier attributed to the physical device or installation of the application by the manufacturer/publisher
+When a source is not provided in a signalk-delta message the client SHOULD take the source from the 'hello' as a default.
+
+"timestamp" - The 'hello' message SHOULD contain a "timestamp" element which MUST have a string value representing the date and time at the server that the 'hello' mesage was sent at. The client SHOULD compare the timestamp to the local time at the client at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the server.
+
+"self" - The 'hello' massege MAY contain a "self" element whcih MUST have a string value that identifies the vessle the message pertains to.
+

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -3,7 +3,6 @@
 ### Short Names
 
 - `self` refers to the current vessel. Normally used in `vessels.self...`.
-
 ### Ports
 
 The Signal K HTTP and WebSocket services SHOULD be found on the usual HTTP/S ports (80 or 443). The services SHOULD be
@@ -14,7 +13,6 @@ A Signal K server MAY offer Signal K over TCP or UDP, these services SHOULD be o
 If an alternate port is needed it SHOULD be an arbitrary high port in the range 49152&ndash;65535[[2]](#fn_2).
 
 ### URL Prefix
-
 The Signal K applications start from the `/signalk` root. This provides some protection against name collisions with
 other applications on the same server. Therefore the Signal K entry point will always be found by loading
 `http(s)://«host»:«port»/signalk`.
@@ -24,8 +22,7 @@ other applications on the same server. Therefore the Signal K entry point will a
 The version(s) of the Signal K API that a server supports SHALL be available as a JSON object available at `/signalk`:
 ```json
 {
-    "endpoints": {
-        "v1": {
+    "endpoints": {        "v1": {
             "version": "1.1.2",
             "signalk-http": "http://192.168.1.2/signalk/v1/api/",
             "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
@@ -82,7 +79,7 @@ Before a node sends any signalk-delta messages over a streaming connection it MU
 
 "version" - The 'hello' message MUST contain a "version" property which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will follow.
 
-"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the sending node.
+"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the sending node.
 
 "self" - The 'hello' massege MAY contain a "self" property which MUST have a string value that identifies the vessle the message pertains to.
 

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -1,9 +1,9 @@
-#Ports, Urls and Versioning
+##Ports, Urls and Versioning
 
 ### Short Names
 
 - `self` refers to the current vessel. Normally used in `vessels.self...`.
-### Ports
+-### Ports
 
 The Signal K HTTP and WebSocket services SHOULD be found on the usual HTTP/S ports (80 or 443). The services SHOULD be
 found on the same port, but may be configured for independent ports and MAY be configured for ports other than HTTP/S.
@@ -13,7 +13,7 @@ A Signal K server MAY offer Signal K over TCP or UDP, these services SHOULD be o
 If an alternate port is needed it SHOULD be an arbitrary high port in the range 49152&ndash;65535[[2]](#fn_2).
 
 ### URL Prefix
-The Signal K applications start from the `/signalk` root. This provides some protection against name collisions with
+Tihe Signal K applications start from the `/signalk` root. This provides some protection against name collisions with
 other applications on the same server. Therefore the Signal K entry point will always be found by loading
 `http(s)://«host»:«port»/signalk`.
 
@@ -23,8 +23,7 @@ The version(s) of the Signal K API that a server supports SHALL be available as 
 ```json
 {
     "endpoints": {        "v1": {
-            "version": "1.1.2",
-            "signalk-http": "http://192.168.1.2/signalk/v1/api/",
+            "version": "1.1.2",            "signalk-http": "http://192.168.1.2/signalk/v1/api/",
             "signalk-ws": "ws://192.168.1.2:34567/signalk/v1/stream"
         },
         "v3": {
@@ -79,7 +78,7 @@ Before a node sends any signalk-delta messages over a streaming connection it MU
 
 "version" - The 'hello' message MUST contain a "version" property which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will follow.
 
-"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages recieved from the sending node.
+"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages received from the sending node.
 
 "self" - The 'hello' massege MAY contain a "self" property which MUST have a string value that identifies the vessle the message pertains to.
 

--- a/gitbook-docs/urls_etc.md
+++ b/gitbook-docs/urls_etc.md
@@ -77,7 +77,11 @@ Before a node sends any signalk-delta messages over a Web Socket or TCP connecti
 
 "version" - The 'hello' message MUST contain a "version" property which MUST have a string value identifying the lowest version of signalk-delta that defines the format of the messages that will follow.
 
-"timestamp" - The 'hello' message SHOULD contain a "timestamp" property which MUST have a string value representing the date and time at the node that sent the 'hello' mesage. The timestamp SHOULD be synchronised with UTC. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages received from the sending node.
+"timestamp" - The 'hello' message SHOULD contain a "timestamp" property.
+
+1. The timestamp MUST have a string value representing the date and time at the node that sent the 'hello' message.
+2. The timestamp SHOULD be synchronised with UTC. UTC timestamps MUST end with a capital Z.
+3. If the timestamp is not synchronised with UTC then the receiving node SHOULD compare the timestamp with the time at the receiving node at which the 'hello' is received and use the delta to correct the timestamp of subsequent signalk-delta messages received from the sending node. If it can not perform this function it MUST delete the timestamp and treat the message as if it had no timestamp.
 
 "self" - The 'hello' massage MAY contain a "self" property which MUST have a string value that identifies the vessel the message pertains to.
 


### PR DESCRIPTION
Added rules for supporting mixed message TCP sockets.

Each message must begin {
Each message must end \r\n

Added source to hello message
Added description of how to use hello timestamp to increase the accuracy of subsequent delta messages