### PR TITLE
[WIP] Support Average AC Quantites and More Natural Single Phase Representation

### DIFF
--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -719,12 +719,15 @@
               "$ref": "#/definitions/identity"
             },
             {
+              "$ref": "#/definitions/acQualities"
+            },
+            {
               "properties": {
                 "phase": {
                   "type": "object",
-                  "description": "Single or A,B or C in 3 Phase systems ",
+                  "description": "Detailed information for each leg of split or 3-phase systems",
                   "patternProperties": {
-                    "(single)|([A-C])": {
+                    "([A-C])": {
                       "$ref": "#/definitions/acQualities"
                     }
                   }

--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -19,6 +19,7 @@
           "type": "string",
           "description": "Installed location of device on vessel"
         },
+
         "dateInstalled": {
           "$ref": "../definitions.json#/definitions/timestamp",
           "description": "Date device was installed"
@@ -30,10 +31,12 @@
               "type": "string",
               "description": "Manufacturer's name"
             },
+
             "model": {
               "type": "string",
               "description": "Model or part number"
             },
+
             "URL": {
               "type": "string",
               "description": "Web referance / URL"
@@ -57,91 +60,98 @@
           "type": "object",
           "description": "Voltage measured at or as close as possible to the device",
           "units": "V",
-          "allOf": [{
-            "$ref": "../definitions.json#/definitions/numberValue"
-          }, {
-            "properties": {
-              "ripple": {
-                "description": "DC Ripple voltage",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "V"
-              },
-              "meta": {
-                "type": "object",
-                "properties": {
-                  "nominal": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Designed 'voltage' of device (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
-                  },
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            {
+              "properties": {
+                "ripple": {
+                  "description": "DC Ripple voltage",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "V"
+                },
 
-                  "warnUpper": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Upper operational voltage limit"
-                  },
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "nominal": {
+                      "type": "number",
+                      "units": "V",
+                      "description": "Designed 'voltage' of device (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
+                    },
 
-                  "warnLower": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Lower operational voltage limit"
-                  },
+                    "warnUpper": {
+                      "type": "number",
+                      "units": "V",
+                      "description": "Upper operational voltage limit"
+                    },
 
-                  "faultUpper": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Upper fault voltage limit - device may disable/disconnect"
-                  },
+                    "warnLower": {
+                      "type": "number",
+                      "units": "V",
+                      "description": "Lower operational voltage limit"
+                    },
 
-                  "faultLower": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Lower fault voltage limit - device may disable/disconnect"
+                    "faultUpper": {
+                      "type": "number",
+                      "units": "V",
+                      "description": "Upper fault voltage limit - device may disable/disconnect"
+                    },
+
+                    "faultLower": {
+                      "type": "number",
+                      "units": "V",
+                      "description": "Lower fault voltage limit - device may disable/disconnect"
+                    }
                   }
                 }
               }
             }
-          }]
+          ]
         },
 
         "current": {
           "type": "object",
           "description": "Current flowing out (+ve) or in (-ve) to the device",
           "units": "A",
-          "allOf": [{
-            "$ref": "../definitions.json#/definitions/numberValue"
-          }, {
-            "properties": {
-              "meta": {
-                "type": "object",
-                "properties": {
-                  "warnUpper": {
-                    "type": "number",
-                    "description": "Upper operational current limit",
-                    "units": "A"
-                  },
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            {
+              "properties": {
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "warnUpper": {
+                      "type": "number",
+                      "description": "Upper operational current limit",
+                      "units": "A"
+                    },
 
-                  "warnLower": {
-                    "type": "number",
-                    "description": "Lower operational current limit",
-                    "units": "A"
-                  },
+                    "warnLower": {
+                      "type": "number",
+                      "description": "Lower operational current limit",
+                      "units": "A"
+                    },
 
-                  "faultUpper": {
-                    "type": "number",
-                    "description": "Upper fault current limit - device may disable/disconnect",
-                    "units": "A"
-                  },
+                    "faultUpper": {
+                      "type": "number",
+                      "description": "Upper fault current limit - device may disable/disconnect",
+                      "units": "A"
+                    },
 
-                  "faultLower": {
-                    "type": "number",
-                    "description": "Lower fault current limit - device may disable/disconnect",
-                    "units": "A"
+                    "faultLower": {
+                      "type": "number",
+                      "description": "Lower fault current limit - device may disable/disconnect",
+                      "units": "A"
+                    }
                   }
                 }
               }
             }
-          }]
+          ]
         },
 
         "temperature": {
@@ -149,35 +159,38 @@
           "description": "Temperature measured within or on the device",
           "units": "K",
           "title": "temperature",
-          "allOf": [{
-            "$ref": "../definitions.json#/definitions/numberValue"
-          }, {
-            "properties": {
-              "warnUpper": {
-                "type": "number",
-                "description": "Upper operational temperature limit",
-                "units": "K"
-              },
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            {
+              "properties": {
+                "warnUpper": {
+                  "type": "number",
+                  "description": "Upper operational temperature limit",
+                  "units": "K"
+                },
 
-              "warnLower": {
-                "type": "number",
-                "description": "Lower operational temperature limit",
-                "units": "K"
-              },
+                "warnLower": {
+                  "type": "number",
+                  "description": "Lower operational temperature limit",
+                  "units": "K"
+                },
 
-              "faultUpper": {
-                "type": "number",
-                "description": "Upper fault temperature limit - device may disable/disconnect",
-                "units": "K"
-              },
+                "faultUpper": {
+                  "type": "number",
+                  "description": "Upper fault temperature limit - device may disable/disconnect",
+                  "units": "K"
+                },
 
-              "faultLower": {
-                "type": "number",
-                "description": "Lower fault temperature limit - device may disable/disconnect",
-                "units": "K"
+                "faultLower": {
+                  "type": "number",
+                  "description": "Lower fault temperature limit - device may disable/disconnect",
+                  "units": "K"
+                }
               }
             }
-          }]
+          ]
         }
       }
     },
