### PR TITLE
Generate documentation for object types

### DIFF
--- a/keyswithmetadata.json
+++ b/keyswithmetadata.json
@@ -643,23 +643,8 @@
   "/vessels/*/electrical/batteries/RegExp": {
     "description": "Batteries, one or many, within the vessel"
   },
-  "/vessels/*/electrical/batteries/RegExp/associatedBus": {
-    "description": "Name of BUS device is associated with"
-  },
-  "/vessels/*/electrical/batteries/RegExp/voltage": {
-    "units": "V",
-    "description": "Data should be of type number."
-  },
-  "/vessels/*/electrical/batteries/RegExp/voltage/ripple": {
-    "units": "V",
-    "description": "Ripple voltage"
-  },
-  "/vessels/*/electrical/batteries/RegExp/current": {
-    "units": "A",
-    "description": "Data should be of type number."
-  },
   "/vessels/*/electrical/batteries/RegExp/temperature": {
-    "description": "Data should be of type number."
+    "description": "Additional / unique temperatures associated with a battery"
   },
   "/vessels/*/electrical/batteries/RegExp/capacity": {
     "description": "[missing]"
@@ -703,6 +688,21 @@
   "/vessels/*/electrical/batteries/RegExp/lifetimeRecharge": {
     "units": "C",
     "description": "Cumulative charge recharged into battery over operational lifetime of battery"
+  },
+  "/vessels/*/electrical/batteries/RegExp/associatedBus": {
+    "description": "Name of BUS device is associated with"
+  },
+  "/vessels/*/electrical/batteries/RegExp/voltage": {
+    "units": "V",
+    "description": "Data should be of type number."
+  },
+  "/vessels/*/electrical/batteries/RegExp/voltage/ripple": {
+    "units": "V",
+    "description": "Ripple voltage"
+  },
+  "/vessels/*/electrical/batteries/RegExp/current": {
+    "units": "A",
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/inverters": {
     "description": "[missing]"

--- a/keyswithmetadata.json
+++ b/keyswithmetadata.json
@@ -229,6 +229,18 @@
   "/vessels/*/environment/current": {
     "description": "Direction and strength of current affecting the vessel"
   },
+  "/vessels/*/environment/current/drift": {
+    "units": "m/s",
+    "description": "The speed component of the water current vector"
+  },
+  "/vessels/*/environment/current/setTrue": {
+    "units": "rad",
+    "description": "The direction component of the water current vector referenced to true (geographic) north"
+  },
+  "/vessels/*/environment/current/setMagnetic": {
+    "units": "rad",
+    "description": "The direction component of the water current vector referenced to magnetic north"
+  },
   "/vessels/*/environment/tide": {
     "description": "Tide data"
   },
@@ -298,6 +310,12 @@
   "/vessels/*/environment/time": {
     "description": "A time reference onboard."
   },
+  "/vessels/*/environment/time/millis": {
+    "description": "Milliseconds since the UNIX epoch (1970-01-01 00:00:00)"
+  },
+  "/vessels/*/environment/time/timezone": {
+    "description": "Timezone offset in hours and minutes (-)hhmm"
+  },
   "/vessels/*/environment/mode": {
     "description": "Mode of the vessel based on the current conditions. Can be combined with navigation.state to control vessel signals eg switch to night mode for instrumentation and lights, or make sound signals for fog."
   },
@@ -347,8 +365,62 @@
   "/vessels/*/navigation/courseRhumbline/nextPoint": {
     "description": "The point on earth the vessel's presently navigating towards"
   },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/type": {
+    "description": "The type of the next point (e.g. Waypoint, POI, Race Mark, etc)"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/href": {
+    "description": "A reference (URL) to an object (under resources) this point is related to"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/distance": {
+    "units": "m",
+    "description": "The distance in meters between the vessel's present position and the nextPoint"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/bearingTrue": {
+    "units": "rad",
+    "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/bearingMagnetic": {
+    "units": "rad",
+    "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/velocityMadeGood": {
+    "units": "m/s",
+    "description": "The velocity component of the vessel towards the nextPoint"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/timeToGo": {
+    "units": "s",
+    "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/position": {
+    "description": "The position of nextPoint in two dimensions"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/position/latitude": {
+    "description": "[missing]"
+  },
+  "/vessels/*/navigation/courseRhumbline/nextPoint/position/longitude": {
+    "description": "[missing]"
+  },
   "/vessels/*/navigation/courseRhumbline/previousPoint": {
     "description": "The point on earth the vessel's presently navigating from"
+  },
+  "/vessels/*/navigation/courseRhumbline/previousPoint/type": {
+    "description": "The type of the previous point (e.g. Waypoint, POI, Race Mark, etc)"
+  },
+  "/vessels/*/navigation/courseRhumbline/previousPoint/href": {
+    "description": "A reference (URL) to an object (under resources) this point is related to"
+  },
+  "/vessels/*/navigation/courseRhumbline/previousPoint/distance": {
+    "units": "m",
+    "description": "The distance in meters between previousPoint and the vessel's present position"
+  },
+  "/vessels/*/navigation/courseRhumbline/previousPoint/position": {
+    "description": "The position of lastPoint in two dimensions"
+  },
+  "/vessels/*/navigation/courseRhumbline/previousPoint/position/latitude": {
+    "description": "[missing]"
+  },
+  "/vessels/*/navigation/courseRhumbline/previousPoint/position/longitude": {
+    "description": "[missing]"
   },
   "/vessels/*/navigation/courseGreatCircle": {
     "description": "Course information computed with Great Circle"
@@ -382,8 +454,62 @@
   "/vessels/*/navigation/courseGreatCircle/nextPoint": {
     "description": "The point on earth the vessel's presently navigating towards"
   },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/type": {
+    "description": "The type of the next point (e.g. Waypoint, POI, Race Mark, etc)"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/href": {
+    "description": "A reference (URL) to an object (under resources) this point is related to"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/distance": {
+    "units": "m",
+    "description": "The distance in meters between the vessel's present position and the nextPoint"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/bearingTrue": {
+    "units": "rad",
+    "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/bearingMagnetic": {
+    "units": "rad",
+    "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/velocityMadeGood": {
+    "units": "m/s",
+    "description": "The velocity component of the vessel towards the nextPoint"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/timeToGo": {
+    "units": "s",
+    "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/position": {
+    "description": "The position of nextPoint in two dimensions"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/position/latitude": {
+    "description": "[missing]"
+  },
+  "/vessels/*/navigation/courseGreatCircle/nextPoint/position/longitude": {
+    "description": "[missing]"
+  },
   "/vessels/*/navigation/courseGreatCircle/previousPoint": {
     "description": "The point on earth the vessel's presently navigating from"
+  },
+  "/vessels/*/navigation/courseGreatCircle/previousPoint/type": {
+    "description": "The type of the previous point (e.g. Waypoint, POI, Race Mark, etc)"
+  },
+  "/vessels/*/navigation/courseGreatCircle/previousPoint/href": {
+    "description": "A reference (URL) to an object (under resources) this point is related to"
+  },
+  "/vessels/*/navigation/courseGreatCircle/previousPoint/distance": {
+    "units": "m",
+    "description": "The distance in meters between previousPoint and the vessel's present position"
+  },
+  "/vessels/*/navigation/courseGreatCircle/previousPoint/position": {
+    "description": "The position of lastPoint in two dimensions"
+  },
+  "/vessels/*/navigation/courseGreatCircle/previousPoint/position/latitude": {
+    "description": "[missing]"
+  },
+  "/vessels/*/navigation/courseGreatCircle/previousPoint/position/longitude": {
+    "description": "[missing]"
   },
   "/vessels/*/navigation/racing": {
     "description": "[missing]"
@@ -433,8 +559,21 @@
   "/vessels/*/navigation/destination": {
     "description": "The intended destination of this trip"
   },
+  "/vessels/*/navigation/destination/eta": {
+    "units": "ISO-8601 (UTC)",
+    "description": "ISO-8601 (UTC) string representing date and time."
+  },
+  "/vessels/*/navigation/destination/waypoint": {
+    "description": "UUID of destination waypoint"
+  },
   "/vessels/*/navigation/gnss": {
     "description": "Global satellite navigation meta information"
+  },
+  "/vessels/*/navigation/gnss/methodQuality": {
+    "description": "Quality of the satellite fix"
+  },
+  "/vessels/*/navigation/gnss/integrity": {
+    "description": "Integrity of the satellite fix"
   },
   "/vessels/*/navigation/gnss/satellites": {
     "description": "Number of satellites"
@@ -470,8 +609,32 @@
   "/vessels/*/navigation/position": {
     "description": "The position of the vessel in 2 or 3 dimensions (WGS84 datum)"
   },
+  "/vessels/*/navigation/position/longitude": {
+    "units": "deg",
+    "description": "Longitude"
+  },
+  "/vessels/*/navigation/position/latitude": {
+    "units": "deg",
+    "description": "Latitude"
+  },
+  "/vessels/*/navigation/position/altitude": {
+    "units": "m",
+    "description": "Altitude"
+  },
   "/vessels/*/navigation/attitude": {
     "description": "Vessel attitude: roll, pitch and yaw"
+  },
+  "/vessels/*/navigation/attitude/roll": {
+    "units": "rad",
+    "description": "Vessel roll, +ve is list to starboard"
+  },
+  "/vessels/*/navigation/attitude/pitch": {
+    "units": "rad",
+    "description": "Pitch, +ve is bow up"
+  },
+  "/vessels/*/navigation/attitude/yaw": {
+    "units": "rad",
+    "description": "Yaw, +ve is heading change to starboard"
   },
   "/vessels/*/navigation/rateOfTurn": {
     "units": "rad/s",
@@ -510,8 +673,23 @@
   "/vessels/*/navigation/anchor/position": {
     "description": "The actual anchor position of the vessel in 3 dimensions, probably an estimate at best"
   },
+  "/vessels/*/navigation/anchor/position/longitude": {
+    "units": "deg",
+    "description": "Longitude"
+  },
+  "/vessels/*/navigation/anchor/position/latitude": {
+    "units": "deg",
+    "description": "Latitude"
+  },
+  "/vessels/*/navigation/anchor/position/altitude": {
+    "units": "m",
+    "description": "Altitude"
+  },
   "/vessels/*/navigation/datetime": {
     "description": "[missing]"
+  },
+  "/vessels/*/navigation/datetime/gnssTimeSource": {
+    "description": "Source of GNSS Date and Time"
   },
   "/vessels/*/propulsion": {
     "description": "Engine data, each engine identified by a unique name i.e. Port_Engine"
@@ -646,6 +824,38 @@
   "/vessels/*/electrical/batteries/RegExp/temperature": {
     "description": "Additional / unique temperatures associated with a battery"
   },
+  "/vessels/*/electrical/batteries/RegExp/temperature/limitDischargeLower": {
+    "units": "K",
+    "description": "Operational minimum temperature limit for battery discharge"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/limitDischargeUpper": {
+    "units": "K",
+    "description": "Operational maximum temperature limit for battery discharge"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/limitRechargeLower": {
+    "units": "K",
+    "description": "Operational minimum temperature limit for battery recharging"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/limitRechargeUpper": {
+    "units": "K",
+    "description": "Operational maximum temperature limit for battery recharging"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/warnUpper": {
+    "units": "K",
+    "description": "Upper operational temperature limit"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/warnLower": {
+    "units": "K",
+    "description": "Lower operational temperature limit"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/faultUpper": {
+    "units": "K",
+    "description": "Upper fault temperature limit - device may disable/disconnect"
+  },
+  "/vessels/*/electrical/batteries/RegExp/temperature/faultLower": {
+    "units": "K",
+    "description": "Lower fault temperature limit - device may disable/disconnect"
+  },
   "/vessels/*/electrical/batteries/RegExp/capacity": {
     "description": "[missing]"
   },
@@ -731,6 +941,22 @@
   "/vessels/*/electrical/inverters/RegExp/dc/temperature": {
     "description": "Data should be of type number."
   },
+  "/vessels/*/electrical/inverters/RegExp/dc/temperature/warnUpper": {
+    "units": "K",
+    "description": "Upper operational temperature limit"
+  },
+  "/vessels/*/electrical/inverters/RegExp/dc/temperature/warnLower": {
+    "units": "K",
+    "description": "Lower operational temperature limit"
+  },
+  "/vessels/*/electrical/inverters/RegExp/dc/temperature/faultUpper": {
+    "units": "K",
+    "description": "Upper fault temperature limit - device may disable/disconnect"
+  },
+  "/vessels/*/electrical/inverters/RegExp/dc/temperature/faultLower": {
+    "units": "K",
+    "description": "Lower fault temperature limit - device may disable/disconnect"
+  },
   "/vessels/*/electrical/inverters/RegExp/ac": {
     "description": "AC equipment common quantities"
   },
@@ -797,6 +1023,22 @@
   },
   "/vessels/*/electrical/chargers/RegExp/temperature": {
     "description": "Data should be of type number."
+  },
+  "/vessels/*/electrical/chargers/RegExp/temperature/warnUpper": {
+    "units": "K",
+    "description": "Upper operational temperature limit"
+  },
+  "/vessels/*/electrical/chargers/RegExp/temperature/warnLower": {
+    "units": "K",
+    "description": "Lower operational temperature limit"
+  },
+  "/vessels/*/electrical/chargers/RegExp/temperature/faultUpper": {
+    "units": "K",
+    "description": "Upper fault temperature limit - device may disable/disconnect"
+  },
+  "/vessels/*/electrical/chargers/RegExp/temperature/faultLower": {
+    "units": "K",
+    "description": "Lower fault temperature limit - device may disable/disconnect"
   },
   "/vessels/*/electrical/chargers/RegExp/mode": {
     "description": "[missing]"
@@ -1192,11 +1434,38 @@
   "/vessels/*/design/draft": {
     "description": "The draft of the vessel"
   },
+  "/vessels/*/design/draft/minimum": {
+    "units": "m",
+    "description": "The minimum draft of the vessel"
+  },
+  "/vessels/*/design/draft/maximum": {
+    "units": "m",
+    "description": "The maximum draft of the vessel"
+  },
+  "/vessels/*/design/draft/canoe": {
+    "units": "m",
+    "description": "The draft of the vessel without protrusions such as keel, centerboard, rudder"
+  },
   "/vessels/*/design/length": {
     "description": "The various lengths of the vessel"
   },
+  "/vessels/*/design/length/overall": {
+    "units": "m",
+    "description": "Length overall"
+  },
+  "/vessels/*/design/length/hull": {
+    "units": "m",
+    "description": "Length of hull"
+  },
+  "/vessels/*/design/length/waterline": {
+    "units": "m",
+    "description": "Length at waterline"
+  },
   "/vessels/*/design/keel": {
     "description": "Information about the vessel's keel"
+  },
+  "/vessels/*/design/keel/type": {
+    "description": "The type of keel."
   },
   "/vessels/*/design/keel/angle": {
     "units": "rad",
@@ -1217,6 +1486,12 @@
   "/vessels/*/design/rigging": {
     "description": "Information about the vessel's rigging"
   },
+  "/vessels/*/design/rigging/configuration": {
+    "description": "The configuration of the rigging"
+  },
+  "/vessels/*/design/rigging/masts": {
+    "description": "The number of masts on the vessel."
+  },
   "/vessels/*/sails": {
     "description": "Sails data"
   },
@@ -1225,6 +1500,33 @@
   },
   "/vessels/*/sails/inventory/RegExp": {
     "description": "'sail' data type."
+  },
+  "/vessels/*/sails/inventory/RegExp/name": {
+    "description": "An unique identifier by which the crew identifies a sail"
+  },
+  "/vessels/*/sails/inventory/RegExp/type": {
+    "description": "The type of sail"
+  },
+  "/vessels/*/sails/inventory/RegExp/material": {
+    "description": "The material the sail is made from (optional)"
+  },
+  "/vessels/*/sails/inventory/RegExp/brand": {
+    "description": "The brand of the sail (optional)"
+  },
+  "/vessels/*/sails/inventory/RegExp/active": {
+    "description": "Indicates wether this sail is currently in use or not"
+  },
+  "/vessels/*/sails/inventory/RegExp/area": {
+    "units": "m2",
+    "description": "The total area of this sail in square meters"
+  },
+  "/vessels/*/sails/inventory/RegExp/minimumWind": {
+    "units": "m/s",
+    "description": "The minimum wind speed this sail can be used with"
+  },
+  "/vessels/*/sails/inventory/RegExp/maximumWind": {
+    "units": "m/s",
+    "description": "The maximum wind speed this sail can be used with"
   },
   "/vessels/*/sails/area": {
     "description": "An object containing information about the vessels' sails."
@@ -1330,11 +1632,75 @@
   "/resources/charts/*": {
     "description": "A chart"
   },
+  "/resources/charts/*/name": {
+    "description": "Chart common name"
+  },
+  "/resources/charts/*/identifier": {
+    "description": "Chart number"
+  },
+  "/resources/charts/*/description": {
+    "description": "A description of the chart"
+  },
+  "/resources/charts/*/tilemapUrl": {
+    "description": "A url to the tilemap of the chart for use in TMS chartplotting apps"
+  },
+  "/resources/charts/*/region": {
+    "description": "Region related to note. A pointer to a region UUID. Alternative to geohash"
+  },
+  "/resources/charts/*/geohash": {
+    "description": "Position related to chart. Alternative to region"
+  },
+  "/resources/charts/*/chartUrl": {
+    "description": "A url to the chart file's storage location"
+  },
+  "/resources/charts/*/scale": {
+    "description": "The scale of the chart, the larger number from 1:200000"
+  },
+  "/resources/charts/*/chartFormat": {
+    "description": "The format of the chart"
+  },
   "/resources/routes": {
     "description": "A holder for routes, each named with a UUID"
   },
   "/resources/routes/*": {
     "description": "A route, named with a UUID"
+  },
+  "/resources/routes/*/name": {
+    "description": "Route's common name"
+  },
+  "/resources/routes/*/description": {
+    "description": "A description of the route"
+  },
+  "/resources/routes/*/distance": {
+    "units": "m",
+    "description": "Total distance from start to end"
+  },
+  "/resources/routes/*/start": {
+    "description": "The waypoint UUID at the start of the route"
+  },
+  "/resources/routes/*/end": {
+    "description": "The waypoint UUID at the end of the route"
+  },
+  "/resources/routes/*/feature": {
+    "description": "A Geo JSON feature object which describes the route between the waypoints"
+  },
+  "/resources/routes/*/feature/type": {
+    "description": "[missing]"
+  },
+  "/resources/routes/*/feature/geometry": {
+    "description": "[missing]"
+  },
+  "/resources/routes/*/feature/geometry/type": {
+    "description": "[missing]"
+  },
+  "/resources/routes/*/feature/geometry/coordinates": {
+    "description": "An array of two or more positions"
+  },
+  "/resources/routes/*/feature/properties": {
+    "description": "Additional data of any type"
+  },
+  "/resources/routes/*/feature/id": {
+    "description": "[missing]"
   },
   "/resources/notes": {
     "description": "A holder for notes about regions, each named with a UUID. Notes might include navigation or cruising info, images, or anything"
@@ -1342,14 +1708,62 @@
   "/resources/notes/*": {
     "description": "A note about a region, named with a UUID. Notes might include navigation or cruising info, images, or anything"
   },
+  "/resources/notes/*/title": {
+    "description": "Note's common name"
+  },
+  "/resources/notes/*/description": {
+    "description": "A textual description of the note"
+  },
+  "/resources/notes/*/region": {
+    "description": "Region related to note. A pointer to a region UUID. Alternative to position or geohash"
+  },
   "/resources/notes/*/position": {
     "description": "Position related to note. Alternative to region or geohash"
+  },
+  "/resources/notes/*/position/longitude": {
+    "units": "deg",
+    "description": "Longitude"
+  },
+  "/resources/notes/*/position/latitude": {
+    "units": "deg",
+    "description": "Latitude"
+  },
+  "/resources/notes/*/position/altitude": {
+    "units": "m",
+    "description": "Altitude"
+  },
+  "/resources/notes/*/geohash": {
+    "description": "Position related to note. Alternative to region or position"
+  },
+  "/resources/notes/*/mimeType": {
+    "description": "MIME type of the note"
+  },
+  "/resources/notes/*/url": {
+    "description": "Location of the note"
   },
   "/resources/regions": {
     "description": "A holder for regions, each named with UUID"
   },
   "/resources/regions/*": {
     "description": "A region of interest, each named with a UUID"
+  },
+  "/resources/regions/*/geohash": {
+    "description": "geohash of the approximate boundary of this region"
+  },
+  "/resources/regions/*/feature": {
+    "description": "A Geo JSON feature object which describes the regions boundary"
+  },
+  "/resources/regions/*/feature/type": {
+    "description": "[missing]"
+  },
+  "/resources/regions/*/feature/geometry": {
+    "description": "[missing]"
+  },
+  "/resources/regions/*/feature/properties": {
+    "description": "Additional data of any type"
+  },
+  "/resources/regions/*/feature/id": {
+    "description": "[missing]"
   },
   "/resources/waypoints": {
     "description": "A holder for waypoints, each named with a UUID"
@@ -1359,6 +1773,18 @@
   },
   "/resources/waypoints/*/position": {
     "description": "The position in 3 dimensions"
+  },
+  "/resources/waypoints/*/position/longitude": {
+    "units": "deg",
+    "description": "Longitude"
+  },
+  "/resources/waypoints/*/position/latitude": {
+    "units": "deg",
+    "description": "Latitude"
+  },
+  "/resources/waypoints/*/position/altitude": {
+    "units": "m",
+    "description": "Altitude"
   },
   "/resources/waypoints/*/feature": {
     "description": "A Geo JSON feature object"

--- a/keyswithmetadata.json
+++ b/keyswithmetadata.json
@@ -6,7 +6,7 @@
     "description": "A wrapper object for vessel objects, each describing vessels in range, including this vessel."
   },
   "/vessels/*": {
-    "description": "An object describing an individual vessel. It should be an object in vessels, named using MMSI or a UUID"
+    "description": "This regex pattern is used for validation of an MMSI or Signal K UUID identifier for the vessel. Examples: urn:mrn:imo:mmsi:230099999 urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d"
   },
   "/vessels/*/url": {
     "description": "URL based identity of the vessel, if available."
@@ -298,12 +298,6 @@
   "/vessels/*/environment/time": {
     "description": "A time reference onboard."
   },
-  "/vessels/*/environment/time/millis": {
-    "description": "Milliseconds since the UNIX epoch (1970-01-01 00:00:00)"
-  },
-  "/vessels/*/environment/time/timezone": {
-    "description": "Timezone offset in hours and minutes (-)hhmm"
-  },
   "/vessels/*/environment/mode": {
     "description": "Mode of the vessel based on the current conditions. Can be combined with navigation.state to control vessel signals eg switch to night mode for instrumentation and lights, or make sound signals for fog."
   },
@@ -439,21 +433,8 @@
   "/vessels/*/navigation/destination": {
     "description": "The intended destination of this trip"
   },
-  "/vessels/*/navigation/destination/eta": {
-    "units": "ISO-8601 (UTC)",
-    "description": "ISO-8601 (UTC) string representing date and time."
-  },
-  "/vessels/*/navigation/destination/waypoint": {
-    "description": "UUID of destination waypoint"
-  },
   "/vessels/*/navigation/gnss": {
     "description": "Global satellite navigation meta information"
-  },
-  "/vessels/*/navigation/gnss/methodQuality": {
-    "description": "Quality of the satellite fix"
-  },
-  "/vessels/*/navigation/gnss/integrity": {
-    "description": "Integrity of the satellite fix"
   },
   "/vessels/*/navigation/gnss/satellites": {
     "description": "Number of satellites"
@@ -667,30 +648,18 @@
   },
   "/vessels/*/electrical/batteries/RegExp/voltage": {
     "units": "V",
-    "description": "[missing]"
+    "description": "Data should be of type number."
+  },
+  "/vessels/*/electrical/batteries/RegExp/voltage/ripple": {
+    "units": "V",
+    "description": "Ripple voltage"
   },
   "/vessels/*/electrical/batteries/RegExp/current": {
     "units": "A",
-    "description": "[missing]"
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/batteries/RegExp/temperature": {
-    "description": "Additional / unique temperatures associated with a battery"
-  },
-  "/vessels/*/electrical/batteries/RegExp/temperature/limitDischargeLower": {
-    "units": "K",
-    "description": "Operational minimum temperature limit for battery discharge"
-  },
-  "/vessels/*/electrical/batteries/RegExp/temperature/limitDischargeUpper": {
-    "units": "K",
-    "description": "Operational maximum temperature limit for battery discharge"
-  },
-  "/vessels/*/electrical/batteries/RegExp/temperature/limitRechargeLower": {
-    "units": "K",
-    "description": "Operational minimum temperature limit for battery recharging"
-  },
-  "/vessels/*/electrical/batteries/RegExp/temperature/limitRechargeUpper": {
-    "units": "K",
-    "description": "Operational maximum temperature limit for battery recharging"
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/batteries/RegExp/capacity": {
     "description": "[missing]"
@@ -749,14 +718,18 @@
   },
   "/vessels/*/electrical/inverters/RegExp/dc/voltage": {
     "units": "V",
-    "description": "[missing]"
+    "description": "Data should be of type number."
+  },
+  "/vessels/*/electrical/inverters/RegExp/dc/voltage/ripple": {
+    "units": "V",
+    "description": "Ripple voltage"
   },
   "/vessels/*/electrical/inverters/RegExp/dc/current": {
     "units": "A",
-    "description": "[missing]"
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/inverters/RegExp/dc/temperature": {
-    "description": "[missing]"
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/inverters/RegExp/ac": {
     "description": "AC equipment common quantities"
@@ -812,14 +785,18 @@
   },
   "/vessels/*/electrical/chargers/RegExp/voltage": {
     "units": "V",
-    "description": "[missing]"
+    "description": "Data should be of type number."
+  },
+  "/vessels/*/electrical/chargers/RegExp/voltage/ripple": {
+    "units": "V",
+    "description": "Ripple voltage"
   },
   "/vessels/*/electrical/chargers/RegExp/current": {
     "units": "A",
-    "description": "[missing]"
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/chargers/RegExp/temperature": {
-    "description": "[missing]"
+    "description": "Data should be of type number."
   },
   "/vessels/*/electrical/chargers/RegExp/mode": {
     "description": "[missing]"
@@ -880,67 +857,97 @@
     "description": "Man overboard"
   },
   "/vessels/*/notifications/mob/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/mob/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/fire": {
     "description": "Fire onboard"
   },
   "/vessels/*/notifications/fire/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/fire/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/sinking": {
     "description": "Vessel is sinking"
   },
   "/vessels/*/notifications/sinking/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/sinking/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/flooding": {
     "description": "Vessel is flooding"
   },
   "/vessels/*/notifications/flooding/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/flooding/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/collision": {
     "description": "In collision with another vessel or object"
   },
   "/vessels/*/notifications/collision/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/collision/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/grounding": {
     "description": "Vessel grounding"
   },
   "/vessels/*/notifications/grounding/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/grounding/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/listing": {
     "description": "Vessel is listing"
   },
   "/vessels/*/notifications/listing/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/listing/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/adrift": {
     "description": "Vessel is adrift"
   },
   "/vessels/*/notifications/adrift/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/adrift/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/piracy": {
     "description": "Under attack or danger from pirates"
   },
   "/vessels/*/notifications/piracy/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/piracy/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/abandon": {
     "description": "Abandon ship"
   },
   "/vessels/*/notifications/abandon/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/abandon/RegExp/RegExp": {
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/RegExp": {
-    "description": "Notifications, their state, and actions. The notification limits are set in any Signal K key.meta.zones array."
+    "description": "This regex pattern is used for validation of the path of the alarm"
   },
   "/vessels/*/notifications/RegExp/RegExp": {
-    "description": "Reference to the source under /sources. A dot spearated path to the data. eg [type].[bus].[device]"
+    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/steering": {
     "description": "Vessel steering data for steering controls (not Autopilot 'Nav Data')"
@@ -965,12 +972,17 @@
   "/vessels/*/steering/autopilot/target": {
     "description": "Autopilot target"
   },
-  "/vessels/*/steering/autopilot/target/angle": {
+  "/vessels/*/steering/autopilot/target/windAngleApparent": {
     "units": "rad",
-    "description": "Target heading for autopilot, relative to magnetic North or Apparent wind +port -starboard"
+    "description": "Target angle to steer, relative to Apparent wind +port -starboard"
   },
-  "/vessels/*/steering/autopilot/target/reference": {
-    "description": "Current source of heading information"
+  "/vessels/*/steering/autopilot/target/headingTrue": {
+    "units": "rad",
+    "description": "Target heading for autopilot, relative to North"
+  },
+  "/vessels/*/steering/autopilot/target/headingMagnetic": {
+    "units": "rad",
+    "description": "Target heading for autopilot, relative to Magnetic North"
   },
   "/vessels/*/steering/autopilot/deadZone": {
     "units": "rad",
@@ -1180,38 +1192,11 @@
   "/vessels/*/design/draft": {
     "description": "The draft of the vessel"
   },
-  "/vessels/*/design/draft/minimum": {
-    "units": "m",
-    "description": "The minimum draft of the vessel"
-  },
-  "/vessels/*/design/draft/maximum": {
-    "units": "m",
-    "description": "The maximum draft of the vessel"
-  },
-  "/vessels/*/design/draft/canoe": {
-    "units": "m",
-    "description": "The draft of the vessel without protrusions such as keel, centerboard, rudder"
-  },
   "/vessels/*/design/length": {
     "description": "The various lengths of the vessel"
   },
-  "/vessels/*/design/length/overall": {
-    "units": "m",
-    "description": "Length overall"
-  },
-  "/vessels/*/design/length/hull": {
-    "units": "m",
-    "description": "Length of hull"
-  },
-  "/vessels/*/design/length/waterline": {
-    "units": "m",
-    "description": "Length at waterline"
-  },
   "/vessels/*/design/keel": {
     "description": "Information about the vessel's keel"
-  },
-  "/vessels/*/design/keel/type": {
-    "description": "The type of keel."
   },
   "/vessels/*/design/keel/angle": {
     "units": "rad",
@@ -1232,12 +1217,6 @@
   "/vessels/*/design/rigging": {
     "description": "Information about the vessel's rigging"
   },
-  "/vessels/*/design/rigging/configuration": {
-    "description": "The configuration of the rigging"
-  },
-  "/vessels/*/design/rigging/masts": {
-    "description": "The number of masts on the vessel."
-  },
   "/vessels/*/sails": {
     "description": "Sails data"
   },
@@ -1246,33 +1225,6 @@
   },
   "/vessels/*/sails/inventory/RegExp": {
     "description": "'sail' data type."
-  },
-  "/vessels/*/sails/inventory/RegExp/name": {
-    "description": "An unique identifier by which the crew identifies a sail"
-  },
-  "/vessels/*/sails/inventory/RegExp/type": {
-    "description": "The type of sail"
-  },
-  "/vessels/*/sails/inventory/RegExp/material": {
-    "description": "The material the sail is made from (optional)"
-  },
-  "/vessels/*/sails/inventory/RegExp/brand": {
-    "description": "The brand of the sail (optional)"
-  },
-  "/vessels/*/sails/inventory/RegExp/active": {
-    "description": "Indicates wether this sail is currently in use or not"
-  },
-  "/vessels/*/sails/inventory/RegExp/area": {
-    "units": "m2",
-    "description": "The total area of this sail in square meters"
-  },
-  "/vessels/*/sails/inventory/RegExp/minimumWind": {
-    "units": "m/s",
-    "description": "The minimum wind speed this sail can be used with"
-  },
-  "/vessels/*/sails/inventory/RegExp/maximumWind": {
-    "units": "m/s",
-    "description": "The maximum wind speed this sail can be used with"
   },
   "/vessels/*/sails/area": {
     "description": "An object containing information about the vessels' sails."
@@ -1289,7 +1241,7 @@
     "description": "Sensors, their state, and data."
   },
   "/vessels/*/sensors/RegExp": {
-    "description": "An object describing an individual sensor. It should be an object in vessel, named using a unique name or UUID"
+    "description": "This regex pattern is used for validation UUID identifier for the sensor"
   },
   "/vessels/*/sensors/RegExp/name": {
     "description": "The common name of the sensor"
@@ -1378,75 +1330,11 @@
   "/resources/charts/*": {
     "description": "A chart"
   },
-  "/resources/charts/*/name": {
-    "description": "Chart common name"
-  },
-  "/resources/charts/*/identifier": {
-    "description": "Chart number"
-  },
-  "/resources/charts/*/description": {
-    "description": "A description of the chart"
-  },
-  "/resources/charts/*/tilemapUrl": {
-    "description": "A url to the tilemap of the chart for use in TMS chartplotting apps"
-  },
-  "/resources/charts/*/region": {
-    "description": "Region related to note. A pointer to a region UUID. Alternative to geohash"
-  },
-  "/resources/charts/*/geohash": {
-    "description": "Position related to chart. Alternative to region"
-  },
-  "/resources/charts/*/chartUrl": {
-    "description": "A url to the chart file's storage location"
-  },
-  "/resources/charts/*/scale": {
-    "description": "The scale of the chart, the larger number from 1:200000"
-  },
-  "/resources/charts/*/chartFormat": {
-    "description": "The format of the chart"
-  },
   "/resources/routes": {
     "description": "A holder for routes, each named with a UUID"
   },
   "/resources/routes/*": {
     "description": "A route, named with a UUID"
-  },
-  "/resources/routes/*/name": {
-    "description": "Route's common name"
-  },
-  "/resources/routes/*/description": {
-    "description": "A description of the route"
-  },
-  "/resources/routes/*/distance": {
-    "units": "m",
-    "description": "Total distance from start to end"
-  },
-  "/resources/routes/*/start": {
-    "description": "The waypoint UUID at the start of the route"
-  },
-  "/resources/routes/*/end": {
-    "description": "The waypoint UUID at the end of the route"
-  },
-  "/resources/routes/*/feature": {
-    "description": "A Geo JSON feature object which describes the route between the waypoints"
-  },
-  "/resources/routes/*/feature/type": {
-    "description": "[missing]"
-  },
-  "/resources/routes/*/feature/geometry": {
-    "description": "[missing]"
-  },
-  "/resources/routes/*/feature/geometry/type": {
-    "description": "[missing]"
-  },
-  "/resources/routes/*/feature/geometry/coordinates": {
-    "description": "[missing]"
-  },
-  "/resources/routes/*/feature/properties": {
-    "description": "Additional data of any type"
-  },
-  "/resources/routes/*/feature/id": {
-    "description": "[missing]"
   },
   "/resources/notes": {
     "description": "A holder for notes about regions, each named with a UUID. Notes might include navigation or cruising info, images, or anything"
@@ -1454,26 +1342,8 @@
   "/resources/notes/*": {
     "description": "A note about a region, named with a UUID. Notes might include navigation or cruising info, images, or anything"
   },
-  "/resources/notes/*/title": {
-    "description": "Note's common name"
-  },
-  "/resources/notes/*/description": {
-    "description": "A textual description of the note"
-  },
-  "/resources/notes/*/region": {
-    "description": "Region related to note. A pointer to a region UUID. Alternative to position or geohash"
-  },
   "/resources/notes/*/position": {
     "description": "Position related to note. Alternative to region or geohash"
-  },
-  "/resources/notes/*/geohash": {
-    "description": "Position related to note. Alternative to region or position"
-  },
-  "/resources/notes/*/mimeType": {
-    "description": "MIME type of the note"
-  },
-  "/resources/notes/*/url": {
-    "description": "Location of the note"
   },
   "/resources/regions": {
     "description": "A holder for regions, each named with UUID"
@@ -1481,29 +1351,11 @@
   "/resources/regions/*": {
     "description": "A region of interest, each named with a UUID"
   },
-  "/resources/regions/*/geohash": {
-    "description": "geohash of the approximate boundary of this region"
-  },
-  "/resources/regions/*/feature": {
-    "description": "A Geo JSON feature object which describes the regions boundary"
-  },
-  "/resources/regions/*/feature/type": {
-    "description": "[missing]"
-  },
-  "/resources/regions/*/feature/geometry": {
-    "description": "[missing]"
-  },
-  "/resources/regions/*/feature/properties": {
-    "description": "Additional data of any type"
-  },
-  "/resources/regions/*/feature/id": {
-    "description": "[missing]"
-  },
   "/resources/waypoints": {
     "description": "A holder for waypoints, each named with a UUID"
   },
   "/resources/waypoints/*": {
-    "description": "A waypoint, an object with a signal k position object, and GeoJSON Feature object (see geojson.org, and https://github.com/fge/sample-json-schemas/tree/master/geojson)"
+    "description": "A waypoint, named with a UUID"
   },
   "/resources/waypoints/*/position": {
     "description": "The position in 3 dimensions"

--- a/keyswithmetadata.json
+++ b/keyswithmetadata.json
@@ -1098,8 +1098,26 @@
   "/vessels/*/notifications/mob": {
     "description": "Man overboard"
   },
+  "/vessels/*/notifications/mob/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/mob/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/mob/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/mob/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/mob/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/mob/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/mob/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/mob/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1107,8 +1125,26 @@
   "/vessels/*/notifications/fire": {
     "description": "Fire onboard"
   },
+  "/vessels/*/notifications/fire/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/fire/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/fire/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/fire/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/fire/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/fire/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/fire/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/fire/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1116,8 +1152,26 @@
   "/vessels/*/notifications/sinking": {
     "description": "Vessel is sinking"
   },
+  "/vessels/*/notifications/sinking/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/sinking/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/sinking/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/sinking/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/sinking/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/sinking/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/sinking/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/sinking/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1125,8 +1179,26 @@
   "/vessels/*/notifications/flooding": {
     "description": "Vessel is flooding"
   },
+  "/vessels/*/notifications/flooding/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/flooding/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/flooding/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/flooding/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/flooding/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/flooding/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/flooding/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/flooding/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1134,8 +1206,26 @@
   "/vessels/*/notifications/collision": {
     "description": "In collision with another vessel or object"
   },
+  "/vessels/*/notifications/collision/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/collision/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/collision/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/collision/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/collision/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/collision/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/collision/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/collision/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1143,8 +1233,26 @@
   "/vessels/*/notifications/grounding": {
     "description": "Vessel grounding"
   },
+  "/vessels/*/notifications/grounding/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/grounding/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/grounding/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/grounding/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/grounding/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/grounding/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/grounding/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/grounding/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1152,8 +1260,26 @@
   "/vessels/*/notifications/listing": {
     "description": "Vessel is listing"
   },
+  "/vessels/*/notifications/listing/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/listing/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/listing/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/listing/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/listing/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/listing/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/listing/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/listing/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1161,8 +1287,26 @@
   "/vessels/*/notifications/adrift": {
     "description": "Vessel is adrift"
   },
+  "/vessels/*/notifications/adrift/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/adrift/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/adrift/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/adrift/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/adrift/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/adrift/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/adrift/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/adrift/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1170,8 +1314,26 @@
   "/vessels/*/notifications/piracy": {
     "description": "Under attack or danger from pirates"
   },
+  "/vessels/*/notifications/piracy/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/piracy/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/piracy/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/piracy/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/piracy/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/piracy/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/piracy/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/piracy/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
@@ -1179,14 +1341,41 @@
   "/vessels/*/notifications/abandon": {
     "description": "Abandon ship"
   },
+  "/vessels/*/notifications/abandon/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/abandon/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/abandon/message": {
+    "description": "Message to display or speak"
+  },
   "/vessels/*/notifications/abandon/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
+  },
+  "/vessels/*/notifications/abandon/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/abandon/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/abandon/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/abandon/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/RegExp": {
     "description": "This regex pattern is used for validation of the path of the alarm"
+  },
+  "/vessels/*/notifications/RegExp/method": {
+    "description": "Method to use to raise notifications"
+  },
+  "/vessels/*/notifications/RegExp/state": {
+    "description": "Current notification state"
+  },
+  "/vessels/*/notifications/RegExp/message": {
+    "description": "Message to display or speak"
   },
   "/vessels/*/notifications/RegExp/RegExp": {
     "description": "This regex pattern is used for validation of the path of the notification"

--- a/keyswithmetadata.json
+++ b/keyswithmetadata.json
@@ -1119,9 +1119,6 @@
   "/vessels/*/notifications/mob/RegExp/message": {
     "description": "Message to display or speak"
   },
-  "/vessels/*/notifications/mob/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
-  },
   "/vessels/*/notifications/fire": {
     "description": "Fire onboard"
   },
@@ -1145,9 +1142,6 @@
   },
   "/vessels/*/notifications/fire/RegExp/message": {
     "description": "Message to display or speak"
-  },
-  "/vessels/*/notifications/fire/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/sinking": {
     "description": "Vessel is sinking"
@@ -1173,9 +1167,6 @@
   "/vessels/*/notifications/sinking/RegExp/message": {
     "description": "Message to display or speak"
   },
-  "/vessels/*/notifications/sinking/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
-  },
   "/vessels/*/notifications/flooding": {
     "description": "Vessel is flooding"
   },
@@ -1199,9 +1190,6 @@
   },
   "/vessels/*/notifications/flooding/RegExp/message": {
     "description": "Message to display or speak"
-  },
-  "/vessels/*/notifications/flooding/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/collision": {
     "description": "In collision with another vessel or object"
@@ -1227,9 +1215,6 @@
   "/vessels/*/notifications/collision/RegExp/message": {
     "description": "Message to display or speak"
   },
-  "/vessels/*/notifications/collision/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
-  },
   "/vessels/*/notifications/grounding": {
     "description": "Vessel grounding"
   },
@@ -1253,9 +1238,6 @@
   },
   "/vessels/*/notifications/grounding/RegExp/message": {
     "description": "Message to display or speak"
-  },
-  "/vessels/*/notifications/grounding/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/listing": {
     "description": "Vessel is listing"
@@ -1281,9 +1263,6 @@
   "/vessels/*/notifications/listing/RegExp/message": {
     "description": "Message to display or speak"
   },
-  "/vessels/*/notifications/listing/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
-  },
   "/vessels/*/notifications/adrift": {
     "description": "Vessel is adrift"
   },
@@ -1307,9 +1286,6 @@
   },
   "/vessels/*/notifications/adrift/RegExp/message": {
     "description": "Message to display or speak"
-  },
-  "/vessels/*/notifications/adrift/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/notifications/piracy": {
     "description": "Under attack or danger from pirates"
@@ -1335,9 +1311,6 @@
   "/vessels/*/notifications/piracy/RegExp/message": {
     "description": "Message to display or speak"
   },
-  "/vessels/*/notifications/piracy/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
-  },
   "/vessels/*/notifications/abandon": {
     "description": "Abandon ship"
   },
@@ -1362,9 +1335,6 @@
   "/vessels/*/notifications/abandon/RegExp/message": {
     "description": "Message to display or speak"
   },
-  "/vessels/*/notifications/abandon/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
-  },
   "/vessels/*/notifications/RegExp": {
     "description": "This regex pattern is used for validation of the path of the alarm"
   },
@@ -1376,9 +1346,6 @@
   },
   "/vessels/*/notifications/RegExp/message": {
     "description": "Message to display or speak"
-  },
-  "/vessels/*/notifications/RegExp/RegExp": {
-    "description": "This regex pattern is used for validation of the path of the notification"
   },
   "/vessels/*/steering": {
     "description": "Vessel steering data for steering controls (not Autopilot 'Nav Data')"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "gitbook-cli": "^2.3.0",
     "infuse.js": "^2.0.2",
-    "json-schema-load-tree": "^0.2.0",
     "markdown-it": "^8.0.0",
     "mocha": "^2.1.0",
     "mz": "^2.4.0",

--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -248,8 +248,6 @@
           "description": "Batteries, one or many, within the vessel",
 
           "allOf": [{
-            "$ref": "#/definitions/dcQuantities"
-          }, {
             "properties": {
               "meta": {
                 "allOf": [{
@@ -362,6 +360,8 @@
                 "units": "C"
               }
             }
+          }, {
+              "$ref": "#/definitions/dcQuantities"
           }]
         }
       }

--- a/schemas/groups/notifications.json
+++ b/schemas/groups/notifications.json
@@ -5,34 +5,32 @@
   "title": "notifications",
   "description": "Notifications, their state, and actions. The notification limits are set in any Signal K key.meta.zones array.",
 
-  "patternProperties": {
-    "(^method$)": {
+  "properties": {
+    "method": {
       "description": "Method to use to raise notifications",
       "type": "array",
       "items": {
         "$ref": "../definitions.json#/definitions/alarmMethodEnum"
       }
     },
-
-    "(^state$)": {
+    "state": {
       "description": "Current notification state",
       "$ref": "../definitions.json#/definitions/alarmState"
     },
-
-    "(^message$)": {
+    "message": {
       "description": "Message to display or speak",
       "type": "string"
     },
-
-    "(^timestamp$)": {
+    "timestamp": {
       "description": "Timestamp of the last update to this data",
       "$ref": "../definitions.json#/definitions/timestamp"
     },
-
-    "(^\\$source$)": {
+    "$source": {
       "description": "Source of this data",
       "$ref": "../definitions.json#/definitions/sourceRef"
-    },
+    }
+  },
+  "patternProperties": {
     "(^[A-Za-z0-9-]+$)": {
       "description": "This regex pattern is used for validation of the path of the notification",
       "$ref": "notifications.json#"

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -317,7 +317,7 @@ class Parser {
         md += '---\n\n'
       })
 
-      fs.writeFile(path.join(__dirname, '../keyswithmetadata.json'), JSON.stringify(keysWithMeta, null, 2))
+      fs.writeFileSync(path.join(__dirname, '../keyswithmetadata.json'), JSON.stringify(keysWithMeta, null, 2))
 
       return fs.writeFile(path.join(this.options.output, 'index.md'), md, this.options.encoding).then(() => {
         results.push({

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -424,6 +424,7 @@ class Parser {
     }
     const splitPrefix = prefix.split("/")
     if (splitPrefix.length > 1 && splitPrefix[splitPrefix.length - 2] === splitPrefix[splitPrefix.length - 1]) {
+      delete this.tree[prefix]
       this.debug("Avoiding self recursion at", prefix)
       return
     }

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -20,9 +20,9 @@
 const _ = require('lodash')
 const fs = require('mz/fs')
 const path = require('path')
-const parser = require('json-schema-load-tree').default
 const rimraf = require('rimraf')
 const markdown = new (require('markdown-it'))()
+const RefParser = require('json-schema-ref-parser')
 
 
 const units = {
@@ -63,41 +63,18 @@ class Parser {
     this.tree = {}
     this.docs = {}
     this.invalid = []
-    this.files = []
 
     this.parseOptions()
     this.parse()
   }
 
   parse () {
-    const schema = require(this.options.entry)
-
     this
     .rm(this.options.output) // remove build directory
     .then(() => fs.mkdir(this.options.output)) // create a new build directory
     .then(() => fs.mkdir(path.join(this.options.output, 'html')))
-    .then(() => parser(schema)) // parse the schema
-    .then(files => {
-      function createFileKeyDecorator(fileKey) {
-        return (value, index, object) => {
-          if (index == "$ref") {
-            return {
-              refString: value,
-              refFile: fileKey
-            }
-          }
-        }
-      }
-
-      Object.keys(files).forEach(key => {
-        let k = key.replace('https://signalk.github.io/specification/schemas/', '')
-        k = k.replace('#', '')
-        files[k] = _.cloneDeep(files[key], createFileKeyDecorator(k))
-        delete files[key]
-      })
-
-      this.files = files
-      return this.files['signalk.json']
+    .then(() => {
+      return RefParser.dereference(this.options.entry)
     })
 
     /*
@@ -133,8 +110,17 @@ class Parser {
         return result
       }
 
+      const safeTree = _.pick(this.tree, value => {
+        try {
+          JSON.stringify(value)
+        } catch(e) {
+          return false
+        }
+        return true
+      })
+
       return fs
-      .writeFile(path.join(this.options.output, 'tree.json'), JSON.stringify(this.tree, null, 2), this.options.encoding)
+      .writeFile(path.join(this.options.output, 'tree.json'), JSON.stringify(safeTree, null, 2), this.options.encoding)
       .then(() => {
         this.debug(`Written total tree to ${path.join(this.options.output, 'tree.json')}`)
         return result
@@ -160,6 +146,13 @@ class Parser {
           }
         }
 
+        const skipFields = ['timestamp', '$source', 'source', '_attr', 'meta', 'pgn', 'sentence', 'value', 'values']
+        const embeddedFields =
+          !this.tree[`${path}/timestamp`] ? {} :
+            _.pick(subtree.properties ? _.omit(subtree.properties || {}, skipFields) : {}, (value, key) => {
+              return !this.tree[`${path}/${key}/timestamp`]
+            })
+
         const documentation = {
           node: node,
           path: path,
@@ -170,7 +163,8 @@ class Parser {
           type: typeof subtree.type !== 'undefined' ? subtree.type : null,
           description: typeof subtree.description !== 'undefined' ? subtree.description : null,
           example: typeof subtree.example !== 'undefined' ? subtree.example : null,
-          json: JSON.stringify(subtree, null, 2)
+          json: subtree,
+          embeddedFields: Object.keys(embeddedFields).length > 0 ? embeddedFields : undefined
         }
         if (subtree.enum) {
           documentation.enum = subtree.enum
@@ -239,26 +233,38 @@ class Parser {
 
       Object.keys(filenames).forEach(fn => {
         let valid = true
-        let json = null
-
         filter.forEach(f => {
           if (filenames[fn].indexOf(f) !== -1) {
             valid = false
           }
         })
-
-        if (valid === false) {
+        if (!valid) {
           return
         }
 
         const path = filenames[fn]
         const doc = this.docs[path]
 
-        try {
-          json = JSON.parse(doc.json)
-        } catch (e) {
-          this.debug(`Error parsing JSON for path ${path}: ${e.message}`)
+        function isEmbedded(path) {
+          if (this.docs[`${path}/timestamp`]) {
+            return false
+          }
+          const parts = path.split('/').filter(x => x.length > 0)
+          let soFar = ""
+          let result = false
+          parts.forEach(part => {
+            soFar = soFar + "/" + part
+            result = result || !!this.docs[soFar + '/timestamp']
+          })
+          return result
         }
+
+        if (isEmbedded.bind(this)(path)) {
+          this.debug("Skipping embedded", path)
+          return
+        }
+
+        let json = doc.json
 
         const key = path.replace(/</g, '').replace(/>/g, '').replace('RegExp', '*')
         keysWithMeta[key] = {
@@ -282,8 +288,30 @@ class Parser {
         md += '\n\n'
 
         if (doc.enum) {
-          md += '**Enum values:**\n'
+          md += '**Enum values:**\n\n'
           doc.enum.forEach(enumValue => md += `* ${enumValue}\n`)
+          md += '\n'
+        }
+
+        function renderField(key, field, baseIndent) {
+          const descString = field.description ? ` (${field.description})` : ''
+          const unitString = field.units ? `, units: ${field.units} (${units[field.units]})` : ''
+          const enumString = field.enum ? `, enum:\n\n${field.enum.map(x => `${baseIndent}  * ${x}\n`).join('')}` : ''
+          md += `${baseIndent}* ${key}${descString}${unitString}${enumString}\n`
+          if (field.properties) {
+            md += '\n'
+            const subKeys = Object.keys(field.properties)
+            subKeys.forEach(subKey => renderField(subKey, field.properties[subKey], baseIndent + "  "))
+          }
+        }
+
+        if (doc.embeddedFields) {
+          md += '**Fields:**\n\n'
+          Object.keys(doc.embeddedFields).forEach(key => {
+            const field = doc.embeddedFields[key]
+            renderField(key, field, "")
+          })
+          md += '\n'
         }
 
         md += '---\n\n'
@@ -393,20 +421,19 @@ class Parser {
     if (prefix.charAt(prefix.length - 1) === '/') {
       prefix = prefix.replace(/\/+$/, '')
     }
+    const splitPrefix = prefix.split("/")
+    if (splitPrefix.length > 1 && splitPrefix[splitPrefix.length - 2] === splitPrefix[splitPrefix.length - 1]) {
+      this.debug("Avoiding self recursion at", prefix)
+      return
+    }
 
     if (typeof data.properties === 'object' && data.properties !== null) {
       Object.keys(data.properties).forEach(key => {
-        if (typeof data.properties[key]['$ref'] === 'undefined') {
-          this.tree[`${prefix}/${key}`] = data.properties[key]
-        } else {
-          this.tree[`${prefix}/${key}`] = {}
-          _.assign(this.tree[`${prefix}/${key}`], _.omit(data.properties[key], '$ref'))
-          _.defaults(this.tree[`${prefix}/${key}`], this.resolveReference(data.properties[key]['$ref']))
-        }
+        this.tree[`${prefix}/${key}`] = data.properties[key]
 
-        // if (typeof this.tree[`${prefix}/${key}`] !== 'undefined' && typeof this.tree[`${prefix}/${key}`].allOf !== 'undefined') {
-        //   this.parseAllOf(`${prefix}/${key}`, this.tree[`${prefix}/${key}`].allOf)
-        // }
+        if (typeof this.tree[`${prefix}/${key}`] !== 'undefined' && typeof this.tree[`${prefix}/${key}`].allOf !== 'undefined') {
+          this.parseAllOf(`${prefix}/${key}`, this.tree[`${prefix}/${key}`].allOf, this.tree[`${prefix}/${key}`] || {})
+        }
 
         if (this.hasProperties(this.tree[`${prefix}/${key}`])) {
           this.parseProperties(`${prefix}/${key}`, this.tree[`${prefix}/${key}`])
@@ -416,29 +443,19 @@ class Parser {
 
     if (typeof data.patternProperties === 'object' && data.patternProperties !== null) {
       Object.keys(data.patternProperties).forEach(key => {
-        if (typeof data.patternProperties[key]['$ref'] === 'undefined') {
-          this.tree[`${prefix}/${key}`] = data.patternProperties[key]
-        } else {
-          this.tree[`${prefix}/${key}`] = this.resolveReference(data.patternProperties[key]['$ref'])
-        }
+        const target = `${prefix}/${key}`
+
+        this.tree[`${prefix}/${key}`] = data.patternProperties[key]
 
         if (typeof this.tree[`${prefix}/${key}`] !== 'undefined' && typeof this.tree[`${prefix}/${key}`].allOf !== 'undefined') {
           this.parseAllOf(`${prefix}/${key}`, this.tree[`${prefix}/${key}`].allOf,
-            _.omit(this.tree[`${prefix}/${key}`], ['properties', 'allOf', 'patternProperties', '$key']))
+            this.tree[`${prefix}/${key}`] || {})
         }
 
         if (this.hasProperties(this.tree[`${prefix}/${key}`])) {
           this.parseProperties(`${prefix}/${key}`, this.tree[`${prefix}/${key}`])
         }
       })
-    }
-
-    if (typeof data['$ref'] !== 'undefined') {
-      this.tree[prefix] = this.resolveReference(data['$ref'])
-
-      if (typeof this.tree[prefix].properties !== 'undefined' || typeof this.tree[prefix].properties !== 'undefined') {
-        this.parseProperties(prefix, this.tree[prefix])
-      }
     }
 
     return data
@@ -451,31 +468,24 @@ class Parser {
 
     let readablePrefix = `${treePrefix.split('/')[treePrefix.split('/').length - 2]}/${treePrefix.split('/')[treePrefix.split('/').length - 1]}`
 
-    let temp = [baseObject].concat(allOf).map(obj => {
-      if (typeof obj === 'object' && obj !== null && typeof obj['$ref'] !== 'undefined') {
-        const ref = this.resolveReference(obj['$ref'])
+    let temp = this.createAllOfArray(allOf, baseObject)
 
-        if (ref !== null && typeof ref !== 'undefined') {
-          return ref
-        } else {
-          console.log(`*** Warning: couldn't resolve ${obj['$ref']} in ${readablePrefix}. No file in $ref value?`)
-        }
-      }
+    this.tree[treePrefix] = this.reduceParsedAllOf(temp)
+  }
 
-      return obj
-    })
+  createAllOfArray (allOf, baseObject) {
+    if (!Array.isArray(allOf)) {
+      return {}
+    }
+
+    const result = [baseObject].concat(allOf)
     .filter(obj => {
       if (obj === null || typeof obj === 'undefined') {
         return false
       }
       return true
     })
-
-    if (!Array.isArray(temp)) {
-      return
-    }
-
-    this.tree[treePrefix] = this.reduceParsedAllOf(temp)
+    return result
   }
 
   reduceParsedAllOf (allOf, result) {
@@ -489,9 +499,11 @@ class Parser {
       }
 
       Object.keys(obj).forEach(key => {
-        if (key !== 'properties' && key !== 'patternProperties' && key !== 'allOf' && key !== '$ref') {
+        if (key !== 'properties' && key !== 'patternProperties' && key !== 'allOf') {
           if (!result[key]) {
             result[key] = obj[key]
+          } else if (result[key] !== obj[key]) {
+            this.debug("avoiding overriding ", key, ". prev", result[key], ", rejected", obj[key])
           }
         }
 
@@ -501,7 +513,10 @@ class Parser {
           }
 
           Object.keys(obj[key]).forEach(k => {
-            result.properties[k] = obj[key][k]
+            if (typeof obj[key][k].allOf !== 'undefined') {
+              this.reduceParsedAllOf(obj[key][k].allOf, obj[key][k])
+            }
+            result.properties[k] = _.merge(result.properties[k] || {}, obj[key][k])
           })
         }
 
@@ -522,40 +537,6 @@ class Parser {
     })
 
     return result
-  }
-
-  resolveReference (refObject) {
-    const origRef = refObject.refString
-    if (typeof origRef !== 'string') {
-      return null
-    }
-
-    const ref = origRef.replace('../', '').split('#')
-    let file = ref[0].trim()
-    let path = ref[1].trim()
-
-
-    if (file.length === 0) {
-      file = refObject.refFile
-    }
-
-    if (path.length === 0) {
-      return this.files[file]
-    }
-
-    if (path.charAt(0) === '/') {
-      path = path.replace(/^\//, '')
-    }
-
-    path = path.split('/')
-
-    // relative references might point to the same file or definitions.json
-    if (_.get(this.files[file], path, "NOT_DEFINED") === "NOT_DEFINED") {
-      file = 'definitions.json'
-    }
-    let cursor = this.files[file]
-
-    return _.get(cursor, path)
   }
 
   parseOptions () {

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -516,7 +516,12 @@ class Parser {
             if (typeof obj[key][k].allOf !== 'undefined') {
               this.reduceParsedAllOf(obj[key][k].allOf, obj[key][k])
             }
-            result.properties[k] = _.merge(result.properties[k] || {}, obj[key][k])
+            result.properties[k] = _.merge(result.properties[k] || {}, obj[key][k], (objectValue, sourceValue, key, object, source) => {
+              if (objectValue && typeof objectValue === "string" && objectValue !== sourceValue) {
+                this.debug("avoiding overriding ", key, ". prev", objectValue, ", rejected", sourceValue)
+                return objectValue
+              }
+            })
           })
         }
 

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -259,17 +259,18 @@ class Parser {
           return result
         }
 
-        if (isEmbedded.bind(this)(path)) {
-          this.debug("Skipping embedded", path)
-          return
-        }
-
         let json = doc.json
 
         const key = path.replace(/</g, '').replace(/>/g, '').replace('RegExp', '*')
         keysWithMeta[key] = {
           units: json.units,
           description: doc.description === null ? '[missing]' : doc.description
+        }
+
+
+        if (isEmbedded.bind(this)(path)) {
+          this.debug("Skipping embedded", path)
+          return
         }
 
         // md += `### [${path.replace(/</g, '&lt;').replace(/>/g, '&gt;')}](http://signalk.org/specification/master/keys/html/${fn.replace('.md', '.html')})\n\n`


### PR DESCRIPTION
This pull request tries to fix #273.

Keys documentation in master: [click here](https://www.niksula.hut.fi/~ristela1/signalk-documentation-master/keys/)
Keys documentation generated by this PR: [click here](https://www.niksula.hut.fi/~ristela1/signalk-documentation-with-object-documentation/keys/)
See for example `/vessels/<RegExp>/navigation/position`.

There are actually multiple parts to my changes but laziness & explorative coding led to just a single commit. The parts are:
1. replace `json-load-tree` with `json-schema-ref-parser` to
   - load schema files locally
   - let a library handle references instead of the previous `resolveReference`
2. fix `allOf` handling to properly handle more difficult cases
3. change Markdown generator to generate documentation for object types (+ fix a couple of already existing bugs)

I didn't verify if the `keyswithmetadata.json` generator still works. @tkurki? Bugs/missing documentation fields would also be nice to be discussed before merging. The leaf logic is probably also still off.