### PR TITLE
feature: specify streaming over TCP in more detail

### DIFF
--- a/gitbook-docs/SUMMARY.md
+++ b/gitbook-docs/SUMMARY.md
@@ -12,7 +12,7 @@
 * [API]()
   * [URLs and Ports](urls_ports.md)
   * [REST API](rest_api.md)
-  * [Streaming WebSocket API](streaming_api.md)
+  * [Streaming API](streaming_api.md)
   * [Subscription Protocol](subscription_protocol.md)
   * [Discovery & Connection Establishment](connection.md)
   * [Notifications](notifications.md)

--- a/gitbook-docs/connection.md
+++ b/gitbook-docs/connection.md
@@ -11,6 +11,7 @@ identifiers are:
 * `_http._tcp` for the server's web interface
 * `_signalk-http._tcp` for the Signal K REST API
 * `_signalk-ws._tcp` for the WebSocket data stream
+* `_signalk-tcp._tcp` for the TCP data stream
 
 If a server is providing Signal K via secure versions of HTTP or WebSockets then they MUST be able to provide a
 redirection to the secure versions of these protocols.

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -1,4 +1,6 @@
-# Streaming WebSocket API: /signalk/«version»/stream
+# Streaming API
+
+## WebSocket API: /signalk/«version»/stream
 
 Initiates a WebSocket connection that will start streaming the server’s updates as Signal K delta messages. You can
 specify the contents of the strea by using the `subscribe` query parameter.
@@ -16,7 +18,7 @@ Implemented`.
 
 See [Subscription Protocol](subscription_protocol.md) for more details.
 
-## Connection Hello
+### Connection Hello
 
 Upon connection the server MUST send a 'hello' JSON message, for example:
 
@@ -51,7 +53,7 @@ The server MAY provide:
 
 `version` MUST be the same value as `version` within the associated endpoints list provided by the http `GET` request to `/signalk` within the [REST API](rest_api.md) (if implemented).
 
-## History playback
+### History playback
 
 The server MAY support history playback from a certain point in time with a specified rate.
 

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -3,7 +3,7 @@
 ## WebSocket API: /signalk/«version»/stream
 
 Initiates a WebSocket connection that will start streaming the server’s updates as Signal K delta messages. You can
-specify the contents of the strea by using the `subscribe` query parameter.
+specify the contents of the stream by using the `subscribe` query parameter.
 
 - ws://hostname/signalk/«version»/stream?subscribe=self
 - ws://hostname/signalk/«version»/stream?subscribe=all

--- a/gitbook-docs/streaming_api.md
+++ b/gitbook-docs/streaming_api.md
@@ -78,3 +78,13 @@ The hello message for a history playback stream MUST NOT contain the `timestamp`
 [<]: #
 
 A server MAY respond with `501 Not Implemented` status code if it does not support history playback and with `400 Bad Request` if it does not have data to play back for the given time period. A `404 Not Found` response is also acceptable to be backwards compatible.
+
+## Streaming over TCP
+
+A server MAY provide streaming delta service over TCP. See [Urls and Ports](urls_ports.md) and [Discovery and Connection Establishment](connection.md) for more details.
+
+The messages MUST be serialised as JSON with one message per line using line terminator `\r\n` (carriage return and newline).
+
+As there is no way to specify the subscription policy using url parameters as when opening a WebSocket connection the initial subscription policy is `none`, no active subscriptions. The client can modify the subscriptions after connection is established.
+
+Connection `hello` is the same as when using WebSockets.


### PR DESCRIPTION
This PR tries to include the bare minimum additions needed to specify a usable TCP streaming service. The more ambitious #294 stalled. Both Artemis and Node server already have streaming over TCP implemented, just need to check that they match this spec / alter the spec if needed.