@@ -191,36 +204,43 @@
           "type": "string",
           "description": "Name of BUS device is associated with"
         },
+
         "lineNeutralVoltage": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "RMS voltage measured between phase and neutral",
           "units": "V"
         },
+
         "lineLineVoltage": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "RMS voltage measured between phases",
           "units": "V"
         },
+
         "current": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "RMS current",
           "units": "A"
         },
+
         "frequency": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "AC frequency.",
           "units": "Hz"
         },
+
         "reactivePower": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Reactive power",
           "units": "W"
         },
+
         "powerFactor": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Power factor",
           "unit": "ratio"
         },
+
         "powerFactorLagging": {
           "description": "Lead/lag status.",
           "example": "leading",
@@ -232,11 +252,13 @@
             "not available"
           ]
         },
+
         "realPower": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Real power.",
           "units": "W"
         },
+
         "apparentPower": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Apparent power.",
@@ -244,7 +266,7 @@
         }
       }
     },
-  
+
     "chargerQualities": {
       "type": "object",
       "title": "Charger Qualities",
@@ -265,7 +287,7 @@
                     "trickle",
                     "two stage",
                     "three stage",
-                    "four stage",       
+                    "four stage",
                     "constant current",
                     "constant voltage",
                     "custom profile"
@@ -275,6 +297,7 @@
             }
           ]
         },
+
         "chargerRole": {
           "type": "object",
           "description": "How is charging source configured?  Standalone, or in sync with another charger?",
@@ -291,12 +314,13 @@
                     "master",
                     "slave",
                     "standby"
-                   ]
+                  ]
                 }
               }
             }
           ]
         },
+
         "chargingMode": {
           "type": "object",
           "description": "Charging mode i.e. float, overcharge, etc.",
@@ -322,22 +346,23 @@
             }
           ]
         },
-       "setpointVoltage": {
+
+        "setpointVoltage": {
           "description": "Target regulation voltage",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "V"
-       }, 
-       "setpointCurrent": {
+        },
+
+        "setpointCurrent": {
           "description": "Target current limit",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "A"
+        }
       }
     }
-  }
   },
