### PR TITLE
Feat: add satellites definition to GNSS object in navigation group (non-breaking)

### DIFF
--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -305,13 +305,13 @@
         "layline": {
           "type": "object",
           "description": "The layline crossing the current course",
-          "properties":{
-            "distance":{
+          "properties": {
+            "distance": {
               "description": "The current distance to the layline",
               "$ref": "../definitions.json#/definitions/numberValue",
               "units": "m"
             },
-            "time":{
+            "time": {
               "description": "The time to the layline at current speed and heading",
               "$ref": "../definitions.json#/definitions/numberValue",
               "units": "s"
@@ -321,13 +321,13 @@
         "oppositeLayline": {
           "type": "object",
           "description": "The layline parallell to current course",
-          "properties":{
-            "distance":{
+          "properties": {
+            "distance": {
               "description": "The current distance to the layline",
               "$ref": "../definitions.json#/definitions/numberValue",
               "units": "m"
             },
-            "time":{
+            "time": {
               "description": "The time to the layline at current speed and heading",
               "$ref": "../definitions.json#/definitions/numberValue",
               "units": "s"
@@ -433,18 +433,52 @@
           "properties": {
             "value": {
               "type": "string",
-              "enum": [
-                "no Integrity checking",
-                "Safe",
-                "Caution",
-                "Unsafe"
-              ]
+              "enum": ["no Integrity checking", "Safe", "Caution", "Unsafe"]
             }
           }
         },
         "satellites": {
           "$ref": "../definitions.json#/definitions/numberValue",
           "description": "Number of satellites"
+        },
+        "satellite": {
+          "description": "The list of satellites in view of the GPS receiver, identified by their PRN code",
+          "patternProperties": {
+            "(^[A-Za-z0-9]+$)": {
+              "type": "object",
+              "title": "A satellite in view of the GPS receiver",
+              "description": "Satellites, zero or many, in view by the GPS receiver",
+              "properties": {
+                "elevation": {
+                  "type": "object",
+                  "title": "Satellite elevation angle",
+                  "description": "Satellite elevation angle in radians",
+                  "allOf": [{ "$ref": "../definitions.json#/definitions/numberValue" }],
+                  "unit": "rad"
+                },
+                "pseudoRandonNoiseCode": {
+                  "type": "object",
+                  "title": "Satellite pseudo random noise (PRN) code",
+                  "description": "Satellite pseudo random noise (PRN) code, unique to each satellite",
+                  "allOf": [{ "$ref": "../definitions.json#/definitions/numberValue" }]
+                },
+                "azimuth": {
+                  "type": "object",
+                  "title": "Satellite azimuth",
+                  "description": "Satellite azimuth; angle from true north in radians",
+                  "allOf": [{ "$ref": "../definitions.json#/definitions/numberValue" }],
+                  "unit": "rad"
+                },
+                "signalToNoiseRatio": {
+                  "type": "object",
+                  "title": "Satellite signal-to-noise ratio",
+                  "description": "Satellite signal-to-noise ratio in dB",
+                  "allOf": [{ "$ref": "../definitions.json#/definitions/numberValue" }],
+                  "unit": "dB"
+                }
+              }
+            }
+          }
         },
         "antennaAltitude": {
           "$ref": "../definitions.json#/definitions/numberValue",
@@ -583,11 +617,7 @@
       "properties": {
         "value": {
           "type": "string",
-          "enum": [
-            "Not available",
-            "No special maneuver",
-            "Special maneuver"
-          ]
+          "enum": ["Not available", "No special maneuver", "Special maneuver"]
         }
       }
     },
@@ -737,16 +767,7 @@
             },
             "gnssTimeSource": {
               "description": "Source of GNSS Date and Time",
-              "enum": [
-                "GPS",
-                "GLONASS",
-                "Galileo",
-                "Beidou",
-                "IRNSS",
-                "Radio Signal",
-                "Internet",
-                "Local clock"
-              ]
+              "enum": ["GPS", "GLONASS", "Galileo", "Beidou", "IRNSS", "Radio Signal", "Internet", "Local clock"]
             }
           }
         }


### PR DESCRIPTION
This PR implements the following paths in the `navigation` group, with the goal of making it possible to express the satellites of a GNSS fix in Signal K. Use cases include:

- Making more informed decisions on the quality of a fix
- Showing a polar graph with all satellites relative to the receiver
- Etc

The PR would add the following paths to the specification, without breaking anything else:
```
navigation.gnss.satellites.<PRN code>.elevation
navigation.gnss.satellites.<PRN code>.pseudoRandonNoiseCode
navigation.gnss.satellites.<PRN code>.azimuth
navigation.gnss.satellites.<PRN code>.signalToNoiseRatio
```

Satellites are identified by PRN code, which is unique to each satellite. `signalToNoiseRatio` has a unit `dB` (decibells), which is *not* a SI base unit, but sanctioned by SI anyway.