### PR TITLE
Tanks

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -226,9 +226,9 @@
         },
         "Pa/s": {
           "display": "Pa/s",
-          "quantity": "Pressure rate",
+          "quantity": "Pressure rate, also viscosity",
           "quantityDisplay": "R",
-          "description": "Pressure change rate in pascal per second"
+          "description": "Pressure change rate in pascal per second, also used for viscosity"
         }
       }
     },

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -98,6 +98,12 @@
           "quantityDisplay": "Q",
           "description": "Liquid or gas flow in cubic meters per second"
         },
+        "kg/m3": {
+          "display": "kg/m3",
+          "quantity": "Density",
+          "quantityDisplay": "kg/m3",
+          "description": "Density in kg per cubic meters"
+        },
         "deg": {
           "display": "\u00b0",
           "quantity": "Angle",

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -114,14 +114,6 @@
           "description": "Water salinity",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "ratio"
-        },
-        "liveWell": {
-          "description": "Current livewell temperature",
-          "$ref": "#/definitions/objectWithTemperature"
-        },
-        "baitWell": {
-          "description": "Current baitwell air temperature",
-          "$ref": "#/definitions/objectWithTemperature"
         }
       }
     },

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -5,14 +5,39 @@
   "description": "Schema describing the environmental child-object of a Vessel.",
   "title": "environment",
   "definitions": {
-    "objectWithTemperature": {
+    "zoneObject": {
       "type": "object",
       "properties": {
         "temperature": {
           "description": "Temperature",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "K"
-        }
+        },
+        "pressure": {
+					"description": "Pressure in zone",
+					"units": "Pa",
+					"$ref": "../definitions.json#/definitions/numberValue"
+				},
+				"relativeHumidity": {
+					"description": "Relative humidity in zone",
+					"units": "ratio",
+					"$ref": "../definitions.json#/definitions/numberValue"
+				},
+				"dewPoint": {
+					"description": "Dewpoint in zone",
+					"units": "K",
+					"$ref": "../definitions.json#/definitions/numberValue"
+				},
+				"airDensity": {
+					"description": "Air density in zone",
+					"units": "kg/m3",
+					"$ref": "../definitions.json#/definitions/numberValue"
+				},
+				"illuminance": {
+					"description": "Illuminance in zone",
+					"units": "Lux",
+					"$ref": "../definitions.json#/definitions/numberValue"
+				}
       }
     }
   },
@@ -79,24 +104,24 @@
         },
         "engineRoom": {
           "description": "Current engine room air temperature",
-          "$ref": "#/definitions/objectWithTemperature"
+          "$ref": "#/definitions/zoneObject"
         },
         "mainCabin": {
           "description": "Current main cabin air temperature",
-          "$ref": "#/definitions/objectWithTemperature"
+          "$ref": "#/definitions/zoneObject"
         },
 
         "refrigerator": {
           "description": "Current refrigerator temperature",
-          "$ref": "#/definitions/objectWithTemperature"
+          "$ref": "#/definitions/zoneObject"
         },
         "freezer": {
           "description": "Current freezer temperature",
-          "$ref": "#/definitions/objectWithTemperature"
+          "$ref": "#/definitions/zoneObject"
         },
         "heating": {
           "description": "Current heating temperature",
-          "$ref": "#/definitions/objectWithTemperature"
+          "$ref": "#/definitions/zoneObject"
         }
       }
     },

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -22,9 +22,12 @@
                 "petrol",
                 "fresh water",
                 "greywater",
+                "blackwater",
                 "holding",
                 "lpg",
                 "diesel",
+                "liveWell",
+                "ballast",
                 "rum"
               ]
             },
@@ -45,6 +48,25 @@
               "description": "Volume of fluid in tank",
               "units": "m3",
               "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            "pressure": {
+              "description": "Pressure of contents in tank, especially LPG/gas",
+              "units": "Pa",
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            "temperature": {
+              "description": "Temperature of tank, especially cryogenic or LPG/gas",
+              "units": "K",
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            "viscosity": {
+              "description": "Viscosity of the fluid, if applicable",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "Pa/s"
+            },
+            "extinguishant": {
+              "description": "The preferred extinguishant to douse a fire in this tank",
+              "$ref": "../definitions.json#/definitions/stringValue"
             }
           }
         }
@@ -74,6 +96,14 @@
     },
     "liveWell": {
       "description": "Live tank (fish)",
+      "$ref": "#/definitions/tankCollection"
+    },
+    "gas": {
+      "description": "Lpg/propane and other gases",
+      "$ref": "#/definitions/tankCollection"
+    },
+    "ballast": {
+      "description": "Ballast tanks",
       "$ref": "#/definitions/tankCollection"
     }
   }

--- a/test/data/tanks.json
+++ b/test/data/tanks.json
@@ -14,6 +14,27 @@
           "timestamp": "2014-08-15T19:00:15.402Z"
         }
       }
-    }
+    },
+		"liveWell": {
+			"live1":{
+				"temperature": {
+					"value": 0,
+					"$source": ".36.0",
+					"timestamp": "2017-01-24T23:59:01Z",
+					"pgn": 130312
+				}
+			}
+		},
+		"liveWell": {
+			"bait1":{
+				"temperature": {
+					"value": 0,
+					"$source": ".36.0",
+					"timestamp": "2017-01-24T23:59:01Z",
+					"pgn": 130312
+				}
+			}
+		}
+    
   }
 }

--- a/test/data/temperatures.json
+++ b/test/data/temperatures.json
@@ -9,22 +9,6 @@
             "$source": ".36.0",
             "timestamp": "2017-01-24T23:59:01Z",
             "pgn": 130312
-          },
-          "liveWell": {
-            "temperature": {
-              "value": 0,
-              "$source": ".36.0",
-              "timestamp": "2017-01-24T23:59:01Z",
-              "pgn": 130312
-            }
-          },
-          "baitWell": {
-            "temperature": {
-              "value": 0,
-              "$source": ".36.0",
-              "timestamp": "2017-01-24T23:59:01Z",
-              "pgn": 130312
-            }
           }
         },
         "outside": {


### PR DESCRIPTION
See #303 
Removed `liveWell` and `baitWell` from `environment.water`, and added attributes to the `tanks` to compensate.
This will affect N2K mapping for pgn 130312. 
This cleans up the majority of the tanks part of #303 