### PR TITLE
Clarify context and allow for update-specific contexts

### DIFF
--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -161,8 +161,7 @@ In more detail we have the header section:
 ```json
 {
   "context": {
-    "scope": "vessel",
-    "id":"vessels.urn:mrn:imo:mmsi:234567890"
+    "vessel": "urn:mrn:imo:mmsi:234567890"
   },
   "updates": [
     ...data goes here...
@@ -178,10 +177,9 @@ required).
 
 The `context` property determines the default scope to which the `updates` should be applied. If not specified, it
 defaults to the vessel for the server sending the delta message (as determined by its `self` attribute).
-The `scope` property may be one of following values (as specified by the `contextScope` enum):
+Exactly one of the following properties may be used:
 
-|Scope|Description|Id|
-|vessel|A single vessel|The unique identifier for the vessel.|
+ `vessel`, a `string` uniquely identifying the vessel
 
 For compatibility with early servers, the `context` property may also be supplied as a `string` in the format
 `vessels.{vesselId}`. This feature is deprecated and may be removed in later versions of this specification.
@@ -228,14 +226,15 @@ In cases where you can get data from only a single source the source may be omit
 
 ### Alternative
 `values` could be an object property containing the new values, for example:
- ```json
- {
-   "values": {
-     "navigation.courseOverGroundTrue": 2.971,
-     "navigation.speedOverGround": 3.85
-   }  
- }
- ```
+```json
+{
+  "values": {
+    "navigation.courseOverGroundTrue": 2.971,
+    "navigation.speedOverGround": 3.85
+  }  
+}
+```
+
 ## Message Integrity
 
 Many messaging systems specify checksums or other forms of message integrity checking. In Signal K we assume a reliable

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -7,11 +7,30 @@
   "required": [
     "updates"
   ],
+  "definitions": {
+    "context": {
+      "oneOf":[{
+        "type": "string",
+        "description": "Legacy format where the vessel is specified as a structured string",
+        "example": "vessels.urn:mrn:signalk:uuid:6b0e776f-811a-4b35-980e-b93405371bc5",
+        "pattern": "^vessels\\."
+      }, {
+        "type": "object",
+        "properties":{
+          "vessel": {
+            "type": "string",
+            "description": "Updates apply to the vessel identified by this property's value."
+          }
+        },
+        "minProperties": 1,
+        "maxProperties": 1,
+        "additionalProperties": false
+      }]
+    }
+  },
   "properties": {
     "context": {
-      "type": "string",
-      "description": "The context path of the updates, eg. the top level path plus object identifier.",
-      "example": "vessels.urn:mrn:signalk:uuid:6b0e776f-811a-4b35-980e-b93405371bc5"
+      "$ref": "#/definitions/context"
     },
     "updates": {
       "type": "array",
@@ -38,32 +57,39 @@
           "timestamp": {
             "$ref": "./definitions.json#/definitions/timestamp"
           },
+          "context": {
+            "$ref": "#/definitions/context"
+          },
           "values": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "path",
-                "value"
-              ],
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "description": "The local path to the data value",
-                  "example": "navigation.courseOverGroundMagnetic"
-                },
-                "value": {
-                  "type": [
-                    "string",
-                    "number",
-                    "object",
-                    "boolean",
-                    "null"
-                  ],
-                  "additionalProperties": true
+            "oneOf": [{
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "path",
+                  "value"
+                ],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "The local path to the data value",
+                    "example": "navigation.courseOverGroundMagnetic"
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "number",
+                      "object",
+                      "boolean",
+                      "null"
+                    ],
+                    "additionalProperties": true
+                  }
                 }
               }
-            }
+            }, {
+              "type": "object"
+            }]
           }
         }
       }


### PR DESCRIPTION
Allow `context` to be supplied as a object rather than a `.` delimited string (while still supporting the older format for backwards compatibility).

Allow `context` to be specified for each individual update to allow deltas to span multiple contexts (e.g. updating all vessels in a race or commercial fleet).

Proposes an alternative representation for an update as a simple object rather than path/value pairs. The two forms can be distinguished by the type of the `values` property making this a backward compatible, additive change.