### PR TITLE
feature: 'meta' deltas

### DIFF
--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -263,6 +263,32 @@ the value should be merged to the full model mounted where the delta‘s context
   ]
 }
 ```
+## Delta Format For Metadata
+
+Metadata can also be specified via a delta. The delta is very similiar to the `values` deltas above, but instead of having `values` key, it will have a `meta` key. Note that a client could multiple meta deltas for any given path from different sources, so the client merge the meta information.
+
+```json
+{
+  "context": "vessels.urn:mrn:imo:mmsi:234567890",
+  "updates": [
+    {
+      "source": {...},
+      "timestamp": "2014-08-15T19:02:31.507Z",
+      "meta":[
+        {
+          "path": "environment.wind.speedApparent",
+          "value":
+            {
+              "units": "m/s",
+              "description": "Apparent wind speed"
+            }
+        }
+      ]
+    }
+  ]
+}
+```
+
 [<]: #
 ## Data Quality
 

--- a/gitbook-docs/data_model.md
+++ b/gitbook-docs/data_model.md
@@ -263,32 +263,42 @@ the value should be merged to the full model mounted where the delta‘s context
   ]
 }
 ```
+[<]: #
 ## Delta Format For Metadata
 
-Metadata can also be specified via a delta. The delta is very similiar to the `values` deltas above, but instead of having `values` key, it will have a `meta` key. Note that a client could multiple meta deltas for any given path from different sources, so the client merge the meta information.
+Metadata can also be updated via a delta within the `meta` key.
 
+Since meta data is not often updated it is only sent when there has been a change. See [Subscription Protocol](subscription_protocol.md) for details.
+
+[>]: # (mdpInsert ```json fsnip ../samples/delta/docs-data_model_meta_deltas.json --prettify 2 20)
 ```json
 {
   "context": "vessels.urn:mrn:imo:mmsi:234567890",
   "updates": [
     {
-      "source": {...},
       "timestamp": "2014-08-15T19:02:31.507Z",
-      "meta":[
+      "meta": [
         {
           "path": "environment.wind.speedApparent",
-          "value":
-            {
-              "units": "m/s",
-              "description": "Apparent wind speed"
-            }
+          "value": {
+            "units": "m/s",
+            "description": "Apparent wind speed",
+            "displayName": "Apparent Wind Speed",
+            "shortName": "AWS",
+            "zones": [
+              {
+                "upper": 15.4333,
+                "state": "warn",
+                "message": "high wind speed"
+              }
+            ]
+          }
         }
       ]
     }
   ]
 }
 ```
-
 [<]: #
 ## Data Quality
 

--- a/gitbook-docs/subscription_protocol.md
+++ b/gitbook-docs/subscription_protocol.md
@@ -86,7 +86,7 @@ The following are optional, included above only for example as it uses defaults 
 
 * `period=[millisecs]` becomes the transmission rate, e.g. every `period/1000` seconds. Default: 1000
 * `format=[delta|full]` specifies delta or full format. Default: delta
-* `policy=[instant|ideal|fixed]`. Default: ideal
+* `policy=[instant|ideal|fixed]`. Default: ideal. (does not apply to meta - see below)
  * `instant` means send all changes as fast as they are received, but no faster than `minPeriod`. With this policy the
      client has an immediate copy of the current state of the server.
  * `ideal` means use `instant` policy, but if no changes are received before `period`, then resend the last known
@@ -100,6 +100,13 @@ subscribes to the data it requires, and the server and/or client implementation 
 duplication as it prefers on a per connection basis. At the same time it is good practice to open the minimum
 connections necessary, for instance one WebSocket connection shared between an instrument panel with many gauges,
 rather then one WebSocket connection per gauge.
