### PR TITLE
[WIP]  add definition for generic data

### DIFF
--- a/schemas/groups/generic.json
+++ b/schemas/groups/generic.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://signalk.org/specification/1.0.0/schemas/groups/generic.json#",
+  "title": "Generic Data",
+  "description": "Generic data that should be user defined based on vessel usage.",
+  "type": "object",
+  "properties": {
+    "temperatures": {
+      "title": "User Defined Temperatures",
+      "description": "Generic temperatures outside of the NMEA defined sources.",
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "type": "object",
+          "title": "User Defined Temperature",
+          "description": "Instance of user defined temperature.",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "properties": {
+                "temperature": {
+                  "description": "User defined temperature",
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "K"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "pressure": {
+      "title": "Actual Pressure",
+      "description": "Generic pressure sources that will vary based on vessel usage.",
+      "type": "object",
+      "properties": {
+        "atmospheric": {
+          "title": "Atmospheric Pressure",
+          "description": "Atmospheric pressure",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "properties": {
+                "pressure": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "Pa"
+                }
+              }
+            }
+          }
+        },
+        "water": {
+          "title": "Water Pressure",
+          "description": "Water pressure",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "properties": {
+                "pressure": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "Pa"
+                }
+              }
+            }
+          }
+        },
+        "steam": {
+          "title": "Steam Pressure",
+          "description": "Steam pressure",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "properties": {
+                "pressure": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "Pa"
+                }
+              }
+            }
+          }
+        },
+        "compressedAir": {
+          "title": "Compressed Air Pressure",
+          "description": "Compressed air pressure",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "properties": {
+                "pressure": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "units": "Pa"
+                }
+              }
+            }
+          }
+        },
+        "hydraulic": {
+          "title": "Hydraulic Pressure",
+          "description": "Hydraulic pressure",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "pressure": {
+                "$ref": "../definitions.json#/definitions/numberValue",
+                "units": "Pa"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -257,6 +257,10 @@
     "performance": {
       "description": "Performance Sailing data including VMG, Polar Speed, tack angle, etc.",
       "$ref": "groups/performance.json#"
+    },
+    "generic": {
+      "description": "Generic vessel data that needs to be user defined based on usage.",
+      "$ref": "groups/generic.json#"
     }
   }
 }

--- a/test/data/full-valid/generic-sample.json
+++ b/test/data/full-valid/generic-sample.json
@@ -1,0 +1,35 @@
+{
+  "vessels": {
+    "urn:mrn:imo:mmsi:311982330": {
+      "mmsi": "311982330",
+      "generic": {
+        "temperatures": {
+          "userDefined129": {
+            "0": {
+              "temperature": {
+                "value": 295.3,
+                "$source": "ydwg-2000.41.0",
+                "timestamp": "2020-04-30T21:54:45.402Z",
+                "pgn": 130312
+              }
+            }
+          }
+        },
+        "pressure": {
+          "water": {
+            "0": {
+              "pressure": {
+                "value": 0,
+                "$source": "ydwg-2000.88.2",
+                "timestamp": "2020-04-30T21:54:44.481Z",
+                "pgn": 130314
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0.0",
+  "self": "urn:mrn:imo:mmsi:311982330"
+}


### PR DESCRIPTION
The Generic Data specification provides a framework for data that falls
outside of standardized sources and is dependent upon vessel usage. This
currently includes temperature and pressure data.

As an example NMEA provides a list of temperature sources but it also
allows for use defined sources #129-252. The user defined sources are now
defined in this specification. An example of user defined temperature would
be generic.temperatures.userDefined129.0.temperature