### PR TITLE
Feature: Additional Note attributes

### DIFF
--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -202,14 +202,14 @@
             },
             "region": {
               "type": "string",
-              "description": "Region related to note. A pointer to a region UUID. Alternative to position or geohash"
+              "description": "Region related to note. A pointer to a region UUID. Can be defined in additon to position or geohash"
             },
             "position": {
-              "description": "Position related to note. Alternative to region or geohash",
+              "description": "Position related to note. Alternative to geohash",
               "$ref": "../definitions.json#/definitions/position"
             },
             "geohash": {
-              "description": "Position related to note. Alternative to region or position",
+              "description": "Position related to note. Alternative to position",
               "$ref": "../definitions.json#/definitions/geohash"
             },
             "mimeType": {
@@ -220,6 +220,14 @@
               "type": "string",
               "description": "Location of the note"
             },
+            "group": {
+                "type": "string",
+                "description": "Name of a group or collection to which the note is attached"
+            }, 
+            "author": {
+                "type": "string",
+                "description": "Name of the creator of the note"
+            },                         
             "timestamp": {
               "description": "Timestamp of the last update to this data",
               "$ref": "../definitions.json#/definitions/timestamp"

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -227,7 +227,15 @@
             "author": {
                 "type": "string",
                 "description": "Name of the creator of the note"
-            },                         
+            }, 
+            "readOnly": {
+                "type": "boolean",
+                "description": "Indicates whether the whether the content of the Note is permitted to be changed."
+            },
+            "published": {
+                "type": "boolean",
+                "description": "Indicates whether the note is available only for use on this server or shared with others."
+            },                                                
             "timestamp": {
               "description": "Timestamp of the last update to this data",
               "$ref": "../definitions.json#/definitions/timestamp"


### PR DESCRIPTION
This PR looks to address Notes schema limitations outlined in Issue #539 (@irandrews)

The current Notes schema facilitates the following:

- Create a Note at a geographic location
- Create a Note at a geohash
- Attach Note to a Region uuid in `/resources/regions`


Although `position`, `region` and `geohash` are not defined as `oneOf` they are described as alternatives to each other. This implies that one can not define a Note at a specific location within a `region`. 

Therefore the scenario where the area of a region is:

1. Large enough to contain multiple hazards, at various locations within the region AND 
2. One wants to place different Notes on specific hazards 

is not specifically supported with the current definitions.

Additionally there is no way to:
- Group Notes together regardless of position or region. 
- Define the author of a Note.
- Define whether the contents of the Note can be edited / changed.
- Define whether the note is available only on the host Signal K server or is shared with other servers / services.



__To facilitate these scenarios the following changes are proposed:__
1. Change the wording of the definitions of:
- `region` to be defined as _additional_ to `position` or `geohash`
- `position` and `geohash` to be defined as only being alternatives to each other

2. Add a `group` attribute to allow the definition of a group or collection to which the Note belongs

3. Add an `author` attribute

4. Add a `readOnly` attribute to show whether the content of the Note is permitted to be changed.

5. Add a `published` attribute, to show whether a Note is available to other Signal K servers or services.

---

Adding these additional attributes would:
- Facilitate the retrieval of notes that are part of a specific `group` by supplying the relevant parameter to `/resources/notes?group=<group_name>` _(as proposed in PR #541)_.

- Identify the author of a Note.

- Identify a Note as non-editable.

- Identify a Note as available outside of the host Signal K server.

