### PR TITLE
feature: add baitWell as a type of tank

### DIFF
--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -27,6 +27,7 @@
                 "lpg",
                 "diesel",
                 "liveWell",
+                "baitWell",
                 "ballast",
                 "rum"
               ]
@@ -96,6 +97,10 @@
     },
     "liveWell": {
       "description": "Live tank (fish)",
+      "$ref": "#/definitions/tankCollection"
+    },
+    "baitWell": {
+      "description": "Bait tank",
       "$ref": "#/definitions/tankCollection"
     },
     "gas": {


### PR DESCRIPTION
The NMEA2000 standard makes a distinction between liveWell and baitWell.
We need to have that distinction too so we can accurately and
unequivocally translate some NMEA2000 PGNs.

See https://github.com/SignalK/n2k-signalk/pull/125 for a discussion of
the issue in the context of processing PGN130311 (temperature).

Example of NMEA2000 PGN with liveWell and baitWell:
https://github.com/sarfata/canboatjs/blob/9590c76ac8b7b265efeb143e318c8c87aaf437bf/lib/pgns.json#L16326