### PR TITLE
Itemize course properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ function getTv4() {
   tv4.addSchema('https://signalk.github.io/specification/schemas/external/geojson/geometry.json', externalGeometry);
   tv4.addSchema('http://json-schema.org/geojson/geometry.json', externalGeometry);
 
+  tv4.addFormat(require('tv4-formats'))
+
   return tv4;
 }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "debug": "^2.2.0",
     "json-schema-ref-parser": "^3.1.2",
     "lodash": "^3.10.1",
-    "tv4": "^1.2.7"
+    "tv4": "^1.2.7",
+    "tv4-formats": "^2.2.1"
   },
   "devDependencies": {
     "gitbook-cli": "^2.3.0",

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -350,6 +350,50 @@
         }
       }
     },
+
+
+    "datetimeValue": {
+      "type": "object",
+      "description": "Data should be of type number.",
+      "allOf": [{
+        "$ref": "#/definitions/commonValueFields"
+      }, {
+        "properties": {
+          "value": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "values": {
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "$ref": "#/definitions/valuesDatetimeValue"
+              }
+            }
+          }
+        }
+      }]
+    },
+
+    "valuesDatetimeValue": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "date-time"
+        },
+        "timestamp": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "pgn": {
+          "type": "number"
+        },
+        "sentence": {
+          "type": "string"
+        }
+      }
+    },
+
+
     "nullValue": {
       "type": "object",
       "description": "Data should be of type NULL.",

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -35,11 +35,11 @@
               "type": "string"
             },
             "estimatedTimeOfArrival": {
-              "$ref": "../definitions.json#/definitions/timestamp",
+              "$ref": "../definitions.json#/definitions/datetimeValue",
               "description": "The estimated time of arrival at the end of the current route"
             },
             "startTime": {
-              "$ref": "../definitions.json#/definitions/timestamp",
+              "$ref": "../definitions.json#/definitions/datetimeValue",
               "description": "The time this route was activated"
             }
           }
