### PR TITLE
feature: add type to meta/displayScale

### DIFF
--- a/gitbook-docs/data_model_metadata.md
+++ b/gitbook-docs/data_model_metadata.md
@@ -16,7 +16,7 @@ saves time and prevents costly or even disastrous mistakes from occurring due to
 ## Metadata for a Data Value
 
 The `meta` object exists at the same level as `value` and `$source` in each key in the Signal K data model.
- 
+
 [>]: # (mdpInsert ```json fsnip ../samples/full/docs-data_model_metadata.json --snip meta --prettify 2 85)
 ```json
 {
@@ -27,15 +27,16 @@ The `meta` object exists at the same level as `value` and `$source` in each key 
   "gaugeType": "analog",
   "units": "Hz",
   "timeout": 1,
+  "displayScale": {"lower": 0, "upper": 75, "type": "linear"},
   "alertMethod": ["visual"],
   "warnMethod": ["visual"],
   "alarmMethod": ["sound", "visual"],
   "emergencyMethod": ["sound", "visual"],
   "zones": [
-    {"upper": 50, "state": "alarm", "message": "Stopped or very slow"},
-    {"lower": 50, "upper": 300, "state": "normal"},
-    {"lower": 300, "upper": 350, "state": "warn", "message": "Approaching maximum"},
-    {"lower": 350, "state": "alarm", "message": "Exceeding maximum"}
+    {"upper": 4, "state": "alarm", "message": "Stopped or very slow"},
+    {"lower": 4, "upper": 60, "state": "normal"},
+    {"lower": 60, "upper": 65, "state": "warn", "message": "Approaching maximum"},
+    {"lower": 65, "state": "alarm", "message": "Exceeding maximum"}
   ]
 }
 ```
@@ -45,7 +46,28 @@ few different options for the consumer to use to display the name of the measure
 of measure. It also specifies a recommended display format via `gaugeType`.
 
 The `timeout` property tells the consumer how long it should consider the value valid. This value is specified
