### PR TITLE
fix: don't create undefined meta properties

### DIFF
--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -187,8 +187,9 @@ function addValue(context, contextPath, source, timestamp, pathValue) {
     valueLeaf = splitPath.reduce(function(previous, pathPart, i) {
       if (!previous[pathPart]) {
         previous[pathPart] = {};
-        if (i === splitPath.length-1) {
-          previous[pathPart].meta = signalkSchema.getMetadata(contextPath + '.' + pathValue.path);
+        const meta = signalkSchema.getMetadata(contextPath + '.' + pathValue.path)
+        if (meta && i === splitPath.length-1) {
+          previous[pathPart].meta = meta;
         }
       }
       return previous[pathPart];


### PR DESCRIPTION
Before this change the full tree had undefined meta properties for example
under notifications, where the path is dynamic and no metadata is
available in the schema for values' paths. Undefined properties
do not matter in creating JSON, as they are ignored, but matter in
validation, breaking schema validation in a way that is very hard
to detect.