### PR TITLE
Removed refererence to Boundary Layer

### DIFF
--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -440,7 +440,7 @@
     },
      "speedThroughWaterLongitudinal": {
       "$ref": "../definitions.json#/definitions/numberValue",
-      "description": "Longitudinal speed through the water (outside boundary layer)",
+      "description": "Longitudinal speed through the water",
       "units": "m/s"
     },
     "leewayAngle": {


### PR DESCRIPTION
As pointed out by @canboat, whether the waterspeed is measured inside or outside the boundary layer is a feature of the sensor and should not be dictated by the schema. Therefore have removed mention of the boundary layer in the description of Longitudinal Speed.