### PR TITLE
Add Alternator and Solar devices, create chargerQualitiies + cleanups 

### DIFF
--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -33,16 +33,20 @@
             "model": {
               "type": "string",
               "description": "Model or part number"
+            },
+            "URL": {
+              "type": "string",
+              "description": "Web referance / URL"
             }
           }
         }
       }
     },
 
-    "dcQuantities": {
+    "dcQualities": {
       "type": "object",
-      "title": "DC Quantities",
-      "description": "DC common quantities",
+      "title": "DC Qualities",
+      "description": "DC common qualities",
       "properties": {
         "associatedBus": {
           "type": "string",
@@ -51,7 +55,7 @@
 
         "voltage": {
           "type": "object",
-          "description": "Voltage measured as close as possible to the device",
+          "description": "Voltage measured at or as close as possible to the device",
           "units": "V",
           "allOf": [{
             "$ref": "../definitions.json#/definitions/numberValue"
@@ -177,18 +181,18 @@
       }
     },
 
-    "acQuantities": {
+    "acQualities": {
       "type": "object",
-      "title": "AC Quantities",
-      "description": "AC equipment common quantities",
+      "title": "AC Qualities",
+      "description": "AC equipment common qualities",
       "properties": {
         "associatedBus": {
           "type": "string",
-          "description": "Name of BUS source is assocated with (if applicable, may = NULL)"
+          "description": "Name of BUS device is associated with"
         },
         "lineNeutralVoltage": {
           "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "RMS voltage measured between phase and neutral.",
+          "description": "RMS voltage measured between phase and neutral",
           "units": "V"
         },
         "lineLineVoltage": {
@@ -238,11 +242,104 @@
           "units": "W"
         }
       }
+    },
+  
+    "chargerQualities": {
+      "type": "object",
+      "title": "Charger Qualities",
+      "description": "Common charger qualities",
+      "properties": {
+        "allOf": [{
+            "$ref": "#/definitions/identity"
+            }],
+        "chargingAlgorithm": {
+          "type": "object",
+          "description": "Algorithm being used by the charger",
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/commonValueFields"
+            },
+            {
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "enum": [
+                    "trickle",
+                    "two stage",
+                    "three stage",
+                    "four stage",       
+                    "constant current",
+                    "constant voltage",
+                    "custom profile"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "chargerRole": {
+          "type": "object",
+          "description": "How is charging source configured?  Standalone, or in sync with another charger?",
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/commonValueFields"
+            },
+            {
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "enum": [
+                    "standalone",
+                    "master",
+                    "slave",
+                    "standby"
+                   ]
+                }
+              }
+            }
+          ]
+        },
+        "chargingMode": {
+          "type": "object",
+          "description": "Charging mode i.e. float, overcharge, etc.",
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/commonValueFields"
+            },
+            {
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "enum": [
+                    "bulk",
+                    "acceptance",
+                    "overcharge",
+                    "float",
+                    "equalize",
+                    "unknown",
+                    "other"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+       "setpointVoltage": {
+          "description": "Target regulation voltage",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "V"
+       }, 
+       "setpointCurrent": {
+          "description": "Target current limit",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "A"
+      }
     }
+  }
   },
-
-
-  "properties": {
+  
+  
+  "properties": { 
     "batteries": {
       "description": "Data about the vessel's batteries",
       "patternProperties": {
@@ -250,240 +347,311 @@
           "type": "object",
           "title": "Battery keyed by instance id",
           "description": "Batteries, one or many, within the vessel",
-
           "allOf": [{
-            "properties": {
-              "meta": {
-                "allOf": [{
-                  "$ref": "#/definitions/identity"
-                }, {
-                  "properties": {
-                    "chemistry": {
-                      "type": "string",
-                      "description": "Type of battery FLA, LiFePO4, etc."
-                    }
-                  }
-                }]
-              },
+              "$ref": "#/definitions/identity"
+               },{
+              "$ref": "#/definitions/dcQualities"
+              }],
+           "properties": { 
+            "chemistry": {
+              "type": "string",
+              "description": "Type of battery FLA, LiFePO4, etc."
+            },
+            "temperature": {
+              "type": "object",
+              "title": "temperature",
+              "description": "Additional / unique temperatures associated with a battery",
+              "properties": {
+                "limitDischargeLower": {
+                  "type": "number",
+                  "description": "Operational minimum temperature limit for battery discharge",
+                  "units": "K"
+                },
 
-              "temperature": {
-                "type": "object",
-                "title": "temperature",
-                "description": "Additional / unique temperatures associated with a battery",
-                "properties": {
-                  "limitDischargeLower": {
-                    "type": "number",
-                    "description": "Operational minimum temperature limit for battery discharge",
-                    "units": "K"
-                  },
+                "limitDischargeUpper": {
+                  "type": "number",
+                  "description": "Operational maximum temperature limit for battery discharge",
+                  "units": "K"
+                },
 
-                  "limitDischargeUpper": {
-                    "type": "number",
-                    "description": "Operational maximum temperature limit for battery discharge",
-                    "units": "K"
-                  },
+                "limitRechargeLower": {
+                  "type": "number",
+                  "description": "Operational minimum temperature limit for battery recharging",
+                  "units": "K"
+                },
 
-                  "limitRechargeLower": {
-                    "type": "number",
-                    "description": "Operational minimum temperature limit for battery recharging",
-                    "units": "K"
-                  },
-
-                  "limitRechargeUpper": {
-                    "type": "number",
-                    "description": "Operational maximum temperature limit for battery recharging",
-                    "units": "K"
-                  }
+                "limitRechargeUpper": {
+                  "type": "number",
+                  "description": "Operational maximum temperature limit for battery recharging",
+                  "units": "K"
                 }
-              },
+              }
+            },
 
-              "capacity": {
-                "type": "object",
-                "description": "Data about the battery's capacity",
-                "title": "capacity",
-                "properties": {
-                  "nominal": {
-                    "type": "number",
-                    "description": "The capacity of battery as specified by the manufacturer",
-                    "units": "J"
-                  },
+            "capacity": {
+              "type": "object",
+              "description": "Data about the battery's capacity",
+              "title": "capacity",
+              "properties": {
+                "nominal": {
+                  "type": "number",
+                  "description": "The capacity of battery as specified by the manufacturer",
+                  "units": "J"
+                },
 
-                  "actual": {
-                    "type": "number",
-                    "description": "The measured capacity of battery. This may change over time and will likely deviate from the nominal capacity.",
-                    "units": "J"
-                  },
+                "actual": {
+                  "type": "number",
+                  "description": "The measured capacity of battery. This may change over time and will likely deviate from the nominal capacity.",
+                  "units": "J"
+                },
 
-                  "remaining": {
-                    "type": "number",
-                    "description": "Capacity remaining in battery",
-                    "units": "J"
-                  },
+                "remaining": {
+                  "type": "number",
+                  "description": "Capacity remaining in battery",
+                  "units": "J"
+                },
 
-                  "dischargeLimit": {
-                    "type": "number",
-                    "description": "Minimum capacity to be left in the battery while discharging",
-                    "units": "J"
-                  },
+                "dischargeLimit": {
+                  "type": "number",
+                  "description": "Minimum capacity to be left in the battery while discharging",
+                  "units": "J"
+                },
 
-                  "stateOfCharge": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "State of charge, 1 = 100%",
-                    "units": "ratio"
-                  },
+                "stateOfCharge": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "description": "State of charge, 1 = 100%",
+                  "units": "ratio"
+                },
 
-                  "stateOfHealth": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "State of Health, 1 = 100%",
-                    "units": "ratio"
-                  },
+                "stateOfHealth": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "description": "State of Health, 1 = 100%",
+                  "units": "ratio"
+                },
 
-                  "dischargeSinceFull": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Cumulative discharge since battery was last full",
-                    "units": "C"
-                  },
+                "dischargeSinceFull": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "description": "Cumulative discharge since battery was last full",
+                  "units": "C"
+                },
 
-                  "timeRemaining": {
-                    "$ref": "../definitions.json#/definitions/numberValue",
-                    "description": "Time to discharge to discharge limit at current rate",
-                    "units": "s"
-                  }
+                "timeRemaining": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "description": "Time to discharge to discharge limit at current rate",
+                  "units": "s"
                 }
-              },
+              }
+            },
 
 
-              "lifetimeDischarge": {
-                "type": "number",
-                "description": "Cumulative charge discharged from battery over operational lifetime of battery",
-                "units": "C"
-              },
+            "lifetimeDischarge": {
+              "type": "number",
+              "description": "Cumulative charge discharged from battery over operational lifetime of battery",
+              "units": "C"
+            },
 
-              "lifetimeRecharge": {
+            "lifetimeRecharge": {
                 "type": "number",
                 "description": "Cumulative charge recharged into battery over operational lifetime of battery",
                 "units": "C"
-              }
             }
-          }, {
-              "$ref": "#/definitions/dcQuantities"
-          }]
+          }
         }
-      }
-    },
-
+      }  
+     },
     "inverters": {
-      "description": "Data about the Inverter that has both DC and AC quantities",
+      "description": "Data about the Inverter that has both DC and AC qualities",
       "patternProperties": {
         "(^[A-Za-z0-9]+$)": {
           "type": "object",
           "title": "Inverter",
           "description": "DC to AC inverter, one or many, within the vessel",
-          "properties": {
-            "meta": {
-              "$ref": "#/definitions/identity"
-            },
+          "allOf": [{
+            "$ref": "#/definitions/identity"
+            }],   
+          "properties": {   
             "dc": {
-              "$ref": "#/definitions/dcQuantities"
+              "$ref": "#/definitions/dcQualities"
             },
             "ac": {
-              "$ref": "#/definitions/acQuantities"
+              "$ref": "#/definitions/acQualities"
             },
-            "mode": {
+            "inverterMode": {
               "type": "object",
               "description": "Mode of inverter",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "enum": [
-                    "idle",
-                    "inverting",
-                    "disabled",
-                    "standby",
-                    "faulted",
-                    "unknown",
-                    "other"
-                  ]
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
                 },
-
-                "timestamp": {
-                  "$ref": "../definitions.json#/definitions/timestamp"
-                },
-
-                "$source": {
-                  "$ref": "../definitions.json#/definitions/sourceRef"
+                {
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "enum": [
+                      "idle",
+                      "inverting",
+                      "disabled",
+                      "standby",
+                      "faulted",
+                      "unknown",
+                      "other"
+                      ]
+                    }
+                  }
                 }
-              }
+              ]
             }
           }
         }
       }