-in seconds, so for a high speed GPS sensor it may 0.1 or even 0.05. The `alertMethod`, `warnMethod`, `alarmMethod` and
+in seconds, so for a high speed GPS sensor it may 0.1 or even 0.05.
+
+The `displayScale` object provides information regarding the recommended type and extent of the scale used for displaying
+values. The `lower` and `upper` indicate the extent of the scale to be shown. Some values are better shown on a non linear
+scale, for example logarithmic for luminosity, depth, signal strength, etc. whilst others may be better on a squareroot
+scale eg. depth, windspeed. `type` has possible values of `linear` (default), `logarithmic`, `squareroot` or `power`. When
+`"type": "power"` is specified an additional property `power` must be present to define the power. Note that a power of
+0.5 is equivalent to `squareroot` and a power of 1 is equivalent to linear. In using these scales the type defines the
+function which is applied to all values in order to calculate % scale deflection of the pointer/needle/plot:
+
+| Type        | Formula for % deflection             |
+| ----------- | ------------------------------------ |
+| linear      | (V - L)/(U - L)                      |
+| logarithmic | (log(V) - log(L) / (log(U) - log(L)) |
+| squareroot  | (√V - √L) / (√U - √L)                |
+| power (P)   | (Vᴾ - Lᴾ) / (Uᴾ - Lᴾ)                |
+
+Where: V = value, L = lower bound of the gauge, U = upper bound of the gauge and P = power
+
+Note that on a logarithmic scale neither L nor U can be zero. 
+
+The `alertMethod`, `warnMethod`, `alarmMethod` and
 `emergencyMethod` properties tell the consumer how it should respond to an abnormal data condition. Presently the
 values for these properties are `sound` and `visual` and the method is specified as an array containing one or both of
 these options. It is up to the consumer to decide how to convey these alerts.

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -569,7 +569,6 @@
           "type": "object",
           "title": "Scale to display.",
           "description": "Gives details of the display scale against which the value should be displayed",
-          "required": ["lower", "upper"],
           "properties": {
             "lower": {
               "type": "number",
@@ -582,9 +581,26 @@
               "title": "Display upper limit.",
               "description": "The suggested upper limit for the pointer (or equivalent) on the display",
               "example": 4000
+            },
+            "type": {
+              "type": "string",
+              "enum": ["linear", "logarithmic", "squareroot", "power"],
+              "title": "Scale type used on the display.",
+              "description": "The suggested type of scale to use",
+              "example": "logarithmic"
+            },
+            "power": {
+              "type": "number",
+              "title": "Selected power for display scale",
+              "description": "The power to use when the displayScale/type is set to 'power'. Can be any numeric value except zero.",
+              "example": 2
             }
           },
-          "additionalProperties": false
+          "oneOf": [
+            {"required": ["lower", "upper"], "properties": {"lower": {}, "upper": {}}, "additionalProperties": false},
+            {"required": ["lower", "upper", "type"], "properties": {"lower": {}, "upper": {}, "type": {"enum": ["linear", "squareroot", "logarithmic"]}}, "additionalProperties": false},
+            {"required": ["lower", "upper", "type", "power"], "properties": {"lower": {}, "upper": {}, "type": {"enum": ["power"]}, "power": {}}, "additionalProperties": false}
+          ]
         },
         
         "units": {

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -584,7 +584,12 @@
             },
             "type": {
               "type": "string",
-              "enum": ["linear", "logarithmic", "squareroot", "power"],
+              "enum": [
+                "linear",
+                "logarithmic",
+                "squareroot",
+                "power"
+              ],
               "title": "Scale type used on the display.",
               "description": "The suggested type of scale to use",
               "example": "logarithmic"
@@ -597,12 +602,57 @@
             }
           },
           "oneOf": [
-            {"required": ["lower", "upper"], "properties": {"lower": {}, "upper": {}}, "additionalProperties": false},
-            {"required": ["lower", "upper", "type"], "properties": {"lower": {}, "upper": {}, "type": {"enum": ["linear", "squareroot", "logarithmic"]}}, "additionalProperties": false},
-            {"required": ["lower", "upper", "type", "power"], "properties": {"lower": {}, "upper": {}, "type": {"enum": ["power"]}, "power": {}}, "additionalProperties": false}
+            {
+              "required": [
+                "lower",
+                "upper"
+              ],
+              "properties": {
+                "lower": {},
+                "upper": {}
+              },
+              "additionalProperties": false
+            },
+            {
+              "required": [
+                "lower",
+                "upper",
+                "type"
+              ],
+              "properties": {
+                "lower": {},
+                "upper": {},
+                "type": {
+                  "enum": [
+                    "linear",
+                    "squareroot",
+                    "logarithmic"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "required": [
+                "lower",
+                "upper",
+                "type",
+                "power"
+              ],
+              "properties": {
+                "lower": {},
+                "upper": {},
+                "type": {
+                  "enum": [
+                    "power"
+                  ]
+                },
+                "power": {}
+              },
+              "additionalProperties": false
+            }
           ]
         },
-        
         "units": {
           "type": "string",
           "title": "units schema.",

--- a/test/data/vessel-invalid/meta-with_displayScale_and_invalid_power.json
+++ b/test/data/vessel-invalid/meta-with_displayScale_and_invalid_power.json
@@ -1,0 +1,30 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "propulsion": {
+    "instance0": {
+      "label": "Main Engine",
+      "revolutions": {
+        "value":  43.5,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "Engine revolutions (x60 for RPM)",
+          "units": "Hz",
+          "displayName": "Tachometer",
+          "shortName": "RPM",
+          "displayScale": {
+            "lower": 0,
+            "upper": 66.667,
+            "type": "logarithmic",
+            "power": 2
+          },
+          "zones": [{
+            "lower": 60.0,
+            "state": "alarm",
+            "message": "Engine exceeds maximum rpm!"
+          }]
+        }
+      }
+    }
+  }
+}

--- a/test/data/vessel-valid/meta-with_displayScale_type.json
+++ b/test/data/vessel-valid/meta-with_displayScale_type.json
@@ -1,0 +1,32 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "environment": {
+    "depth": {
+      "belowKeel": {
+        "value":  43.5,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "Depth below keel",
+          "units": "m",
+          "displayName": "Depth below Keel",
+          "shortName": "Depth",
+          "displayScale": {
+            "lower": 0.5,
+            "upper": 200,
+            "type": "logarithmic"
+          },
+          "zones": [{
+            "upper": 2.0,
+            "state": "alarm",
+            "message": "Shallow"
+          },{
+            "upper": 5.0,
+            "state": "warn",
+            "message": "Shallow"
+          }]
+        }
+      }
+    }
+  }
+}

--- a/test/data/vessel-valid/meta-with_displayScale_type_power.json
+++ b/test/data/vessel-valid/meta-with_displayScale_type_power.json
@@ -1,0 +1,30 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "propulsion": {
+    "instance0": {
+      "label": "Main Engine",
+      "revolutions": {
+        "value":  43.5,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "Engine revolutions (x60 for RPM)",
+          "units": "Hz",
+          "displayName": "Tachometer",
+          "shortName": "RPM",
+          "displayScale": {
+            "lower": 0,
+            "upper": 66.667,
+            "type": "power",
+            "power": 0.5
+          },
+          "zones": [{
+            "lower": 60.0,
+            "state": "alarm",
+            "message": "Engine exceeds maximum rpm!"
+          }]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add `type` within `displayScale` object to allow for non linear scales, ie. logarithmic, squareroot and power.

Tests added, sample extended and documentation updated.

closes #418