### PR TITLE
fix: choice of the value of the notification state

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -505,6 +505,19 @@
       }
     },
 
+    "notificationLevel": {
+      "type": "string",
+      "title": "notificationLevel",
+      "description": "The alarm level when a notification is raised.",
+      "default": "normal",
+      "enum": [
+        "normal",
+        "alert",
+        "warn",
+        "alarm",
+        "emergency"
+      ]
+    },
     "alarmState": {
       "type": "string",
       "title": "alarmState",

--- a/schemas/groups/notifications.json
+++ b/schemas/groups/notifications.json
@@ -28,7 +28,7 @@
                 },
                 "state": {
                   "description": "Current notification state",
-                  "$ref": "../definitions.json#/definitions/alarmState"
+                  "$ref": "../definitions.json#/definitions/notificationLevel"
                 },
                 "message": {
                   "description": "Message to display or speak",


### PR DESCRIPTION
The purpose of this PR is to clarify the possible values for the states in notifications vs the states in zones.
- For a notification, the possible states are:
`[normal|alert|warn|alarm|emergency]` (deletion of nominal).
- For a zone, the possible states are:
`[nominal|normal|alert|warn|alarm|emergency]` (no change).

The file `gitbook-docs\data_model_metadata.md#alarm-management` was already updated in the documentation.

Please comment to find the best compromise.