### PR TITLE
fix: accommodate any server software versioning scheme

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -49,8 +49,8 @@
           "type": "string"
         },
         "version": {
-          "description": "The version of this server",
-          "$ref": "definitions.json#/definitions/version"
+          "description": "The version of this server (not limited to signalk versioning rules).",
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
The server software (not signalk schema) version was previously limited to the versioning regime mandated by signalk. This relaxes the schema to allow for servers which use alternative versioning systems.