### PR TITLE
Fixed: bug in messages tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ function chaiAsPromised(chai, utils) {
       );
   });
   Assertion.addProperty('validSubscribeMessage', function () {
-    var result = validateWithSchema(msg, 'messages/subscribe');
+    var result = validateWithSchema(this._obj, 'messages/subscribe.json');
     var message = result.error ? result.error.message + ':' + result.error.dataPath : '';
     this.assert(
       result.valid
@@ -160,7 +160,7 @@ function chaiAsPromised(chai, utils) {
       );
   });
   Assertion.addProperty('validUnsubscribeMessage', function () {
-    var result = validateWithSchema(msg, 'messages/unsubscribe');
+    var result = validateWithSchema(this._obj, 'messages/unsubscribe.json');
     var message = result.error ? result.error.message + ':' + result.error.dataPath : '';
     this.assert(
       result.valid

--- a/test/messageValidation.js
+++ b/test/messageValidation.js
@@ -5,11 +5,11 @@ chai.use(require('../dist/').chaiModule);
 describe('Message validation', function() {
   it('Simple subscribe validates', function() {
     var subscribe =  require('../samples/signalk-subscribe');
-    subscribe.should.be.validSubscriptionMessage;
+    subscribe.should.be.validSubscribeMessage;
   });
 
   it('Simple unsubscribe validates', function() {
     var subscribe =  require('../samples/signalk-unsubscribe');
-    subscribe.should.be.validUnsubscriptionMessage;
+    subscribe.should.be.validUnsubscribeMessage;
   });
 });


### PR DESCRIPTION
The validSubscribeMessage and validUnsubscribeMessage were never being called when the tests ran, and so the message tests would always return valid even if there were errors. The actual 2 messages being tested (signalk-subscribe.json and signalk-unsubscribe.json) were in fact OK so no changes are needed to them.