### PR TITLE
Update Travis tests to use latest node-js v8.x.x release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "6"
-  - "7"
+  - "8"
 sudo: false


### PR DESCRIPTION
The recent outage on Travis CI lead me to look at the version of node we are using for Travis tests and the length of time they take to run. Currently we test using both v6 and v7 of node-js. The current version is 8.9.4 LTS or 9.4.0.

I have changed .travis.yml so that we only test using the latest v8 build of node-js which works fine.