@@ -51,38 +51,43 @@
             "$ref": "../definitions.json#/definitions/commonValueFields"
           }, {
             "properties": {
-              "type": {
-                "description": "The type of the next point (e.g. Waypoint, POI, Race Mark, etc)",
-                "type": "string"
-              },
-              "href": {
-                "description": "A reference (URL) to an object (under resources) this point is related to",
-                "type": "string"
+              "value": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "The type of the next point (e.g. Waypoint, POI, Race Mark, etc)",
+                    "type": "string"
+                  },
+                  "href": {
+                    "description": "A reference (URL) to an object (under resources) this point is related to",
+                    "type": "string"
+                  }
+                }
               },
               "distance": {
                 "description": "The distance in meters between the vessel's present position and the nextPoint",
                 "units": "m",
-                "type": "number"
+                "$ref": "../definitions.json#/definitions/numberValue"
               },
               "bearingTrue": {
                 "description": "The bearing of a line between the vessel's current position and nextPoint, relative to true north",
                 "units": "rad",
-                "type": "number"
+                "$ref": "../definitions.json#/definitions/numberValue"
               },
               "bearingMagnetic": {
                 "description": "The bearing of a line between the vessel's current position and nextPoint, relative to magnetic north",
                 "units": "rad",
-                "type": "number"
+                "$ref": "../definitions.json#/definitions/numberValue"
               },
               "velocityMadeGood": {
                 "description": "The velocity component of the vessel towards the nextPoint",
                 "units": "m/s",
-                "type": "number"
+                "$ref": "../definitions.json#/definitions/numberValue"
               },
               "timeToGo": {
                 "description": "Time in seconds to reach nextPoint's perpendicular) with current speed & direction",
                 "units": "s",
-                "type": "number"
+                "$ref": "../definitions.json#/definitions/numberValue"
               },
               "position": {
                 "type": "object",
@@ -106,18 +111,23 @@
             "$ref": "../definitions.json#/definitions/commonValueFields"
           }, {
             "properties": {
-              "type": {
-                "description": "The type of the previous point (e.g. Waypoint, POI, Race Mark, etc)",
-                "type": "string"
-              },
-              "href": {
-                "description": "A reference (URL) to an object (under resources) this point is related to",
-                "type": "string"
+              "value": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "The type of the previous point (e.g. Waypoint, POI, Race Mark, etc)",
+                    "type": "string"
+                  },
+                  "href": {
+                    "description": "A reference (URL) to an object (under resources) this point is related to",
+                    "type": "string"
+                  }
+                }
               },
               "distance": {
                 "description": "The distance in meters between previousPoint and the vessel's present position",
                 "units": "m",
-                "type": "number"
+                "$ref": "../definitions.json#/definitions/numberValue"
               },
               "position": {
                 "type": "object",

--- a/test/data/course.json
+++ b/test/data/course.json
@@ -34,34 +34,62 @@
 
           "activeRoute": {
             "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/routes/urn:mrn:signalk:uuid:3dd34dcc-36bf-4d61-ba80-233799b25672",
-            "estimatedTimeOfArrival": "2016-04-24T06:24:18.632Z",
-            "startTime": "2016-04-24T05:14:18.632Z"
+            "estimatedTimeOfArrival": {
+              "value": "2016-04-24T06:24:18.632Z",
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "startTime": {
+              "value": "2016-04-24T05:14:18.632Z",
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            }
           },
 
           "nextPoint": {
-            "type": "Waypoint",
-            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:4fe4ff38-879a-46ed-9a7d-7caeea475241",
-            "distance": 2407.6000020320143,
-            "bearingTrue": 0.9162978572970231,
-            "velocityMadeGood": 0.2572222873852017,
-            "timeToGo": 9628,
+            "value": {
+              "type": "Waypoint",
+              "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:4fe4ff38-879a-46ed-9a7d-7caeea475241"
+            },
+            "timestamp": "(...)",
+            "$source": "a.suitable.path",
+            "distance": {
+              "value": 2407.6000020320143,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "bearingTrue": {
+              "value": 0.9162978572970231,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "velocityMadeGood": {
+              "value": 0.2572222873852017,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "timeToGo": {
+              "value": 9628,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
             "position": {
               "latitude": 49.287333333333336,
               "longitude": -123.1595
-            },
-            "timestamp": "(...)",
-            "$source": "a.suitable.path"
+            }
           },
 
           "previousPoint": {
-            "type": "Waypoint",
-            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:dd4a4c06-0c1d-4b5e-90c3-963649ee5e6d",
+            "value": {
+              "type": "Waypoint",
+              "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:dd4a4c06-0c1d-4b5e-90c3-963649ee5e6d"
+            },
+            "timestamp": "(...)",
+            "$source": "a.suitable.path",
             "position": {
               "latitude": 49.287333333333336,
               "longitude": -123.1595
-            },
-            "timestamp": "(...)",
-            "$source": "a.suitable.path"
+            }
           }
         },
 
@@ -86,34 +114,62 @@
 
           "activeRoute": {
             "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/routes/urn:mrn:signalk:uuid:3dd34dcc-36bf-4d61-ba80-233799b25672",
-            "estimatedTimeOfArrival": "2016-04-24T06:24:18.632Z",
-            "startTime": "2016-04-24T05:14:18.632Z"
+            "estimatedTimeOfArrival": {
+              "value": "2016-04-24T06:24:18.632Z",
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "startTime": {
+              "value": "2016-04-24T05:14:18.632Z",
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            }
           },
 
           "nextPoint": {
-            "type": "Waypoint",
-            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:4fe4ff38-879a-46ed-9a7d-7caeea475241",
-            "distance": 2407.6000020320143,
-            "bearingTrue": 0.9162978572970231,
-            "velocityMadeGood": 0.2572222873852017,
-            "timeToGo": 9628,
+            "value": {
+              "type": "Waypoint",
+              "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:4fe4ff38-879a-46ed-9a7d-7caeea475241"
+            },
+            "timestamp": "(...)",
+            "$source": "a.suitable.path",
+            "distance": {
+              "value": 2407.6000020320143,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "bearingTrue": {
+              "value": 0.9162978572970231,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "velocityMadeGood": {
+              "value": 0.2572222873852017,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
+            "timeToGo": {
+              "value": 9628,
+              "timestamp": "(...)",
+              "$source": "a.suitable.path"
+            },
             "position": {
               "latitude": 49.287333333333336,
               "longitude": -123.1595
-            },
-            "timestamp": "(...)",
-            "$source": "a.suitable.path"
+            }
           },
 
           "previousPoint": {
-            "type": "Waypoint",
-            "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:dd4a4c06-0c1d-4b5e-90c3-963649ee5e6d",
+            "value": {
+              "type": "Waypoint",
+              "href": "/vessels/vessels.urn:mrn:imo:mmsi:230099999/resources/waypoints/urn:mrn:signalk:uuid:dd4a4c06-0c1d-4b5e-90c3-963649ee5e6d"
+            },
+            "timestamp": "(...)",
+            "$source": "a.suitable.path",
             "position": {
               "latitude": 49.287333333333336,
               "longitude": -123.1595
-            },
-            "timestamp": "(...)",
-            "$source": "a.suitable.path"
+            }
           }
         }
       }


### PR DESCRIPTION
This PR "itemizes" course properties: each is pushed under `value` property and accompanied with timestamp, source and values structure.

This makes possible to update them individually and retain source and timestamp information. 

More importantly this is in line with using just leaf paths in delta.

The possible backwards compatibility issue with this is that if a source has produced object valued deltas it should now send scalar-valued deltas, with the properties in individual pathvalues.