### PR TITLE
chore: remove dependency on tv4-formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3937,7 +3937,8 @@
     "moment": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
+      "dev": true
     },
     "moment-timezone": {
       "version": "0.5.5",
@@ -9947,22 +9948,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
       "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
-    },
-    "tv4-formats": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-2.2.2.tgz",
-      "integrity": "sha1-gz2mNt7jtOd85kHRUOYIAY3GW40=",
-      "requires": {
-        "moment": "2.20.1",
-        "validator": "7.2.0"
-      },
-      "dependencies": {
-        "validator": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
-          "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
-        }
-      }
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/signalk-schema",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "SignalK specification schema as an npm module with tests",
   "main": "dist/index.js",
   "scripts": {
@@ -47,8 +47,7 @@
     "debug": "^2.2.0",
     "json-schema-ref-parser": "^3.1.2",
     "lodash": "^3.10.1",
-    "tv4": "^1.2.7",
-    "tv4-formats": "^2.2.1"
+    "tv4": "^1.2.7"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,6 @@ function getTv4() {
   tv4.addSchema('https://signalk.org/specification/1.0.0/schemas/external/geojson/geometry.json', externalGeometry);
   tv4.addSchema('http://json-schema.org/geojson/geometry.json', externalGeometry);
 
-  tv4.addFormat(require('tv4-formats'))
-
   return tv4;
 }
 
@@ -118,7 +116,7 @@ function chaiAsPromised(chai, utils) {
   Assertion.addProperty('validSignalKIgnoringSelf', function() {
     this._obj.self = 'urn:mrn:imo:mmsi:230099999';
     checkValidFullSignalK.call(this);
-  });  
+  });
   Assertion.addProperty('validSignalKVessel', function() {
     this._obj = {
       'vessels': {
@@ -318,12 +316,12 @@ module.exports.getAISShipTypeName = function(id) {
   const the_enum = subSchemas['design'].properties.aisShipType.allOf[1].properties.value.allOf[1].enum;
   //const the_enum = module.exports.getMetadata('vessels.foo.design.aisShipType').enum
   var res = the_enum.find(item => { return item.id  == id });
-  return res ? res.name : undefined 
+  return res ? res.name : undefined
 }
 
 
 module.exports.getAtonTypeName = function(id) {
   const the_enum = require('../schemas/aton.json').properties.atonType.allOf[1].properties.value.allOf[1].enum;
   var res = the_enum.find(item => { return item.id  == id });
-  return res ? res.name : undefined 
+  return res ? res.name : undefined
 }


### PR DESCRIPTION
TV4-Format provides some JSON validation helper for common string
formats. It was loaded only when validating the full model (not delta)
and all the tests run without it so I propose we remove it.

Reason for me looking into this is that this library causes problem with
webpack because of a heuristic they use to require one of their
dependency. This is a known issue that they have fixed in a later
version and I have confirmed that upgrading the package fixes the issue
for us too. However, if we do not use the library I think it's better to
completely remove it.

For more info: https://github.com/ikr/tv4-formats/commit/61450dc7499440980169a67bc51d554a67c5c30d