-    },
+    },    
     "chargers": {
-      "description": "Data about the Charger that has both DC and AC quantities",
+      "description": "Data about AC sourced battery charger",
       "patternProperties": {
         "(^[A-Za-z0-9]+$)": {
           "type": "object",
           "title": "Charger",
           "description": "Battery charger",
           "allOf": [{
-            "$ref": "#/definitions/dcQuantities"
-          }, {
-            "properties": {
-              "meta": {
-                "allOf": [{
-                  "$ref": "#/definitions/identity"
-                }, {
-                  "properties": {
-                    "chargingAlgorithm": {
-                      "enum": [
-                        "trickle",
-                        "two stage",
-                        "three stage",
-                        "constant current",
-                        "constant voltage",
-                        "custom profile"
-                      ]
-                    },
-                    "chargerMode": {
-                      "enum": [
-                        "standalone",
-                        "master",
-                        "slave",
-                        "standby"
-                      ]
-                    }
-                  }
-                }]
-              },
-              "mode": {
-                "type": "object",
-                "description": "Charging mode i.e. float, overcharge, etc.",
-                "properties": {
-                  "value": {
-                    "enum": [
-                      "charging bulk",
-                      "charging acceptance",
-                      "charging overcharge",
-                      "charging float",
-                      "charging equalize",
-                      "unknown",
-                      "other"
-                    ]
-                  },
-                  "timestamp": {
-                    "$ref": "../definitions.json#/definitions/timestamp"
-                  },
-                  "source": {
-                    "$ref": "../definitions.json#/definitions/source"
-                  }
-                }
-              }
-            }
+            "$ref": "#/definitions/identity"
+          },{
+            "$ref": "#/definitions/dcQualities"
+          },{
+            "$ref": "#/definitions/chargerQualities"
           }]
         }
       }
     },
