### PR TITLE
fix: modify schema to enforce `description` and `units`

### DIFF
--- a/gitbook-docs/data_model_metadata.md
+++ b/gitbook-docs/data_model_metadata.md
@@ -60,9 +60,14 @@ raise a generic alarm event. See the section on [Alarm Handling](notifications.m
 
 ## Implicit Metadata
 
-All keys in the Signal K specification must have `units` and a `description`. If a client requests the `meta` property
-for a valid Signal K key via the HTTP REST interface, the server must return the `units` and `description`, even if no
-value has ever been generated for that key.
+All keys in the Signal K specification must have a `description`, and where the key is a numeric value it must have
+`units`.
+
+If a client requests the `meta` property for a valid Signal K key via the HTTP REST interface, the server must return
+the `description` and, if applicable, `units`, even if no value has ever been generated for that key.
+
+If a key has values determined by an enum, the server should include the enum in the meta. NB. in future versions
+it is likely that this will become a mandatory requirement for the server.
 
 ```javascript
 // GET /signalk/v1/api/vessels/self/environment/depth/belowKeel/meta

--- a/samples/full/0183-RMC-full.json
+++ b/samples/full/0183-RMC-full.json
@@ -19,6 +19,8 @@
         },
         "courseOverGroundTrue": {
           "meta": {
+            "description": "Course over ground (true)",
+            "units": "rad",
             "zones": [
               {
                 "lower": 260,

--- a/samples/full/signalk-depth-meta-attr.json
+++ b/samples/full/signalk-depth-meta-attr.json
@@ -14,6 +14,7 @@
 		                    "_group": "self"
 		                },
 		                "meta": {
+		                    "description": "Depth below keel",
 		                    "displayName": "Depth Below Keel",
 		                    "longName": "Depth Below Keel in Meters",
 		                    "shortName": "DBK",

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -346,6 +346,9 @@
                 "$ref": "#/definitions/valuesNumberValue"
               }
             }
+          },
+          "meta": {
+            "required": ["units"]
           }
         }
       }]
@@ -529,6 +532,7 @@
       "type": "object",
       "title": "Meta schema.",
       "description": "Provides meta data to enable alarm and display configuration.",
+      "required": ["description"],
       "properties": {
         "displayName": {
           "type": "string",
@@ -556,6 +560,13 @@
           "title": "Description schema.",
           "description": "Description of the SK path.",
           "example": "Engine revolutions (x60 for RPM)"
+        },
+        
+        "enum": {
+          "type": "array",
+          "title": "Permissible values",
+          "description": "List of permissible values",
+          "example": ["stopped", "started", "unusable"]
         },
 
         "gaugeType": {

--- a/test/data/full-valid/electrical-full_tree.json
+++ b/test/data/full-valid/electrical-full_tree.json
@@ -22,6 +22,8 @@
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar",
               "meta": {
+                "description": "Voltage measured at or as close as possible to the device",
+                "units": "V",
                 "nominal": 12,
                 "warnLower": 12,
                 "faultLower": 11.6,
@@ -71,6 +73,8 @@
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar",
               "meta": {
+                "description": "Voltage measured at or as close as possible to the device",
+                "units": "V",
                 "nominal": 12
               }
             },
@@ -86,6 +90,8 @@
               "timestamp": "2014-08-15T19:00:15.402Z",
               "$source": "foo.bar",
               "meta": {
+                "description": "Voltage measured at or as close as possible to the device",
+                "units": "V",
                 "nominal": 12
               }
             },

--- a/test/data/vessel-invalid/meta-missing-description.json
+++ b/test/data/vessel-invalid/meta-missing-description.json
@@ -1,0 +1,16 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "propulsion": {
+    "instance0": {
+      "label": "Main Engine - The Olde Faithful",
+      "revolutions": {
+        "value": 1280,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "units": "Hz"
+        }
+      }
+    }
+  }
+}

--- a/test/data/vessel-invalid/meta-missing-units.json
+++ b/test/data/vessel-invalid/meta-missing-units.json
@@ -1,0 +1,16 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "propulsion": {
+    "instance0": {
+      "label": "Main Engine - The Olde Faithful",
+      "revolutions": {
+        "value": 1280,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "Engine revolutions (x60 for RPM)"
+        }
+      }
+    }
+  }
+}

--- a/test/data/vessel-invalid/meta-with-invalid-enum.json
+++ b/test/data/vessel-invalid/meta-with-invalid-enum.json
@@ -1,0 +1,17 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "propulsion": {
+    "instance0": {
+      "label": "Main Engine - The Olde Faithful",
+      "state": {
+        "value": "started",
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "The current state of the engine",
+          "enum": "stopped"
+        }
+      }
+    }
+  }
+}

--- a/test/data/vessel-valid/meta-with-enum.json
+++ b/test/data/vessel-valid/meta-with-enum.json
@@ -1,0 +1,21 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "propulsion": {
+    "instance0": {
+      "label": "Main Engine - The Olde Faithful",
+      "state": {
+        "value": "started",
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "The current state of the engine",
+          "enum": [
+            "stopped",
+            "started",
+            "unusable"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/data/vessel-valid/propulsion-sample.json
+++ b/test/data/vessel-valid/propulsion-sample.json
@@ -55,6 +55,8 @@
         "timestamp": "2014-08-15T19:00:15.402Z",
         "$source": "foo.bar",
         "meta": {
+          "description": "Engine revolutions (x60 for RPM)",
+          "units": "Hz",
           "displayName": "Tachometer",
           "shortName": "RPM",
           "warnMethod": ["visual"],


### PR DESCRIPTION
Schema modified to enforce the written specification that description and units must be present in meta.

Also added possibility for meta to include an enum list of possible values where the value is non numeric. This is not mandatory as at 1.0.x but the documentation notes that it is likely to become mandatory in future (see issue #439).

Samples and tests corrected to comply with the requirement.

Additional tests added to test the schema modifications.

Although the schema is not backwards compatible (making `description` mandatory where it wasn't previously), this change is just placing into the schema a requirement that was previously written in the specification. As such it can be viewed as an ADDITION (a schema change that is compatible with all historical data).

closes #439
