### PR TITLE
fix: remove wildcard properties in groups/sources

### DIFF
--- a/schemas/groups/sources.json
+++ b/schemas/groups/sources.json
@@ -115,7 +115,12 @@
                 }
               }
             }
-          ]
+          ],
+          "patternProperties": {
+            ".*": {
+              "properties": {}
+            }
+          }
         }
       },
       "properties": {

--- a/schemas/groups/sources.json
+++ b/schemas/groups/sources.json
@@ -114,13 +114,6 @@
                   }
                 }
               }
-            },
-            {
-              "patternProperties": {
-                ".*": {
-                  "properties": {}
-                }
-              }
             }
           ]
         }


### PR DESCRIPTION
Having a wildcard `patternProperties` in parallel of `ais`, `talker`, `sentences`, `n2k` won't correctly validate compliance.

Any object that would define a wrongly typed message inside of the above properties will then fallback on matching the wildcard property which won't return an error on validation.

example `sources`:
```
{
  "label1": {
    "talker1": {
      "ais": {
        "aisType": "long range"
      }
    }
  }
}
```

## Actual Behavior
The validator will try to match the nested object with the `ais` property which won't work given that the `aisType` is a string and not a number here *but* the validator will then fallback to match `ais` with the wildcard property in the second nested object which will *succeed* the validation test.

## Expected Behavior
The validator should *fail* given that `aisType` is in the wrong format (`string` instead of `number`)

## Remark
json-schema already let's you have properties outside of the defined list in `anyOf` unless you specify `otherProperties` to false which is not the case here.

## Solution
Just removing the wildcard property should makes the definition work as expected

