### PR TITLE
docs: clarify websockets hello message

### DIFF
--- a/gitbook-docs/connection.md
+++ b/gitbook-docs/connection.md
@@ -29,6 +29,8 @@ The server MAY provide the following values:
 * `swname` is the name of the Signal K server software, e.g. signalk-server-node
 * `swvers` is the version of the Signal K server software
 
+`swname`, `self` amd `roles` MUST be the same values as provided by the `name`, `self` and `roles` properties within the [Websocket hello message](streaming_api.md) (if implemented).
+
 An example DNS-SD record set is shown below.
 
 ```
@@ -38,7 +40,7 @@ Service data for service 'signalk-http' of type '_signalk-http._tcp' in domain '
     TXT data: [
         'txtvers=1',
         'roles=master,main',
-        'self=urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d',
+        'self=vessels.urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d',
         'swname=signalk-server',
         'swvers=0.1.23'
         ]

--- a/gitbook-docs/rest_api.md
+++ b/gitbook-docs/rest_api.md
@@ -43,8 +43,10 @@ the server supports a `signalk-tcp` stream over TCP at on port 8367.
 
 A server may return relative URIs that the client must resolve against the base of the original request.
 
-A server may return information about itself in the `server` property. The id and version scheme is not defined as part
-of the specification and there is no registry for id values.
+A server MAY return information about itself in the `server` property. The id and version scheme is not defined as part
+of the specification and there is no registry for id values. If providfed, the `id` and `version` MUST be the same values
+as `swname` and `swvers` within the [DNS-SD advertisement](connection.md) (if implemented), and also the `id` MUST
+provide the same value as `name` within the [Websocket hello message](streaming_api.md) (if implemented).
 
 ## /signalk/«version»/api/
 

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -18,12 +18,35 @@ See [Subscription Protocol](subscription_protocol.md) for more details.
 
 ## Connection Hello
 
-Upon connection a 'hello' message is sent as follows:
+Upon connection the server MUST send a 'hello' JSON message, for example:
 
+[>]: # (mdpInsert ```json cat ../samples/hello/docs-hello.json)
 ```json
 {
-  "version": "1.1.2",
-  "timestamp": "2015-04-13T01:13:50.524Z",
-  "self": "123456789"
+    "name": "foobar marine server",
+    "version": "1.0.4",
+    "timestamp": "2018-06-21T15:09:16.704Z",
+    "self": "vessels.urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+    "roles": [
+        "master",
+        "main"
+    ]
 }
 ```
+[<]: #
+This response is defined by the `hello.json` schema.
+
+The server MUST provide:
+- `roles` which specifies which roles the server is capable of providing. See [roles](connection.md#roles) for details about possible server roles.
+- `version` which specifies the version of the SignalK schema and APIs that the server is using. See [versioning](versioning.md) for details about `version` strings.
+
+The server SHOULD provide:
+- `timestamp` but only if the server is equipped with a time source and it has been set.
+
+The server MAY provide:
+- `self` is the unique identifier of the vessel using the URN format specified for the uuid field in the Signal K schema. It may also use the URN format specified for the mmsi field in the Signal K schema if it exists. This is only provided if the server relates to a specific vessel, aircraft, aid to navigation or sar.
+- `name` is the name of the Signal K server software, e.g. signalk-server
+
+`name`, `self` and `roles` MUST return the same values as provided in the `swname`, `self` and `roles` properties within the [DNS-SD advertisement](connection.md) (if implemented).
+
+`version` MUST be the same value as `version` within the associated endpoints list provided by the http `GET` request to `/signalk` within the [REST API](rest_api.md) (if implemented).

--- a/samples/hello/docs-hello-minimal.json
+++ b/samples/hello/docs-hello-minimal.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.0.2",
+    "roles": [
+        "slave"
+    ]
+}

--- a/samples/hello/docs-hello.json
+++ b/samples/hello/docs-hello.json
@@ -1,0 +1,10 @@
+{
+    "name": "foobar marine server",
+    "version": "1.0.4",
+    "timestamp": "2018-06-21T15:09:16.704Z",
+    "self": "vessels.urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+    "roles": [
+        "master",
+        "main"
+    ]
+}

