### PR TITLE
[WIP] feature: add preferredSource to common fields

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -306,6 +306,9 @@
         },
         "sentence": {
           "type": "string"
+        },
+        "preferredSource": {
+          "type": "string"
         }
       }
     },

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -146,7 +146,7 @@ class Parser {
           }
         }
 
-        const skipFields = ['timestamp', '$source', 'source', '_attr', 'meta', 'pgn', 'sentence', 'value', 'values']
+        const skipFields = ['timestamp', '$source', 'source', '_attr', 'meta', 'pgn', 'sentence', 'value', 'values', 'preferredSource']
         const embeddedFields =
           !this.tree[`${path}/timestamp`] ? {} :
             _.pick(subtree.properties ? _.omit(subtree.properties || {}, skipFields) : {}, (value, key) => {
@@ -212,7 +212,7 @@ class Parser {
      */
     .then(results => {
       const filenames = {}
-      const filter = ['/timestamp', '/$source', '/source', '/_attr', '/meta', '/pgn', '/sentence', '/value', '/values']
+      const filter = ['/timestamp', '/$source', '/source', '/_attr', '/meta', '/pgn', '/sentence', '/value', '/values', '/preferredSource']
 
       results.forEach(result => {
         filenames[result.name] = result.path

--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -220,11 +220,15 @@ function addValue(context, contextPath, source, timestamp, pathValue) {
     valueLeaf.values[sourceId].timestamp = timestamp;
     setMessage(valueLeaf.values[sourceId], source);
   }
-  assignValueToLeaf(pathValue.value, valueLeaf);
-  if (pathValue.path.length != 0) {
-    valueLeaf['$source'] = getId(source);
-    valueLeaf.timestamp = timestamp;
-    setMessage(valueLeaf, source);
+  var sourceId = getId(source);
+  if ( !valueLeaf.preferredSource || valueLeaf.preferredSource == sourceId )
+  {
+    assignValueToLeaf(pathValue.value, valueLeaf);
+    if (pathValue.path.length != 0) {
+      valueLeaf['$source'] = getId(source);
+      valueLeaf.timestamp = timestamp;
+      setMessage(valueLeaf, source);
+    }
   }
 }
 


### PR DESCRIPTION

This allows the user to specify a preferred source for any given path. In node server this would be done in defaults.json.

Example:
```
{
  "vessels": {
    "self": {
      "navigation": {
        "position": {
          "preferredSource": "actisense.3"
        }
  }
}
```

The server then will only fill `.value` with data from that source, but others will still go into `.values` and have deltas sent. It will be up to he clients getting deltas to get the preferredSource setting from the server and filter based on that.