-  
-  
-  "properties": { 
+
+  "properties": {
     "batteries": {
       "description": "Data about the vessel's batteries",
       "patternProperties": {
@@ -345,118 +370,125 @@
           "type": "object",
           "title": "Battery keyed by instance id",
           "description": "Batteries, one or many, within the vessel",
-          "allOf": [{
+          "allOf": [
+            {
               "$ref": "#/definitions/identity"
-               },{
+            },
+            {
               "$ref": "#/definitions/dcQualities"
-              }],
-           "properties": { 
-            "chemistry": {
-              "type": "string",
-              "description": "Type of battery FLA, LiFePO4, etc."
             },
-            "temperature": {
-              "type": "object",
-              "title": "temperature",
-              "description": "Additional / unique temperatures associated with a battery",
+            {
               "properties": {
-                "limitDischargeLower": {
+                "chemistry": {
+                  "type": "string",
+                  "description": "Type of battery FLA, LiFePO4, etc."
+                },
+
+                "temperature": {
+                  "type": "object",
+                  "title": "temperature",
+                  "description": "Additional / unique temperatures associated with a battery",
+                  "properties": {
+                    "limitDischargeLower": {
+                      "type": "number",
+                      "description": "Operational minimum temperature limit for battery discharge",
+                      "units": "K"
+                    },
+
+                    "limitDischargeUpper": {
+                      "type": "number",
+                      "description": "Operational maximum temperature limit for battery discharge",
+                      "units": "K"
+                    },
+
+                    "limitRechargeLower": {
+                      "type": "number",
+                      "description": "Operational minimum temperature limit for battery recharging",
+                      "units": "K"
+                    },
+
+                    "limitRechargeUpper": {
+                      "type": "number",
+                      "description": "Operational maximum temperature limit for battery recharging",
+                      "units": "K"
+                    }
+                  }
+                },
+
+                "capacity": {
+                  "type": "object",
+                  "description": "Data about the battery's capacity",
+                  "title": "capacity",
+                  "properties": {
+                    "nominal": {
+                      "type": "number",
+                      "description": "The capacity of battery as specified by the manufacturer",
+                      "units": "J"
+                    },
+
+                    "actual": {
+                      "type": "number",
+                      "description": "The measured capacity of battery. This may change over time and will likely deviate from the nominal capacity.",
+                      "units": "J"
+                    },
+
+                    "remaining": {
+                      "type": "number",
+                      "description": "Capacity remaining in battery",
+                      "units": "J"
+                    },
+
+                    "dischargeLimit": {
+                      "type": "number",
+                      "description": "Minimum capacity to be left in the battery while discharging",
+                      "units": "J"
+                    },
+
+                    "stateOfCharge": {
+                      "$ref": "../definitions.json#/definitions/numberValue",
+                      "description": "State of charge, 1 = 100%",
+                      "units": "ratio"
+                    },
+
+                    "stateOfHealth": {
+                      "$ref": "../definitions.json#/definitions/numberValue",
+                      "description": "State of Health, 1 = 100%",
+                      "units": "ratio"
+                    },
+
+                    "dischargeSinceFull": {
+                      "$ref": "../definitions.json#/definitions/numberValue",
+                      "description": "Cumulative discharge since battery was last full",
+                      "units": "C"
+                    },
+
+                    "timeRemaining": {
+                      "$ref": "../definitions.json#/definitions/numberValue",
+                      "description": "Time to discharge to discharge limit at current rate",
+                      "units": "s"
+                    }
+                  }
+                },
+
+
+                "lifetimeDischarge": {
                   "type": "number",
-                  "description": "Operational minimum temperature limit for battery discharge",
-                  "units": "K"
-                },
-
-                "limitDischargeUpper": {
-                  "type": "number",
-                  "description": "Operational maximum temperature limit for battery discharge",
-                  "units": "K"
-                },
-
-                "limitRechargeLower": {
-                  "type": "number",
-                  "description": "Operational minimum temperature limit for battery recharging",
-                  "units": "K"
-                },
-
-                "limitRechargeUpper": {
-                  "type": "number",
-                  "description": "Operational maximum temperature limit for battery recharging",
-                  "units": "K"
-                }
-              }
-            },
-
-            "capacity": {
-              "type": "object",
-              "description": "Data about the battery's capacity",
-              "title": "capacity",
-              "properties": {
-                "nominal": {
-                  "type": "number",
-                  "description": "The capacity of battery as specified by the manufacturer",
-                  "units": "J"
-                },
-
-                "actual": {
-                  "type": "number",
-                  "description": "The measured capacity of battery. This may change over time and will likely deviate from the nominal capacity.",
-                  "units": "J"
-                },
-
-                "remaining": {
-                  "type": "number",
-                  "description": "Capacity remaining in battery",
-                  "units": "J"
-                },
-
-                "dischargeLimit": {
-                  "type": "number",
-                  "description": "Minimum capacity to be left in the battery while discharging",
-                  "units": "J"
-                },
-
-                "stateOfCharge": {
-                  "$ref": "../definitions.json#/definitions/numberValue",
-                  "description": "State of charge, 1 = 100%",
-                  "units": "ratio"
-                },
-
-                "stateOfHealth": {
-                  "$ref": "../definitions.json#/definitions/numberValue",
-                  "description": "State of Health, 1 = 100%",
-                  "units": "ratio"
-                },
-
-                "dischargeSinceFull": {
-                  "$ref": "../definitions.json#/definitions/numberValue",
-                  "description": "Cumulative discharge since battery was last full",
+                  "description": "Cumulative charge discharged from battery over operational lifetime of battery",
                   "units": "C"
                 },
 
-                "timeRemaining": {
-                  "$ref": "../definitions.json#/definitions/numberValue",
-                  "description": "Time to discharge to discharge limit at current rate",
-                  "units": "s"
+                "lifetimeRecharge": {
+                  "type": "number",
+                  "description": "Cumulative charge recharged into battery over operational lifetime of battery",
+                  "units": "C"
                 }
               }
-            },
-
-
-            "lifetimeDischarge": {
-              "type": "number",
-              "description": "Cumulative charge discharged from battery over operational lifetime of battery",
-              "units": "C"
-            },
-
-            "lifetimeRecharge": {
-                "type": "number",
-                "description": "Cumulative charge recharged into battery over operational lifetime of battery",
-                "units": "C"
             }
-          }
+          ]
         }
-      }  
-     },
+      }
+    },
+
     "inverters": {
       "description": "Data about the Inverter that has both DC and AC qualities",
       "patternProperties": {
@@ -464,45 +496,52 @@
           "type": "object",
           "title": "Inverter",
           "description": "DC to AC inverter, one or many, within the vessel",
-          "allOf": [{
-            "$ref": "#/definitions/identity"
-            }],   
-          "properties": {   
-            "dc": {
-              "$ref": "#/definitions/dcQualities"
+          "allOf": [
+            {
+              "$ref": "#/definitions/identity"
             },
-            "ac": {
-              "$ref": "#/definitions/acQualities"
-            },
-            "inverterMode": {
-              "type": "object",
-              "description": "Mode of inverter",
-              "allOf": [
-                {
-                  "$ref": "../definitions.json#/definitions/commonValueFields"
+            {
+              "properties": {
+                "dc": {
+                  "$ref": "#/definitions/dcQualities"
                 },
-                {
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "enum": [
-                      "idle",
-                      "inverting",
-                      "disabled",
-                      "standby",
-                      "faulted",
-                      "unknown",
-                      "other"
-                      ]
+
+                "ac": {
+                  "$ref": "#/definitions/acQualities"
+                },
+
+                "inverterMode": {
+                  "type": "object",
+                  "description": "Mode of inverter",
+                  "allOf": [
+                    {
+                      "$ref": "../definitions.json#/definitions/commonValueFields"
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "enum": [
+                            "idle",
+                            "inverting",
+                            "disabled",
+                            "standby",
+                            "faulted",
+                            "unknown",
+                            "other"
+                          ]
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             }
-          }
+          ]
         }
       }
-    },    
+    },
+
     "chargers": {
       "description": "Data about AC sourced battery charger",
       "patternProperties": {
@@ -510,16 +549,21 @@
           "type": "object",
           "title": "Charger",
           "description": "Battery charger",
-          "allOf": [{
-            "$ref": "#/definitions/identity"
-          },{
-            "$ref": "#/definitions/dcQualities"
-          },{
-            "$ref": "#/definitions/chargerQualities"
-          }]
+          "allOf": [
+            {
+              "$ref": "#/definitions/identity"
+            },
+            {
+              "$ref": "#/definitions/dcQualities"
+            },
+            {
+              "$ref": "#/definitions/chargerQualities"
+            }
+          ]
         }
       }
     },
+
     "alternators": {
       "description": "Data about an Alternator charging device",
       "patternProperties": {
@@ -527,38 +571,48 @@
           "type": "object",
           "title": "Alternator",
           "description": "Mechanically driven alternator, includes dynamos",
-            "allOf": [{
-                "$ref": "#/definitions/identity"
-              },{
-                "$ref": "#/definitions/dcQualities"
-              },{
-                "$ref": "#/definitions/chargerQualities"
-              }],
-            "properties": {  
-              "revolutions": {
-                "description": "Alternator revolutions per second (x60 for RPM)",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "Hz"
-              },
-              "pulleyRatio": {
-                "description": "Mechanical pulley ratio of driving source (Used to back calculate engine RPMs)",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "ratio"
-              },
-              "fieldDrive": {
-                "description": "% (0..100) of field voltage applied",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "%"
-              },
-              "regulatorTemperature": {
-                "description": "Current temperature of critical regulator components",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "K"
+          "allOf": [
+            {
+              "$ref": "#/definitions/identity"
+            },
+            {
+              "$ref": "#/definitions/dcQualities"
+            },
+            {
+              "$ref": "#/definitions/chargerQualities"
+            },
+            {
+              "properties": {
+                "revolutions": {
+                  "description": "Alternator revolutions per second (x60 for RPM)",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "Hz"
+                },
+
+                "pulleyRatio": {
+                  "description": "Mechanical pulley ratio of driving source (Used to back calculate engine RPMs)",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "ratio"
+                },
+
+                "fieldDrive": {
+                  "description": "% (0..100) of field voltage applied",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "%"
+                },
+
+                "regulatorTemperature": {
+                  "description": "Current temperature of critical regulator components",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "K"
+                }
               }
             }
-         }
+          ]
+        }
       }
     },
+
     "solar": {
       "description": "Data about Solar charging device(s)",
       "patternProperties": {
@@ -566,90 +620,93 @@
           "type": "object",
           "title": "Solar",
           "description": "Photovoltaic charging devices",
-          "allOf": [{
-            "$ref": "#/definitions/identity"
-          },{
-            "$ref": "#/definitions/dcQualities"
-          },{
-            "$ref": "#/definitions/chargerQualities"
-          }],
-          "properties": { 
-            "controllerMode": {
-              "type": "object",
-              "description": "The current state of the engine",
-              "allOf": [
-                {
-                  "$ref": "../definitions.json#/definitions/commonValueFields"
-                },
-                {
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "enum": [
-                         "off",
-                         "idle",
-                         "direct",
-                         "PWM",
-                         "MPPT"
-                      ]
+          "allOf": [
+            {
+              "$ref": "#/definitions/identity"
+            },
+            {
+              "$ref": "#/definitions/dcQualities"
+            },
+            {
+              "$ref": "#/definitions/chargerQualities"
+            },
+            {
+              "properties": {
+                "controllerMode": {
+                  "type": "object",
+                  "description": "The current state of the engine",
+                  "allOf": [
+                    {
+                      "$ref": "../definitions.json#/definitions/commonValueFields"
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "enum": [
+                            "off",
+                            "idle",
+                            "direct",
+                            "PWM",
+                            "MPPT"
+                          ]
+                        }
+                      }
                     }
-                  }
-                }
-              ]
-            },
-            "panelVoltage": {
-                "description": "Voltage being supplied from Solar Panels to controller",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "V"
-            },
-            "panelCurrent": {
-                "description": "Amperage being supplied from Solar Panels to controller",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "A"
-            },
-            "panelTemperature": {
-                "description": "Temperature of panels",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "K"
-            },
+                  ]
+                },
 
-            "load": {
-              "type": "object",
-              "description": "State of load port on controller (if applicable)",
-              "allOf": [
-                {
-                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                "panelVoltage": {
+                  "description": "Voltage being supplied from Solar Panels to controller",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "V"
                 },
-                {
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "enum": [
-                        "enabled",
-                        "disabled"
-                      ]
+
+                "panelCurrent": {
+                  "description": "Amperage being supplied from Solar Panels to controller",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "A"
+                },
+
+                "panelTemperature": {
+                  "description": "Temperature of panels",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "K"
+                },
+
+                "load": {
+                  "type": "object",
+                  "description": "State of load port on controller (if applicable)",
+                  "allOf": [
+                    {
+                      "$ref": "../definitions.json#/definitions/commonValueFields"
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled"
+                          ]
+                        }
+                      }
                     }
-                  }
+                  ]
+                },
+
+                "loadCurrent": {
+                  "description": "Amperage being supplied to load directly connected to controller",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "A"
                 }
-              ]
-            },        
-            "loadCurrent": {
-                "description": "Amperage being supplied to load directly connected to controller",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "A"
+              }
             }
-          }
+          ]
         }
       }
     },
 
-
-  
-    
-    
-    
-    
-    
     "ac": {
       "description": "AC buses",
       "patternProperties": {
@@ -657,20 +714,24 @@
           "type": "object",
           "title": "AC Bus keyed by instance id",
           "description": "AC Bus, one or many, within the vessel",
-          "allOf": [{
-            "$ref": "#/definitions/identity"
-          }],
-          "properties": {
-            "phase": {
-              "type": "object",
-              "description": "Single or A,B or C in 3 Phase systems ",
-              "patternProperties": {
-                "(single)|([A-C])": {
-                  "$ref": "#/definitions/acQualities"
+          "allOf": [
+            {
+              "$ref": "#/definitions/identity"
+            },
+            {
+              "properties": {
+                "phase": {
+                  "type": "object",
+                  "description": "Single or A,B or C in 3 Phase systems ",
+                  "patternProperties": {
+                    "(single)|([A-C])": {
+                      "$ref": "#/definitions/acQualities"
+                    }
+                  }
                 }
               }
             }
-          }
+          ]
         }
       }
     }

--- a/test/data/full-valid/electrical-full_tree.json
+++ b/test/data/full-valid/electrical-full_tree.json
@@ -271,7 +271,7 @@
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar",
               "value": 14.52
-            },            
+            },
             "current": {
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar",
@@ -281,34 +281,50 @@
         },
         "ac": {
           "utility1": {
-              "name": "Single phase shore power",
-            "phase": {
-              "single": {
-                "frequency": {
-                  "timestamp": "2014-08-15T19:00:15.402Z",
-                  "$source": "foo.bar",
-                  "value": 50
-                },
-                "current": {
-                  "timestamp": "2014-08-15T19:00:15.402Z",
-                  "$source": "foo.bar",
-                  "value": 0.12
-                },
-                "lineLineVoltage": {
-                  "timestamp": "2014-08-15T19:00:15.402Z",
-                  "$source": "foo.bar",
-                  "value": 230
-                },
-                "lineNeutralVoltage": {
-                  "timestamp": "2014-08-15T19:00:15.402Z",
-                  "$source": "foo.bar",
-                  "value": 230
-                }
-              }
+            "name": "Single phase shore power",
+            "frequency": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 50
+            },
+            "current": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 0.12
+            },
+            "lineLineVoltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 230
+            },
+            "lineNeutralVoltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 230
             }
           },
           "utility3": {
             "name": "Three phase shore power",
+            "frequency": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 50
+            },
+            "current": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 0.12
+            },
+            "lineLineVoltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 400
+            },
+            "lineNeutralVoltage": {
+              "timestamp": "2014-08-15T19:00:15.402Z",
+              "$source": "foo.bar",
+              "value": 230
+            },
             "phase": {
               "A": {
                 "frequency": {


### PR DESCRIPTION
This PR comes out of the discussion at https://github.com/SignalK/n2k-signalk/issues/16.

Three-phase systems need a way to represent average values and it doesn't make much sense to nest single phase systems values all the way under `electrical.ac.<device>.phases.single.*`.

In split and poly-phase electrical systems, it is common to monitor the average voltage and current for all phases of the circuit. Typical monitoring equipment will provide these values as separate from the per-phase values.

This removes the `single` key under `phases` and adds `aqQualities` fields at the same level as `phases` under individual AC monitoring devices in the schema.

The following new paths are added:

```
electrical.ac.<device>.associatedBus
electrical.ac.<device>.lineNeutralVoltage
electrical.ac.<device>.lineLineVoltage
electrical.ac.<device>.current
electrical.ac.<device>.frequency
electrical.ac.<device>.reactivePower
electrical.ac.<device>.powerFactor
electrical.ac.<device>.powerFactorLagging
electrical.ac.<device>.realPower
electrical.ac.<device>.apparentPower
```

and these are removed:

```
electrical.ac.<device>.phase.single.associatedBus
electrical.ac.<device>.phase.single.lineNeutralVoltage
electrical.ac.<device>.phase.single.lineLineVoltage
electrical.ac.<device>.phase.single.current
electrical.ac.<device>.phase.single.frequency
electrical.ac.<device>.phase.single.reactivePower
electrical.ac.<device>.phase.single.powerFactor
electrical.ac.<device>.phase.single.powerFactorLagging
electrical.ac.<device>.phase.single.realPower
electrical.ac.<device>.phase.single.apparentPower
```