### PR TITLE
fix: invalid electrical schema

### DIFF
--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -250,9 +250,6 @@
       "title": "Charger Qualities",
       "description": "Common charger qualities",
       "properties": {
-        "allOf": [{
-            "$ref": "#/definitions/identity"
-            }],
         "chargingAlgorithm": {
           "type": "object",
           "description": "Algorithm being used by the charger",


### PR DESCRIPTION
Fix issue #434.

Because the schema was previously invalid it is not clear whether or what previous data would have passed the TV4 schema validation, or not. Therefore the appropriate schema version bump as a result of this fix is unclear to me. One could take the view that this fixes a bug in the schema and does not change the schema itself, so should be an ADDITION??

I have added a new issue regarding the lack of schema validation tests #437.