### PR TITLE
docs: fix 'context' in Subscription Protocol examples

### DIFF
--- a/gitbook-docs/subscription_protocol.md
+++ b/gitbook-docs/subscription_protocol.md
@@ -60,7 +60,7 @@ To subscribe to the required criteria send a suitable subscribe message:
 [>]: # (mdpInsert ```json fsnip ../samples/subscribe/docs-subscription_protocol1.json --prettify)
 ```json
 {
-  "context": "vessels.self",
+  "context": "self",
   "subscribe": [
     {
       "path": "navigation.speedThroughWater",
@@ -128,7 +128,7 @@ This can be achieved by a default WebSocket connection `/signalk/v1/stream?subcr
 [>]: # (mdpInsert ```json fsnip ../samples/subscribe/docs-subscription_protocol2.json --prettify)
 ```json
 {
-  "context": "vessels.self",
+  "context": "self",
   "subscribe": [
     {
       "path": "environment.depth.belowTransducer"
@@ -170,7 +170,7 @@ vessels, sent every 2 minutes (120 seconds) even if no data has been updated.
 [>]: # (mdpInsert ```json fsnip ../samples/subscribe/docs-subscription_protocol4.json --prettify)
 ```json
 {
-  "context": "vessels.230029970",
+  "context": "vessels.urn:mrn:imo:mmsi:230029970",
   "subscribe": [
     {
       "path": "navigation.position",

--- a/samples/subscribe/docs-subscription_protocol1.json
+++ b/samples/subscribe/docs-subscription_protocol1.json
@@ -1,5 +1,5 @@
 {
-  "context": "vessels.self",
+  "context": "self",
   "subscribe": [
     {
       "path": "navigation.speedThroughWater",

--- a/samples/subscribe/docs-subscription_protocol2.json
+++ b/samples/subscribe/docs-subscription_protocol2.json
@@ -1,5 +1,5 @@
 {
-  "context": "vessels.self",
+  "context": "self",
   "subscribe": [
     {
       "path": "environment.depth.belowTransducer"

--- a/samples/subscribe/docs-subscription_protocol4.json
+++ b/samples/subscribe/docs-subscription_protocol4.json
@@ -1,5 +1,5 @@
 {
-  "context": "vessels.230029970",
+  "context": "vessels.urn:mrn:imo:mmsi:230029970",
   "subscribe": [
     {
       "path": "navigation.position",


### PR DESCRIPTION
Examples in the documentation showed `vessels.self` in the context section, whereas `self` includes the vessels (or aton, etc) part. (`vessels.self` would expand to `vessels.vessels.urn:mrn...`)

Just to clarify, `http://<<IP>>/signalk/v1/api/self` returns something like "vessels.urn:mrn:signalk:uuid:490be140-16f7-48bc-9c17-05ca7efbb745", 

the websockets hello has:
```
{
  ...
  "self": "vessels.urn:mrn:signalk:uuid:490be140-16f7-48bc-9c17-05ca7efbb745",
}
```

The above examples are taken from node-server.

Also checked node-server to ensure that the subscription messages as modified here, work correctly.