### PR TITLE
fix: fix dollarsource references in full tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,8 +239,11 @@ function getSourceId(source) {
       (source.src ? '.' + source.src : '') +
       (source.instance ? '.' + source.instance : '');
   }
-  return source.label +
-    (source.talker ? '.' + source.talker : '.XX');
+  if (typeof source === 'object') {
+    return source.label + (source.talker ? '.' + source.talker : '.XX');
+  }
+  //source data is actually from $source, not source: {...}
+  return source
 }
 
 function keyForSourceIdPath(sourceId, path) {

--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -104,7 +104,7 @@ FullSignalK.prototype.addUpdate = function(context, update) {
   } else {
     console.error("No source in delta update:" + JSON.stringify(update));
   }
-  addValues(context, update.source, update.timestamp, update.values);
+  addValues(context, update.source || update['$source'], update.timestamp, update.values);
 }
 
 FullSignalK.prototype.updateDollarSource = function(context, dollarSource, timestamp) {

--- a/test/fullsignalk.js
+++ b/test/fullsignalk.js
@@ -156,4 +156,27 @@ describe('FullSignalK', function() {
     full.sources['N2K'].should.have.property('36');
     full.sources['N2K']['36'].should.have.property('0');
   })
+
+  it('Delta with $source produces sources hierarchy and correct $source reference', function() {
+
+    var msg =   {
+      "context": "vessels.urn:mrn:imo:mmsi:276810000",
+      "updates": [{
+        "$source": "1W.0316013faeff",
+        "values": [{
+          "path": "propulsion.engine1.temperature",
+          "value": 301.837
+        }]
+      }]
+    }
+
+    var fullSignalK = new FullSignalK();
+    fullSignalK.addDelta(msg);
+    var full = fullSignalK.retrieve();
+    full.sources.should.have.property('1W');
+    full.sources['1W'].should.have.property('0316013faeff');
+    var vessel = full.vessels['urn:mrn:imo:mmsi:276810000'];
+    vessel.propulsion.engine1.temperature.should.have.property('$source', '1W.0316013faeff')
+  })
+
 })


### PR DESCRIPTION
$source references in the full tree were being filled with `no_source` values, because $source data was not being handled previously.

Fix and add a test to cover this case.