+    "alternators": {
+      "description": "Data about an Alternator charging device",
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "type": "object",
+          "title": "Alternator",
+          "description": "Mechanically driven alternator, includes dynamos",
+            "allOf": [{
+                "$ref": "#/definitions/identity"
+              },{
+                "$ref": "#/definitions/dcQualities"
+              },{
+                "$ref": "#/definitions/chargerQualities"
+              }],
+            "properties": {  
+              "revolutions": {
+                "description": "Alternator revolutions per second (x60 for RPM)",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "Hz"
+              },
+              "pulleyRatio": {
+                "description": "Mechanical pulley ratio of driving source (Used to back calculate engine RPMs)",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "ratio"
+              },
+              "fieldDrive": {
+                "description": "% (0..100) of field voltage applied",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "%"
+              },
+              "regulatorTemperature": {
+                "description": "Current temperature of critical regulator components",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "K"
+              }
+            }
+         }
+      }
+    },
+    "solar": {
+      "description": "Data about Solar charging device(s)",
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "type": "object",
+          "title": "Solar",
+          "description": "Photovoltaic charging devices",
+          "allOf": [{
+            "$ref": "#/definitions/identity"
+          },{
+            "$ref": "#/definitions/dcQualities"
+          },{
+            "$ref": "#/definitions/chargerQualities"
+          }],
+          "properties": { 
+            "controllerMode": {
+              "type": "object",
+              "description": "The current state of the engine",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "enum": [
+                         "off",
+                         "idle",
+                         "direct",
+                         "PWM",
+                         "MPPT"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "panelVoltage": {
+                "description": "Voltage being supplied from Solar Panels to controller",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "V"
+            },
+            "panelCurrent": {
+                "description": "Amperage being supplied from Solar Panels to controller",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "A"
+            },
+            "panelTemperature": {
+                "description": "Temperature of panels",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "K"
+            },
+
+            "load": {
+              "type": "object",
+              "description": "State of load port on controller (if applicable)",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "enum": [
+                        "enabled",
+                        "disabled"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },        
+            "loadCurrent": {
+                "description": "Amperage being supplied to load directly connected to controller",
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "A"
+            }
+          }
+        }
+      }
+    },
+
+
+  
+    
+    
+    
+    
+    
     "ac": {
       "description": "AC buses",
       "patternProperties": {
@@ -491,16 +659,16 @@
           "type": "object",
           "title": "AC Bus keyed by instance id",
           "description": "AC Bus, one or many, within the vessel",
+          "allOf": [{
+            "$ref": "#/definitions/identity"
+          }],
           "properties": {
-            "meta": {
-              "$ref": "#/definitions/identity"
-            },
             "phase": {
               "type": "object",
               "description": "Single or A,B or C in 3 Phase systems ",
               "patternProperties": {
                 "(single)|([A-C])": {
-                  "$ref": "#/definitions/acQuantities"
+                  "$ref": "#/definitions/acQualities"
                 }
               }
             }
@@ -510,3 +678,4 @@
     }
   }
 }
+

--- a/test/data/electrical.json
+++ b/test/data/electrical.json
@@ -5,22 +5,20 @@
       "electrical": {
         "batteries": {
           "house1": {
-            "meta": {
               "name": "House battery 1 (forward)",
-              "location": "Under forward bunk",
+              "location": "Lazarette",
               "manufacturer": {
-                "name": "MasterVolt",
-                "model": "AGM 12/130"
+                "name": "Dyno",
+                "model": "D85-29"
               },
-              "chemistry": "FLA"
-            },
+            "chemistry": "FLA",
             "temperature": {
               "value": 290,
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar"
             },
             "voltage": {
-              "value": 12.5,
+              "value": 14.13,
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar",
               "meta": {
@@ -37,12 +35,12 @@
               }
             },
             "current": {
-              "value": 0.1,
+              "value": 124.2,
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar"
             },
             "capacity": {
-              "nominal": 2400,
+              "nominal": 61689600,
               "stateOfCharge": {
                 "value": 81,
                 "timestamp": "2014-08-15T19:00:15.402Z",
@@ -61,14 +59,13 @@
             }
           },
           "house2": {
-            "meta": {
-              "name": "House battery 2 (rear)",
-              "location": "Engine room",
-              "manufacturer": {
-                "name": "MasterVolt",
-                "model": "AGM 12/130"
-              }
-            },
+            "name": "House battery 2",
+            "location": "Engine room",
+            "manufacturer": {
+              "name": "MasterVolt",
+              "model": "AGM 12/130"
+             },
+            "chemistry": "AGM",
             "voltage": {
               "value": 12.8,
               "timestamp": "2014-08-15T19:00:15.402Z",
@@ -101,15 +98,23 @@
         },
         "chargers": {
           "main": {
-            "meta": {
-              "manufacturer": {
-                "name": "C-Tek"
-              },
-              "chargingAlgorithm": "two stage",
-              "chargerMode": "standalone"
+            "manufacturer": {
+              "name": "C-Tek"
             },
-            "mode": {
-              "value": "charging float"
+            "chargingAlgorithm": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "two stage"
+            },
+            "chargerRole": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value":  "standalone"
+            },
+            "chargingMode": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "float"
             },
             "current": {
               "timestamp": "2014-08-15T19:00:15.402Z",
@@ -120,11 +125,9 @@
         },
         "inverters": {
           "main": {
-            "meta": {
-              "location": "Under forward bunk",
-              "manufacturer": {
-                "name": "Xantrex"
-              }
+            "location": "Under forward bunk",
+            "manufacturer": {
+              "name": "Xantrex"
             },
             "dc": {
               "current": {
@@ -154,14 +157,131 @@
                 "$source": "foo.bar",
                 "value": 230
               }
+            },
+            "inverterMode": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "idle"
+            }
+          }
+        },
+        "alternators": {
+          "main": {
+            "location": "Mains - (house) alternator",
+            "manufacturer": {
+              "name": "Leece Neville + Arduino Alt Reg",
+              "model": "4870 + 0.3.6",
+              "URL":  "https://arduinoalternatorregulator.blogspot.com/"         
+            },
+            "associatedBus": "house1",
+            "chargingAlgorithm": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "three stage"
+            },
+            "chargerRole": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value":  "slave"
+            },
+            "chargingMode": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "bulk"
+            },
+            "voltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 14.13
+            },
+            "setpointVoltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 14.52
+            },            
+            "current": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 210.5
+            }
+          }
+        },
+        "solar": {
+          "port240": {
+            "location": "Port array",
+            "manufacturer": {
+              "name": "REC + Morningstar",
+              "model": "REC-240 + Tristar MPPT45"      
+            },
+            "associatedBus": "house1",
+            "chargingAlgorithm": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "three stage"
+            },
+            "chargerRole": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value":  "standalone"
+            },
+            "chargingMode": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "acceptance"
+            },
+            "voltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 14.3
+            },            
+            "current": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 12.2
+            }
+          },
+          "star240": {
+            "location": "Starbord array",
+            "manufacturer": {
+              "name": "REC + LibraSolar",
+              "model": "REC-240 + LibraSolar 25A"      
+            },
+            "associatedBus": "house1",
+            "chargingAlgorithm": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "three stage"
+            },
+            "chargerRole": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value":  "master"
+            },
+            "chargingMode": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": "bulk"
+            },
+            "voltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 14.13
+            },
+            "setpointVoltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 14.52
+            },            
+            "current": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 13.7
             }
           }
         },
         "ac": {
           "utility1": {
-            "meta": {
-              "name": "Single phase shore power"
-            },
+              "name": "Single phase shore power",
             "phase": {
               "single": {
                 "frequency": {
@@ -188,9 +308,7 @@
             }
           },
           "utility3": {
-            "meta": {
-              "name": "Three phase shore power"
-            },
+            "name": "Three phase shore power",
             "phase": {
               "A": {
                 "frequency": {


### PR DESCRIPTION
This is a cumulative (squash) of pull request #330 (which was canceled).  This replacement pull request has all the changes in one entry for simpler reading.

Major changes:

- Creation of common quality:  `chargerQualities` -- to be used by any device providing 'charging' to a battery
- Addition of `Solar` device type
- Addition of `Alternator` device type

There are also several cleanups in this submission, the largest is the scrubbing of the keyword `meta` which was applied incorrectly.  Other small changes include spelling, formatting for consistent punctuation, and the changing xxQuanities (A count) to xxQuality (a characteristic).


Pull request #330 had many changes and direction refinements; this new pull request is the end results. 

---
**UNRESOLVED ISSUE:**  One key issue unresolved is how to report up cumulative charge transfers (example, number of Ahs produced by a solar panel in a day's charging).  Different approaches were proposed and tried in #330, with no definitive conclusion - as such, this request does not have any additions addressing device charge transfers.  That will need to be a future work item.

