### PR TITLE
Specify vessel context and leaf path for delta

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+test
+.travis.yml

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -163,9 +163,10 @@ A delta message can be recognised from the other types by the topmost level havi
 `updates` is the only required property.
 If `context` is missing it is assumed that the data is related to the `self` context.
 
-Context is a path from the root of the full tree. In this case 'vessels.urn:mrn:imo:mmsi:234567890'. All subsequent data is relative to
-that location. The context could be much more specific, e.g. 'vessels.urn:mrn:imo:mmsi:234567890.navigation', whatever is the common root
-of the updated data.
+Context is a path from the root of the full tree to the _container object_, which is always a vessel with the current Signal K version.
+The delimiter in the context path is `.` (period).
+In this case the context is `vessels.urn:mrn:imo:mmsi:234567890`.
+All subsequent data is relative to that location.
 
 The `updates` holds an array (JSON array) of updates, each of which has a `source` and a JSON array of `values`.
 
@@ -197,7 +198,11 @@ A Signal K producer may not have access to a real time clock or UTC time.
 In these cases timestamp should be omitted.
 Elements in the Signal K processing chain, like a server receiving data from a producer, should fill in timestamp if it is missing in the incoming delta message.
 
-Each 'value' item is then simply a pair of 'relative path', and 'value'.
+Each `value` item is then simply a pair of `path` and `value`.
+The `path` must be a _leaf path_: it must be a path to a leaf the of the full model.
+A leaf is where the actual value of the Signal K property is and where `timestamp`, `$source` and `values` properties are in the full model.
+The value is often a scalar - a numeric value, as in the example above, but it can also be an object.
+For example a `navigation.position` value would be an object like `{"latitude": -41.2936935424, "longitude": 173.2470855712}`.
 
 ## Message Integrity
 

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -201,6 +201,10 @@ The `updates` holds an array (JSON array) of updates, each of which has a `sourc
 An `update` has a single `source` value and it applies to each of the `values` items.
 In cases where you can get data from only a single source the source may be omitted and the receiver may fill it in when multiplexing data from several sources.
 
+A Signal K producer may not have access to a real time clock or UTC time.
+In these cases timestamp should be omitted.
+Elements in the Signal K processing chain, like a server receiving data from a producer, should fill in timestamp if it is missing in the incoming delta message.
+
 Each 'value' item is then simply a pair of 'relative path', and 'value'.
 
 ## Message Integrity

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -7,14 +7,7 @@ format is the same as the full format, but doesn't contain a full tree, just par
 
 ## Full format
 
-The simplest format is the full format, which is the complete Signal K data model  as a JSON string. Abbreviated for
-clarity it looks like this:
-
-```json
-{"vessels":{"9334562":{"navigation":{"courseOverGroundTrue":{"value":11.9600000381},"courseOverGroundMagnetic":{"value":93.0000000000},"more":"a lot more data here...","wind":{"angleApparent":{"value":0.0000000000},"directionTrue": {"value":0.0000000000},"speedApparent":{"value":0.0000000000},"speedTrue": {"value":0.0000000000}}}}}}
-```
-
-Formatted for ease of reading:
+The simplest format is the full format, which is the complete Signal K data model  as a JSON string.
 
 ```json
 {

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -211,4 +211,4 @@ at the message level no checksum or other tests need to be made.
 The JSON message format is supported across most programming environments and can be handled with any convenient library.
 
 On micro-controllers with limited RAM it is wise to read and write using streaming rather than hold the whole message in precious RAM.
-There is an implementation of Signal K JSON streaming on an Arduino Mega (4K RAM) in the related [Freeboard project](https://github.com/rob42/FreeboardPLC_v1_2).
+There is an implementation of Signal K JSON streaming on an Arduino Mega (4K RAM) in the related [Freeboard project](https://github.com/rob42/FreeboardMega/tree/signal_k_dev/lib/SignalK).

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -163,7 +163,7 @@ A delta message can be recognised from the other types by the topmost level havi
 `updates` is the only required property.
 If `context` is missing it is assumed that the data is related to the `self` context.
 
-Context is a path from the root of the full tree to the _container object_, which is always a vessel with the current Signal K version.
+Context is a path from the root of the full tree to the _container object_, which for vessel related data must refer to the vessel directly under `vessels`.
 The delimiter in the context path is `.` (period).
 In this case the context is `vessels.urn:mrn:imo:mmsi:234567890`.
 All subsequent data is relative to that location.

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -56,7 +56,7 @@ the same content, i.e. you won't have as much data about other vessels as you ha
 
 The values are always SI units, and always the same units for the same key. I.e. `speedOverGround` is always meters per
 second, never knots, km/hr, or miles/hr. This means you never have to send 'units' with data, the units are specific for
-a key, and defined in the data schema.
+a key, and defined in the data schema. A simplified version of the JSON schema with the units is available in [Keys Reference in Appendix A](keys/index.md).
 
 The ordering of keys is also not important, they can occur in any order. In this area Signal K follows normal JSON
 standards.

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -12,7 +12,7 @@ The simplest format is the full format, which is the complete Signal K data mode
 ```json
 {
   "vessels": {
-    "9334562": {
+    "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d": {
       "version": "0.1",
       "name": "motu",
       "mmsi": "2345678",
@@ -25,24 +25,23 @@ The simplest format is the full format, which is the complete Signal K data mode
           "timestamp": "2014-03-24T00:15:41Z"
         },
         "headingTrue": {
-          "value": 23,
-          "source": {
-            "pgn": "128275",
-            "device": "/dev/actisense",
-            "src": "115"
-          },
+          "value": 2.3114,
+          "$source": "nmea0183-1.II",
+          "sentence": "HDT",
           "timestamp": "2014-03-24T00:15:41Z"
         },
-        "more": "a lot more data here...",
-        "roll": {
-          "value": 0,
-          "source": "self",
+        "speedThroughWater": {
+          "value": 2.556,
+          "$source": "n2k-1.160",
+          "pgn": 128259,
           "timestamp": "2014-03-24T00:15:41Z"
         },
-        "rateOfTurn": {
-          "value": 0,
-          "source": "self",
-          "timestamp": "2014-03-24T00:15:41Z"
+        "position": {
+          "longitude": 23.53885,
+          "latitude": 60.0844,
+          "$source": "nmea0183-2.GP",
+          "timestamp": "2014-03-24T00:15:42Z",
+          "sentence": "GLL"
         }
       }
     }

--- a/gitbook-docs/start_using.md
+++ b/gitbook-docs/start_using.md
@@ -10,7 +10,7 @@ You can start using Signal K by
   [NMEA 2000](http://www.actisense.com/products/nmea-2000/ngt-1/ngt-1.html) or roll your own with
   [I2C](https://en.wikipedia.org/wiki/I%C2%B2C) sensors) and installing Node or Java server
 * purchasing a commercial Signal K gateway such as an [iKommunicate](https://ikommunicate.com) by Digital Yacht
-* installing OpenPlotter, which includes a Signal K server
+* installing [OpenPlotter](http://www.sailoog.com/en/openplotter), which includes a Signal K server
 
 Once you have a server running (or you start by using the demo server) you can install some Signal K supporting mobile
 apps such as

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
   "homepage": "https://github.com/SignalK/specification",
   "dependencies": {
     "JSONStream": "^0.7.4",
-    "chai": "^1.9.2",
     "debug": "^2.2.0",
     "json-schema-ref-parser": "^3.1.2",
     "lodash": "^3.10.1",
     "tv4": "^1.2.7"
   },
   "devDependencies": {
+    "chai": "^1.9.2",
     "gitbook-cli": "^2.3.0",
     "infuse.js": "^2.0.2",
     "json-schema-load-tree": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-schema",
-  "version": "0.0.0",
+  "version": "0.0.1-0",
   "description": "SignalK specification schema as an npm module with tests",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-schema",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "SignalK specification schema as an npm module with tests",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change in documentation makes two things explicit:

- `context` is in practice always a vessel path
- `path` is a leaf path

My Signal K related code in lots of places assumes that context is a vessel path to discern  self data from other vessels' data. It would be possible to do just prefix matching, but grouping by vessel is a natural way to handle current Signal K data. One would need to extract the vessel identity anyway in these cases.

Omission of context meaning self context is also well in line with this thinking.

#311 posed the question about should paths be leaf paths. I believe this constraint should be explicit in the documentation. Discerning leaves from the current schema is not always very easy, witness #299, and I think we need to change the schema to make leaves more explicit.

