### PR TITLE
Add reef and furl state to sails [WIP]

### DIFF
--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -1,96 +1,121 @@
 {
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/schemas/0.9.0-SNAPSHOT/groups/sails.json#",
-  "description": "An object describing the vessels sails if the vessel is a sailboat.",
-  "title": "sails",
+	"type": "object",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "https://signalk.org/specification/schemas/0.9.0-SNAPSHOT/groups/sails.json#",
+	"description": "An object describing the vessels sails if the vessel is a sailboat.",
+	"title": "sails",
 
-  "properties": {
-    "inventory": {
-      "type": "object",
-      "description": "An object containing a description of each sail available to the vessel crew",
-      "patternProperties": {
-        "(^[a-zA-Z0-9]+$)": {
-          "type": "object",
-          "description": "'sail' data type.",
-          "required": ["name", "type", "active", "area"],
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "An unique identifier by which the crew identifies a sail",
-              "example": "J1"
-            },
+	"properties": {
+		"inventory": {
+			"type": "object",
+			"description": "An object containing a description of each sail available to the vessel crew",
+			"patternProperties": {
+				"(^[a-zA-Z0-9]+$)": {
+					"type": "object",
+					"description": "'sail' data type.",
+					"required": ["name", "type", "active", "area"],
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "An unique identifier by which the crew identifies a sail",
+							"example": "J1"
+						},
 
-            "type": {
-              "type": "string",
-              "description": "The type of sail",
-              "example": "Genaker"
-            },
+						"type": {
+							"type": "string",
+							"description": "The type of sail",
+							"example": "Genaker"
+						},
 
-            "material": {
-              "type": "string",
-              "description": "The material the sail is made from (optional)",
-              "example": "canvas"
-            },
-            "brand": {
-              "type": "string",
-              "description": "The brand of the sail (optional)",
-              "example": "North Sails"
-            },
-            "active": {
-              "type": "boolean",
-              "description": "Indicates wether this sail is currently in use or not"
-            },
-            "area": {
-              "type": "number",
-              "description": "The total area of this sail in square meters",
-              "units": "m2"
-            },
-            "minimumWind": {
-              "type": "number",
-              "description": "The minimum wind speed this sail can be used with",
-              "units": "m/s",
-              "default": 0
-            },
-            "maximumWind": {
-              "type": "number",
-              "description": "The maximum wind speed this sail can be used with",
-              "units": "m/s",
-              "default": 666
-            },
-            "timestamp": {
-              "$ref": "../definitions.json#/definitions/timestamp"
-            },
-            "source": {
-              "$ref": "../definitions.json#/definitions/source"
-            },
-            "_attr": {
-              "$ref": "../definitions.json#/definitions/_attr"
-            },
-            "meta": {
-              "$ref": "../definitions.json#/definitions/meta"
-            }
-          }
-        }
-      }
-    },
+						"material": {
+							"type": "string",
+							"description": "The material the sail is made from (optional)",
+							"example": "canvas"
+						},
+						"brand": {
+							"type": "string",
+							"description": "The brand of the sail (optional)",
+							"example": "North Sails"
+						},
+						"active": {
+							"type": "boolean",
+							"description": "Indicates wether this sail is currently in use or not"
+						},
+						"area": {
+							"type": "number",
+							"description": "The total area of this sail in square meters",
+							"units": "m2"
+						},
+						"minimumWind": {
+							"type": "number",
+							"description": "The minimum wind speed this sail can be used with",
+							"units": "m/s",
+							"default": 0
+						},
+						"maximumWind": {
+							"type": "number",
+							"description": "The maximum wind speed this sail can be used with",
+							"units": "m/s",
+							"default": 666
+						},
+						"state": {
+							"oneOf": [{
+									"title": "Reefable",
+									"properties": {
+										"reefs": {
+											"type": "number",
+											"description": "Number of reefs set, 0 means full",
+											"default": 0
+										}
+									}
 
-    "area": {
-      "type": "object",
-      "description": "An object containing information about the vessels' sails.",
-      "properties": {
-        "total": {
-          "description": "The total area of all sails on the vessel",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "m2"
-        },
+								},
+								{
+									"title": "Furlable",
+									"properties": {
+										"furledRatio": {
+											"type": "number",
+											"description": "Ratio of sail reduction, 0 means full and 1 is completely furled in",
+											"default": 0
+										}
+									}
+								}
 
-        "active": {
-          "description": "The total area of the sails currently in use on the vessel",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "m2"
-        }
-      }
-    }
-  }
+							]
+						},
+						"timestamp": {
+							"$ref": "../definitions.json#/definitions/timestamp"
+						},
+						"source": {
+							"$ref": "../definitions.json#/definitions/source"
+						},
+						"_attr": {
+							"$ref": "../definitions.json#/definitions/_attr"
+						},
+						"meta": {
+							"$ref": "../definitions.json#/definitions/meta"
+						}
+					}
+				}
+			}
+		},
+
+		"area": {
+			"type": "object",
+			"description": "An object containing information about the vessels' sails.",
+			"properties": {
+				"total": {
+					"description": "The total area of all sails on the vessel",
+					"$ref": "../definitions.json#/definitions/numberValue",
+					"units": "m2"
+				},
+
+				"active": {
+					"description": "The total area of the sails currently in use on the vessel",
+					"$ref": "../definitions.json#/definitions/numberValue",
+					"units": "m2"
+				}
+			}
+		}
+	}
 }

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -58,31 +58,31 @@
 							"units": "m/s",
 							"default": 666
 						},
-						"state": {
+						"reducedState": {
 							"oneOf": [{
-									"title": "Reefable",
-									"properties": {
-										"reefs": {
-											"type": "number",
-											"description": "Number of reefs set, 0 means full",
-											"default": 0
+								"properties":{
+									"Reefable":{
+										"properties": {
+											"reefs": {
+												"type": "number",
+												"description": "Number of reefs set, 0 means full",
+												"default": 0
+											}
 										}
-									}
-
-								},
-								{
-									"title": "Furlable",
-									"properties": {
-										"furledRatio": {
-											"type": "number",
-											"description": "Ratio of sail reduction, 0 means full and 1 is completely furled in",
-											"default": 0
+									},
+									"Furlable":{
+										"properties": {
+											"furledRatio": {
+												"type": "number",
+												"description": "Ratio of sail reduction, 0 means full and 1 is completely furled in",
+												"default": 0
+											}
 										}
 									}
 								}
-
-							]
-						},
+							}
+						]
+					},
 						"timestamp": {
 							"$ref": "../definitions.json#/definitions/timestamp"
 						},

--- a/test/data/sails.json
+++ b/test/data/sails.json
@@ -28,7 +28,12 @@
         "material": "dacron",
         "brand": "WB Sails",
         "area": 33.8,
-        "active": true
+        "active": true,
+        "reducedState": {
+          "Reefable": {
+            "reefs" : 0
+          }
+        }
       },
       "genoa": {
         "name": "Cruising genoa",
@@ -36,7 +41,12 @@
         "material": "dacron",
         "brand": "North Sails",
         "area": 44.6,
-        "active": true
+        "active": true,
+        "reducedState": {
+          "Furlable": {
+            "furledRatio" : 0
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This is an attempt to solve https://github.com/SignalK/specification/issues/188 by allowing both reefable and furlable sails to be status-ed. 

This has come up again with @tkurki 's https://github.com/SignalK/sailsconfiguration where `state` is introduced, but not in schema. Either a sail is reefable (full, 1, 2, ..) or furlable. Other means of reducing sails that I know of such as for gaff sails and square sails are temporary by nature. (correct me if I am wrong).