+
+## Meta data
+Meta is updated via the `meta` section within the delta message. As meta changes infrequently it is only sent when it has changed.
+
+Servers implementing the subscription model (ie. using deltas) SHOULD implement meta deltas. Where meta deltas are implemented, servers MUST only ever send full copies of the meta for a leaf, ie. they MUST NEVER send a partial meta.
+
+Upon receiving a new subscription a server MUST send the meta for each leaf subscribed to; this MAY be in the same JSON document as the values, or in a separate one prior to sending values for that leaf or leaves. Subsequently the server MUST resend the full meta for a leaf each time any item in that meta is changed. This is equivalent to the `instant` subscription for values. Therefore meta is never subscribed on an `ideal` or `fixed` policy, irrespective of the policy requested by the consumer (which applies to values only).
 
 ## Multiple value handling in subscriptions
 

--- a/samples/delta/docs-data_model_meta_deltas.json
+++ b/samples/delta/docs-data_model_meta_deltas.json
@@ -1,0 +1,25 @@
+{
+  "context": "vessels.urn:mrn:imo:mmsi:234567890",
+  "updates": [
+    {
+      "timestamp": "2014-08-15T19:02:31.507Z",
+      "meta": [
+        {
+          "path": "environment.wind.speedApparent",
+          "value": {
+            "units": "m/s",
+            "description": "Apparent wind speed",
+            "displayName": "Apparent Wind Speed",
+            "shortName": "AWS",
+            "zones": [{
+              "upper": 15.4333,
+              "state": "warn",
+              "message": "high wind speed"
+            }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -95,8 +95,7 @@
                   "example": "navigation.courseOverGroundMagnetic"
                 },
                 "value": {
-                  "$ref": "./definitions.json#/definitions/meta",
-                  "additionalProperties": true
+                  "$ref": "./definitions.json#/definitions/meta"
                 }
               }
             }

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -87,13 +87,7 @@
                   "example": "navigation.courseOverGroundMagnetic"
                 },
                 "value": {
-                  "type": [
-                    "string",
-                    "number",
-                    "object",
-                    "boolean",
-                    "null"
-                  ],
+                  "$ref": "./definitions.json#/definitions/meta"
                   "additionalProperties": true
                 }
               }

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -20,13 +20,21 @@
         "type": "object",
         "oneOf": [
           {
-            "required": ["values"]
+            "required": ["values"],
+            "properties": {"$source":{}, "source": {}, "timestamp": {}, "values": {}},
+            "additionalProperties": false
           },
           {
-            "required": ["meta"]
+            "required": ["meta"],
+            "properties": {"$source":{}, "source": {}, "timestamp": {}, "meta": {}},
+            "additionalProperties": false
+          },
+          {
+            "required": ["values", "meta"],
+            "properties": {"$source":{}, "source": {}, "timestamp": {}, "values": {}, "meta": {}},
+            "additionalProperties": false
           }
         ],
-
         "not": {
           "allOf": [{
             "required": ["source"]

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -87,7 +87,7 @@
                   "example": "navigation.courseOverGroundMagnetic"
                 },
                 "value": {
-                  "$ref": "./definitions.json#/definitions/meta"
+                  "$ref": "./definitions.json#/definitions/meta",
                   "additionalProperties": true
                 }
               }

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -18,7 +18,14 @@
       "description": "The updates",
       "items": {
         "type": "object",
-        "required": ["values"],
+        "oneOf": [
+          {
+            "required": ["values"]
+          },
+          {
+            "required": ["meta"]
+          }
+        ],
 
         "not": {
           "allOf": [{
@@ -39,6 +46,33 @@
             "$ref": "./definitions.json#/definitions/timestamp"
           },
           "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "path",
+                "value"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "The local path to the data value",
+                  "example": "navigation.courseOverGroundMagnetic"
+                },
+                "value": {
+                  "type": [
+                    "string",
+                    "number",
+                    "object",
+                    "boolean",
+                    "null"
+                  ],
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "meta": {
             "type": "array",
             "items": {
               "type": "object",

--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -188,6 +188,32 @@ function addValues(context, contextPath, source, timestamp, pathValues) {
   }
 }
 
+function addMetas(context, contextPath, source, timestamp, metas) {
+  var len = metas.length;
+  for (var i = 0; i < len; ++i) {
+    addMeta(context, contextPath, source, timestamp, metas[i]);
+  }
+}
+
+function addMeta(context, contextPath, source, timestamp, pathValue) {
+  if (_.isUndefined(pathValue.path) || _.isUndefined(pathValue.value)) {
+    console.error("Illegal value in delta:" + JSON.stringify(pathValue));
+    return;
+  }
+  var valueLeaf;
+
+  const splitPath = pathValue.path.split('.');
+  
+  valueLeaf = splitPath.reduce(function(previous, pathPart, i) {
+    if (!previous[pathPart]) {
+      previous[pathPart] = {};
+    }
+    return previous[pathPart];
+  }, context);
+
+  valueLeaf.meta = _.merge(valueLeaf.meta || {}, pathValue.value)
+}
+
 function addValue(context, contextPath, source, timestamp, pathValue) {
   let errMessage = ""
   if(_.isUndefined(pathValue.path)){

--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -188,32 +188,6 @@ function addValues(context, contextPath, source, timestamp, pathValues) {
   }
 }
 
-function addMetas(context, contextPath, source, timestamp, metas) {
-  var len = metas.length;
-  for (var i = 0; i < len; ++i) {
-    addMeta(context, contextPath, source, timestamp, metas[i]);
-  }
-}
-
-function addMeta(context, contextPath, source, timestamp, pathValue) {
-  if (_.isUndefined(pathValue.path) || _.isUndefined(pathValue.value)) {
-    console.error("Illegal value in delta:" + JSON.stringify(pathValue));
-    return;
-  }
-  var valueLeaf;
-
-  const splitPath = pathValue.path.split('.');
-  
-  valueLeaf = splitPath.reduce(function(previous, pathPart, i) {
-    if (!previous[pathPart]) {
-      previous[pathPart] = {};
-    }
-    return previous[pathPart];
-  }, context);
-
-  valueLeaf.meta = _.merge(valueLeaf.meta || {}, pathValue.value)
-}
-
 function addValue(context, contextPath, source, timestamp, pathValue) {
   let errMessage = ""
   if(_.isUndefined(pathValue.path)){

--- a/test/data/delta-invalid/meta-missing-value.json
+++ b/test/data/delta-invalid/meta-missing-value.json
@@ -1,12 +1,12 @@
 {
-  "context": "bar",
-  "updates": [{
-	"source": {
-	  "label": "schema"
-	},
-	"timestamp": "2013-10-08T15:47:28.263Z",
-	"meta": [{
-	  "path": "a.b.c"
-	}]
-  }]
+  "context": "vessels.urn:mrn:imo:mmsi:234567890",
+  "updates": [
+    {
+      "meta": [
+        {
+          "path": "propulsion.0.revolutions"
+        }
+      ]
+    }
+  ]
 }

--- a/test/data/delta-invalid/meta-missing-value.json
+++ b/test/data/delta-invalid/meta-missing-value.json
@@ -1,0 +1,12 @@
+{
+  "context": "bar",
+  "updates": [{
+	"source": {
+	  "label": "schema"
+	},
+	"timestamp": "2013-10-08T15:47:28.263Z",
+	"meta": [{
+	  "path": "a.b.c"
+	}]
+  }]
+}

--- a/test/data/delta-valid/meta-and-values.json
+++ b/test/data/delta-valid/meta-and-values.json
@@ -1,0 +1,19 @@
+{
+  "context": "bar",
+  "updates": [{
+	"source": {
+	  "label": "schema"
+	},
+	"timestamp": "2013-10-08T15:47:28.263Z",
+	"meta": [{
+	  "path": "a.b.c",
+	  "value": {
+            "units": "m"
+          }
+        }],
+        "values": [{
+	  "path": "a.b.c",
+	  "value": 1234
+	}]
+  }]
+}

--- a/test/data/delta-valid/meta-and-values.json
+++ b/test/data/delta-valid/meta-and-values.json
@@ -1,20 +1,29 @@
 {
-  "context": "bar",
-  "updates": [{
-	"source": {
-	  "label": "schema"
-	},
-	"timestamp": "2013-10-08T15:47:28.263Z",
-	"meta": [{
-	  "path": "a.b.c",
-	  "value": {
-	          "description": "...",
-            "units": "m"
+  "context": "vessels.urn:mrn:imo:mmsi:234567890",
+  "updates": [
+    {
+      "source": {
+        "label": "N2000-01",
+        "type": "NMEA2000",
+        "src": "017",
+        "pgn": 127488
+      },
+      "timestamp": "2013-10-08T15:47:28.263Z",
+      "meta": [
+        {
+          "path": "propulsion.0.revolutions",
+          "value": {
+            "description": "Engine revolutions (x60 for RPM)",
+            "units": "Hz"
           }
-        }],
-        "values": [{
-	  "path": "a.b.c",
-	  "value": 1234
-	}]
-  }]
+        }
+      ],
+      "values": [
+        {
+          "path": "propulsion.0.revolutions",
+          "value": 11
+        }
+      ]
+    }
+  ]
 }

--- a/test/data/delta-valid/meta-and-values.json
+++ b/test/data/delta-valid/meta-and-values.json
@@ -8,6 +8,7 @@
 	"meta": [{
 	  "path": "a.b.c",
 	  "value": {
+	          "description": "...",
             "units": "m"
           }
         }],

--- a/test/data/delta-valid/meta-delta.json
+++ b/test/data/delta-valid/meta-delta.json
@@ -1,16 +1,25 @@
 {
-  "context": "bar",
-  "updates": [{
-	"source": {
-	  "label": "schema"
-	},
-	"timestamp": "2013-10-08T15:47:28.263Z",
-	"meta": [{
-	  "path": "a.b.c",
-	  "value": {
-	          "description": "...",
-            "units": "m"
+  "context": "vessels.urn:mrn:imo:mmsi:234567890",
+  "updates": [
+    {
+      "meta": [
+        {
+          "path": "environment.depth.belowTransducer",
+          "value": {
+            "description": "Depth below Transducer",
+            "units": "m",
+            "timeout": 2.5,
+            "zones": [
+              {
+                "upper": 5.0,
+                "state": "warn",
+                "message": "Shallow water" 
+              }
+            ],
+            "warnMethod": ["sound"]
           }
-	}]
-  }]
+        }
+      ]
+    }
+  ]
 }

--- a/test/data/delta-valid/meta-delta.json
+++ b/test/data/delta-valid/meta-delta.json
@@ -1,0 +1,15 @@
+{
+  "context": "bar",
+  "updates": [{
+	"source": {
+	  "label": "schema"
+	},
+	"timestamp": "2013-10-08T15:47:28.263Z",
+	"meta": [{
+	  "path": "a.b.c",
+	  "value": {
+            "units": "m"
+          }
+	}]
+  }]
+}

--- a/test/data/delta-valid/meta-delta.json
+++ b/test/data/delta-valid/meta-delta.json
@@ -8,6 +8,7 @@
 	"meta": [{
 	  "path": "a.b.c",
 	  "value": {
+	          "description": "...",
             "units": "m"
           }
 	}]


### PR DESCRIPTION

There is currently no way to send `meta` data via deltas. This PR adds a new type of delta just for meta data.

The deltas would look like this:

```
{
  updates: [
    {
      meta: [
        {
          "path": "electrical.batteries.1.voltage",
          "value": {
              "displayName": "Starter Battery V"
          }
        }
      ]
    }
  ]
}
```

TODO
- [x] add documentation