--- a/schemas/hello.json
+++ b/schemas/hello.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://signalk.org/specification/1.0.0/schemas/delta.json#",
+  "title": "SignalK Websockets Hello message schema",
+  "description": "Schema for defining the hello message passed from the server to a client following succesful websocket connection",
+  "required": [
+    "version",
+    "roles"
+  ],
+  "properties": {
+    "version": {
+      "description": "Version of the schema and APIs that this data is using in canonical format i.e. 1.0.0.",
+      "$ref": "definitions.json#/definitions/version"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the Signal K server software",
+      "example": "iKommunicate"
+    },
+    "timestamp": {
+      "$ref": "./definitions.json#/definitions/timestamp"
+    },
+    "self": {
+      "type": "string",
+      "description": "This holds the context (prefix + UUID, MMSI or URL in dot notation) of the server's self object.",
+      "example": "vessels.urn:mrn:signalk:uuid:6b0e776f-811a-4b35-980e-b93405371bc5",
+      "oneOf": [
+        {
+          "pattern": "^vessels.(urn:mrn:(imo:mmsi:[2-7][0-9]{8}$|signalk:uuid:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$))|(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
+        },
+        {
+          "pattern": "^aircraft.(urn:mrn:(imo:mmsi:1[0-9]{8}$|signalk:uuid:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$))|(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
+        },
+        {
+          "pattern": "^aton.(urn:mrn:(imo:mmsi:99[0-9]{7}$|signalk:uuid:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$))|(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
+        },{
+          "pattern": "^sar.(urn:mrn:(imo:mmsi:97[0-9]{7}$|signalk:uuid:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$))|(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
+        }
+      ]
+    },
+    "roles": {
+      "type": "array",
+      "description": "The designated roles of the server",
+      "oneOf": [
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [{"enum": ["master"]}, {"enum": ["main", "aux"]}]
+        },
+        {
+          "minItems": 1,
+          "maxItems": 1,
+          "items": [{"enum": ["slave"]}]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/hello.json
+++ b/schemas/hello.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.0.0/schemas/delta.json#",
+  "id": "https://signalk.org/specification/1.0.0/schemas/hello.json#",
   "title": "SignalK Websockets Hello message schema",
   "description": "Schema for defining the hello message passed from the server to a client following succesful websocket connection",
   "required": [
@@ -34,7 +34,8 @@
         },
         {
           "pattern": "^aton.(urn:mrn:(imo:mmsi:99[0-9]{7}$|signalk:uuid:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$))|(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
-        },{
+        },
+        {
           "pattern": "^sar.(urn:mrn:(imo:mmsi:97[0-9]{7}$|signalk:uuid:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$))|(http(s?):.*|mailto:.*|tel:(\\+?)[0-9]{4,})$"
         }
       ]

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,15 @@ function chaiAsPromised(chai, utils) {
     }
     checkValidFullSignalK.call(this);
   });
+  Assertion.addProperty('validSignalKHello', function () {
+    var result = validateWithSchema(this._obj, 'hello.json');
+    var message = result.error ? result.error.message + ':' + result.error.dataPath : '';
+    this.assert(
+      result.valid
+      , message
+      , 'expected #{this} to be valid SignalK hello message'
+      );
+  });
   Assertion.addProperty('validSignalKDelta', function () {
     var result = validateDelta(this._obj);
     var message = result.errors.length === 0 ? '' : result.errors[0].message + ':' + result.errors[0].dataPath +

--- a/test/data/hello-invalid/version_bad.json
+++ b/test/data/hello-invalid/version_bad.json
@@ -1,0 +1,6 @@
+{
+    "version": "V1.0.2",
+    "roles": [
+        "slave"
+    ]
+}

--- a/test/data/hello-valid/master.json
+++ b/test/data/hello-valid/master.json
@@ -1,0 +1,10 @@
+{
+    "name": "signalk-server",
+    "version": "1.0.4",
+    "timestamp": "2018-06-21T15:09:16.704Z",
+    "self": "vessels.urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+    "roles": [
+        "master",
+        "aux"
+    ]
+}

--- a/test/data/hello-valid/slave_minimal.json
+++ b/test/data/hello-valid/slave_minimal.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.0.0",
+    "roles": [
+        "slave"
+    ]
+}

--- a/test/jsonSamplesAndTestFiles.js
+++ b/test/jsonSamplesAndTestFiles.js
@@ -13,6 +13,15 @@ describe('Samples', function() {
     })
   });
   
+  describe('hello', function() {
+    getFiles('./samples/hello').forEach(function(file) {
+      it(file, function() {
+        assert.equal(file.indexOf(' '), -1, "spaces are not permitted in file names");
+        require('../samples/hello/' + file).should.be.validSignalKHello;
+      });
+    })
+  });
+  
   describe('delta', function() {
     getFiles('./samples/delta').forEach(function(file) {
       it(file, function() {
@@ -86,6 +95,25 @@ describe('Unit tests', function() {
         it(file, function () {
           assert.equal(file.indexOf(' '), -1, "spaces are not permitted in file names");
           require('../test/data/discovery-invalid/' + file).should.not.be.validDiscovery;
+        });
+      })
+    });
+  });
+
+  describe('hello', function () {
+    describe('valid', function () {
+      getFiles('./test/data/hello-valid').forEach(function (file) {
+        it(file, function () {
+          assert.equal(file.indexOf(' '), -1, "spaces are not permitted in file names");
+          require('../test/data/hello-valid/' + file).should.be.validSignalKHello;
+        });
+      })
+    });
+    describe('invalid', function () {
+      getFiles('./test/data/hello-invalid').forEach(function (file) {
+        it(file, function () {
+          assert.equal(file.indexOf(' '), -1, "spaces are not permitted in file names");
+          require('../test/data/hello-invalid/' + file).should.not.be.validSignalKHello;
         });
       })
     });


### PR DESCRIPTION
Documentation improved.

Add new json schema file to be used to validate the hello message.

Add sample and test json files to illustrate and test usage.

resolves #473 

@tkurki be grateful if you could take a look at this. In particular there appears to be some commonality between the websocket hello message, the rest api, and the streaming api. None of which have to be implemented but I'm assuming if more than one is implemented the values (server name, signalK version, etc) should be the same in each place. I've assumed this and added to the documentation accordingly.

