### PR TITLE
fix: discrepancy between docs and sample json

### DIFF
--- a/gitbook-docs/data_model_metadata.md
+++ b/gitbook-docs/data_model_metadata.md
@@ -21,9 +21,9 @@ The `meta` object exists at the same level as `value` and `$source` in each key 
 ```json
 {
   "displayName": "Port Tachometer",
-  "longName": "Engine 2 Tachometer (x60 for RPM)",
-  "shortName": "Revs",
-  "description": "Revolutions in HZ, measured via the W terminal on the alternator",
+  "longName": "Engine 2 Tachometer",
+  "shortName": "Tacho",
+  "description": "Engine revolutions (x60 for RPM)",
   "units": "Hz",
   "timeout": 1,
   "displayScale": {"lower": 0, "upper": 75, "type": "linear"},

--- a/samples/full/docs-data_model_metadata.json
+++ b/samples/full/docs-data_model_metadata.json
@@ -12,11 +12,16 @@
             "$source": "foo.bar",
             "meta": {
               "displayName": "Port Tachometer",
-              "longName": "Engine 2 Tachometer (x60 for RPM)",
-              "shortName": "Revs",
-              "description": "Revolutions in HZ, measured via the W terminal on the alternator",
+              "longName": "Engine 2 Tachometer",
+              "shortName": "Tacho",
+              "description": "Engine revolutions (x60 for RPM)",
               "units": "Hz",
               "timeout": 1,
+              "displayScale": {
+                "lower": 0,
+                "upper": 75,
+                "type": "linear"
+              },
               "alertMethod": [
                 "visual"
               ],
@@ -33,23 +38,23 @@
               ],
               "zones": [
                 {
-                  "upper": 50,
+                  "upper": 4,
                   "state": "alarm",
                   "message": "Stopped or very slow"
                 },
                 {
-                  "lower": 50,
-                  "upper": 300,
+                  "lower": 4,
+                  "upper": 60,
                   "state": "normal"
                 },
                 {
-                  "lower": 300,
-                  "upper": 350,
+                  "lower": 60,
+                  "upper": 65,
                   "state": "warn",
                   "message": "Approaching maximum"
                 },
                 {
-                  "lower": 350,
+                  "lower": 65,
                   "state": "alarm",
                   "message": "Exceeding maximum"
                 }


### PR DESCRIPTION
Documentation discrepancy between the meta documentation and the sample file populating it. Also minor fix in the sample to ensure meta/description agrees with the value in the schema. This was introduced in PR #461 by me, sorry.