### PR TITLE
feature: include all source information under `sources`

### DIFF
--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -142,10 +142,17 @@ function handleNmea2000Source(labelSource, source, timestamp) {
   if(!labelSource[source.src]) {
     labelSource[source.src] = {
       n2k: {
-        src: source.src,
+        ...source,
         pgns: {}
       }
     };
+    delete labelSource[source.src].n2k.pgn
+  } else {
+    labelSource[source.src].n2k = {
+      ...source,
+      ...labelSource[source.src].n2k
+    }
+    delete labelSource[source.src].n2k.pgn
   }
   if(source.instance && !labelSource[source.src][source.instance]) {
     labelSource[source.src][source.instance] = {}

--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -151,6 +151,9 @@ function handleNmea2000Source(labelSource, source, timestamp) {
 
   _.assign(existing.n2k, source)
   delete existing.n2k.pgn
+  delete existing.n2k.label
+  delete existing.n2k.instance
+  delete existing.n2k.type
   
   if(source.instance && !labelSource[source.src][source.instance]) {
     labelSource[source.src][source.instance] = {}

--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -139,21 +139,19 @@ FullSignalK.prototype.updateSource = function(context, source, timestamp) {
 }
 
 function handleNmea2000Source(labelSource, source, timestamp) {
-  if(!labelSource[source.src]) {
-    labelSource[source.src] = {
+  let existing = labelSource[source.src]
+
+  if ( !existing ) {
+    existing = labelSource[source.src] = {
       n2k: {
-        ...source,
-        pgns: {}
+        pgns:{}
       }
-    };
-    delete labelSource[source.src].n2k.pgn
-  } else {
-    labelSource[source.src].n2k = {
-      ...source,
-      ...labelSource[source.src].n2k
     }
-    delete labelSource[source.src].n2k.pgn
   }
+
+  _.assign(existing.n2k, source)
+  delete existing.n2k.pgn
+  
   if(source.instance && !labelSource[source.src][source.instance]) {
     labelSource[source.src][source.instance] = {}
   }


### PR DESCRIPTION
This is a change only the code use by node server to build the full tree.

Currently when building a the full tree from deltas, this code will not include things like `hardwareVersion` and `productName` under `/sources` when included in deltas. This changes makes so all extra fields under `source` for deltas are included.

