### PR TITLE
feature: add metadata handling to js lib

### DIFF
--- a/gitbook-docs/data_model_metadata.md
+++ b/gitbook-docs/data_model_metadata.md
@@ -13,6 +13,8 @@ Currently the Signal K server has a set of specific alarm keys. These grow over 
 Each data key should have an optional ```.meta``` object. This holds data in a standard way which enables the max/min/alarm and display to be automatically derived.
 ```json
 {
+  "units": "Hz",
+  "description": "Engine revolutions (x60 for RPM)",
   "displayName": "Tachometer, Engine 1",
   "shortName": "RPM",
   "warnMethod": "visual",

--- a/gitbook-docs/data_model_metadata.md
+++ b/gitbook-docs/data_model_metadata.md
@@ -38,7 +38,7 @@ The alarms functionality then becomes generic, and grows with the spec. This is 
 
 #### Meta.units value
 
-All keys in the specification must have `units`. If a client requests the `meta.units` for a valid key eg  `GET /signalk/v1/api/vessels/123456789/navigation/speedThroughWater/meta/units`, the REST interface MUST return proper value.
+All keys in the specification must have `units`. If a client requests the `meta.units` for a valid key eg  `GET /signalk/v1/api/vessels/123456789/navigation/speedThroughWater/meta/units`, the REST interface MUST return proper value, even if that particular data key has no data in the full model of that server.
 
 See https://github.com/SignalK/specification/blob/_version_/keyswithmetadata.json
 

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -532,6 +532,13 @@
           "example": "RPM"
         },
 
+        "description": {
+          "type": "string",
+          "title": "ShortName schema.",
+          "description": "A short name for this value.",
+          "example": "RPM"
+        },
+
         "gaugeType": {
           "type": "string",
           "title": "gaugeType schema.",

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -534,9 +534,9 @@
 
         "description": {
           "type": "string",
-          "title": "ShortName schema.",
-          "description": "A short name for this value.",
-          "example": "RPM"
+          "title": "Description schema.",
+          "description": "Description of the SK path.",
+          "example": "Engine revolutions (x60 for RPM)"
         },
 
         "gaugeType": {

--- a/src/index.js
+++ b/src/index.js
@@ -273,3 +273,30 @@ module.exports.FullSignalK = FullSignalK;
 module.exports.fakeMmsiId = "urn:mrn:imo:mmsi:230099999";
 module.exports.getSourceId = getSourceId;
 module.exports.keyForSourceIdPath = keyForSourceIdPath;
+
+module.exports.metadata = require('./keyswithmetadata');
+
+var metadataByRegex = []
+_.forIn(module.exports.metadata, (value, key) => {
+  const regexpKey =
+    '^' + key.replace(/\*/g, '.*').replace(/RegExp/g, '.*') + '$'
+  if (!regexpKey.endsWith('.*$')) {
+    metadataByRegex.push({
+      regexp: new RegExp(regexpKey),
+      metadata: value
+    })
+  }
+})
+
+module.exports.getUnits = function (path) {
+  const meta = module.exports.getMetadata(path)
+  return meta ? meta.units : undefined
+}
+
+module.exports.getMetadata = function (path) {
+  const result = metadataByRegex.find(entry =>
+    entry.regexp.test('/' + path.replace(/\./g, '/'))
+  )
+  return result ? result.metadata : undefined
+}
+

--- a/test/fullsignalk.js
+++ b/test/fullsignalk.js
@@ -94,7 +94,6 @@ describe('FullSignalK', function() {
       "context": "vessels.urn:mrn:imo:mmsi:276780000"
     };
     var fullSignalK = new FullSignalK("urn:mrn:imo:mmsi:276799999", "mmsi");
-    console.log(JSON.stringify(fullSignalK, null, 2))
     fullSignalK.addDelta(aisDelta);
     fullSignalK.retrieve().should.be.validSignalK;
 

--- a/test/schema-api.js
+++ b/test/schema-api.js
@@ -1,0 +1,56 @@
+var chai = require('chai')
+chai.Should()
+const expect = chai.expect
+const signalkSchema = require('../dist/')
+
+describe('metadata:getUnits', function () {
+  it('Valid simple getUnits works', function () {
+    signalkSchema.getUnits('vessels.foo.navigation.speedOverGround').should.equal('m/s')
+  })
+
+  it('Valid complex path getUnits works', function () {
+    signalkSchema.getUnits('vessels.foo.propulsion.0.oilTemperature').should.equal('K')
+  })
+
+  it('Invalid getUnits returns undefined', function () {
+    expect(signalkSchema.getUnits('vessels.foo.bar.0.oilTemperature')).to.be.undefined
+  })
+})
+
+describe('metadata:getMetadata', function () {
+  it('Valid simple getMetadata works', function () {
+    signalkSchema.getMetadata('vessels.foo.navigation.speedOverGround').should.deep.equal({
+      units: 'm/s',
+      description: "Vessel speed over ground. If converting from AIS 'HIGH' value, set to 102.2 (Ais max value) and add warning in notifications"
+    })
+  })
+
+  it('Valid complex path getMetadata works', function () {
+    signalkSchema.getMetadata('vessels.foo.propulsion.0.oilTemperature').should.deep.equal({
+      units: 'K',
+      description: 'Oil temperature'
+    })
+  })
+
+  it('Invalid getMetadata returns undefined', function () {
+    expect(signalkSchema.getMetadata('vessels.foo.0.oilTemperature')).to.be.undefined
+  })
+
+  it('getMetadata for path with enum works', function () {
+    expect(
+      signalkSchema.getMetadata('vessels.foo.navigation.datetime.gnssTimeSource')
+    ).to.deep.equal({
+      description: 'Source of GNSS Date and Time',
+      enum: [
+        'GPS',
+        'GLONASS',
+        'Galileo',
+        'Beidou',
+        'IRNSS',
+        'Radio Signal',
+        'Internet',
+        'Local clock'
+      ]
+    })
+  })
+})


### PR DESCRIPTION
This PR adds functions `getMetadata(path)` and `getUnits(path)` to the published js module and uses these to include metadata in the main `/vessels`branch of the full model.