### PR TITLE
fix: 'value' made a required property for anything using commonValueFields in schema

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -303,7 +303,7 @@
 
     "commonValueFields": {
       "type": "object",
-      "required": ["timestamp", "$source"],
+      "required": ["timestamp", "$source", "value"],
       "properties": {
         "timestamp": {
           "$ref": "#/definitions/timestamp"


### PR DESCRIPTION
Ref issue #423.

This changes the schema in a non backwards compatible way, so will bump the version to 1.1.x. Do you want to create a separate branch for changes which will bump the schema version? I will have more to come next week as I'm intending to review the schema once I've completed the testing and document refactoring.