### PR TITLE
Add generator as a new top level

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -904,6 +904,326 @@
           }
         }
       }
-    }
+    },
+    "identity": {
+          "type": "object",
+          "title": "Electrical ID",
+          "description": " Common ID items shared by electrical items",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Unique ID of device (houseBattery, alternator, Generator, solar1, inverter, charger, combiner, etc.)"
+            },
+            "location": {
+              "type": "string",
+              "description": "Installed location of device on vessel"
+            },
+            "dateInstalled": {
+              "$ref": "#/definitions/timestamp",
+              "description": "Date device was installed"
+            },
+            "manufacturer": {
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Manufacturer's name"
+                },
+                "model": {
+                  "type": "string",
+                  "description": "Model or part number"
+                },
+                "URL": {
+                  "type": "string",
+                  "description": "Web referance / URL"
+                }
+              }
+            }
+          }
+    },
+    "dcQualities": {
+          "type": "object",
+          "title": "DC Qualities",
+          "description": "DC common qualities",
+          "properties": {
+            "associatedBus": {
+              "type": "string",
+              "description": "Name of BUS device is associated with"
+            },
+            "voltage": {
+              "type": "object",
+              "description": "Voltage measured at or as close as possible to the device",
+              "units": "V",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/numberValue"
+                },
+                {
+                  "properties": {
+                    "ripple": {
+                      "description": "DC Ripple voltage",
+                      "$ref": "#/definitions/numberValue",
+                      "units": "V"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "nominal": {
+                          "type": "number",
+                          "units": "V",
+                          "description": "Designed 'voltage' of device (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
+                        },
+                        "warnUpper": {
+                          "type": "number",
+                          "units": "V",
+                          "description": "Upper operational voltage limit"
+                        },
+                        "warnLower": {
+                          "type": "number",
+                          "units": "V",
+                          "description": "Lower operational voltage limit"
+                        },
+                        "faultUpper": {
+                          "type": "number",
+                          "units": "V",
+                          "description": "Upper fault voltage limit - device may disable/disconnect"
+                        },
+                        "faultLower": {
+                          "type": "number",
+                          "units": "V",
+                          "description": "Lower fault voltage limit - device may disable/disconnect"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "current": {
+              "type": "object",
+              "description": "Current flowing out (+ve) or in (-ve) to the device",
+              "units": "A",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/numberValue"
+                },
+                {
+                  "properties": {
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "warnUpper": {
+                          "type": "number",
+                          "description": "Upper operational current limit",
+                          "units": "A"
+                        },
+                        "warnLower": {
+                          "type": "number",
+                          "description": "Lower operational current limit",
+                          "units": "A"
+                        },
+                        "faultUpper": {
+                          "type": "number",
+                          "description": "Upper fault current limit - device may disable/disconnect",
+                          "units": "A"
+                        },
+                        "faultLower": {
+                          "type": "number",
+                          "description": "Lower fault current limit - device may disable/disconnect",
+                          "units": "A"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "temperature": {
+              "type": "object",
+              "description": "Temperature measured within or on the device",
+              "units": "K",
+              "title": "temperature",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/numberValue"
+                },
+                {
+                  "properties": {
+                    "warnUpper": {
+                      "type": "number",
+                      "description": "Upper operational temperature limit",
+                      "units": "K"
+                    },
+                    "warnLower": {
+                      "type": "number",
+                      "description": "Lower operational temperature limit",
+                      "units": "K"
+                    },
+                    "faultUpper": {
+                      "type": "number",
+                      "description": "Upper fault temperature limit - device may disable/disconnect",
+                      "units": "K"
+                    },
+                    "faultLower": {
+                      "type": "number",
+                      "description": "Lower fault temperature limit - device may disable/disconnect",
+                      "units": "K"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+    },
+    "acQualities": {
+          "type": "object",
+          "title": "AC Qualities",
+          "description": "AC equipment common qualities",
+          "properties": {
+            "associatedBus": {
+              "type": "string",
+              "description": "Name of BUS device is associated with"
+            },
+            "lineNeutralVoltage": {
+              "$ref": "#/definitions/numberValue",
+              "description": "RMS voltage measured between phase and neutral",
+              "units": "V"
+            },
+            "lineLineVoltage": {
+              "$ref": "#/definitions/numberValue",
+              "description": "RMS voltage measured between phases",
+              "units": "V"
+            },
+            "current": {
+              "$ref": "#/definitions/numberValue",
+              "description": "RMS current flowing out of (+ve) or into (-ve) the device",
+              "units": "A"
+            },
+            "frequency": {
+              "$ref": "#/definitions/numberValue",
+              "description": "AC frequency.",
+              "units": "Hz"
+            },
+            "reactivePower": {
+              "$ref": "#/definitions/numberValue",
+              "description": "Reactive power",
+              "units": "W"
+            },
+            "powerFactor": {
+              "$ref": "#/definitions/numberValue",
+              "description": "Power factor",
+              "unit": "ratio"
+            },
+            "powerFactorLagging": {
+              "description": "Lead/lag status.",
+              "example": "leading",
+              "type": "string",
+              "enum": [
+                "leading",
+                "lagging",
+                "error",
+                "not available"
+              ]
+            },
+            "realPower": {
+              "$ref": "#/definitions/numberValue",
+              "description": "Real power.",
+              "units": "W"
+            },
+            "apparentPower": {
+              "$ref": "#/definitions/numberValue",
+              "description": "Apparent power.",
+              "units": "W"
+            }
+          }
+    },
+    "chargerQualities": {
+          "type": "object",
+          "title": "Charger Qualities",
+          "description": "Common charger qualities",
+          "properties": {
+            "chargingAlgorithm": {
+              "type": "object",
+              "description": "Algorithm being used by the charger",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "enum": [
+                        "trickle",
+                        "two stage",
+                        "three stage",
+                        "four stage",
+                        "constant current",
+                        "constant voltage",
+                        "custom profile"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "chargerRole": {
+              "type": "object",
+              "description": "How is charging source configured?  Standalone, or in sync with another charger?",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "enum": [
+                        "standalone",
+                        "master",
+                        "slave",
+                        "standby"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "chargingMode": {
+              "type": "object",
+              "description": "Charging mode i.e. float, overcharge, etc.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "enum": [
+                        "bulk",
+                        "acceptance",
+                        "overcharge",
+                        "float",
+                        "equalize",
+                        "unknown",
+                        "other"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "setpointVoltage": {
+              "description": "Target regulation voltage",
+              "$ref": "#/definitions/numberValue",
+              "units": "V"
+            },
+            "setpointCurrent": {
+              "description": "Target current limit",
+              "$ref": "#/definitions/numberValue",
+              "units": "A"
+            }
+          }
+    } 
   }
 }

--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -4,339 +4,6 @@
   "description": "Schema describing the electrical child-object of a Vessel.",
   "title": "Electrical Properties",
   "type": "object",
-  "definitions": {
-    "identity": {
-      "type": "object",
-      "title": "Electrical ID",
-      "description": " Common ID items shared by electrical items",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique ID of device (houseBattery, alternator, Generator, solar1, inverter, charger, combiner, etc.)"
-        },
-
-        "location": {
-          "type": "string",
-          "description": "Installed location of device on vessel"
-        },
-        "dateInstalled": {
-          "$ref": "../definitions.json#/definitions/timestamp",
-          "description": "Date device was installed"
-        },
-
-        "manufacturer": {
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "Manufacturer's name"
-            },
-            "model": {
-              "type": "string",
-              "description": "Model or part number"
-            },
-            "URL": {
-              "type": "string",
-              "description": "Web referance / URL"
-            }
-          }
-        }
-      }
-    },
-
-    "dcQualities": {
-      "type": "object",
-      "title": "DC Qualities",
-      "description": "DC common qualities",
-      "properties": {
-        "associatedBus": {
-          "type": "string",
-          "description": "Name of BUS device is associated with"
-        },
-
-        "voltage": {
-          "type": "object",
-          "description": "Voltage measured at or as close as possible to the device",
-          "units": "V",
-          "allOf": [{
-            "$ref": "../definitions.json#/definitions/numberValue"
-          }, {
-            "properties": {
-              "ripple": {
-                "description": "DC Ripple voltage",
-                "$ref": "../definitions.json#/definitions/numberValue",
-                "units": "V"
-              },
-              "meta": {
-                "type": "object",
-                "properties": {
-                  "nominal": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Designed 'voltage' of device (12v, 24v, 32v, 36v, 42v, 48v, 144v, etc.)"
-                  },
-
-                  "warnUpper": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Upper operational voltage limit"
-                  },
-
-                  "warnLower": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Lower operational voltage limit"
-                  },
-
-                  "faultUpper": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Upper fault voltage limit - device may disable/disconnect"
-                  },
-
-                  "faultLower": {
-                    "type": "number",
-                    "units": "V",
-                    "description": "Lower fault voltage limit - device may disable/disconnect"
-                  }
-                }
-              }
-            }
-          }]
-        },
-
-        "current": {
-          "type": "object",
-          "description": "Current flowing out (+ve) or in (-ve) to the device",
-          "units": "A",
-          "allOf": [{
-            "$ref": "../definitions.json#/definitions/numberValue"
-          }, {
-            "properties": {
-              "meta": {
-                "type": "object",
-                "properties": {
-                  "warnUpper": {
-                    "type": "number",
-                    "description": "Upper operational current limit",
-                    "units": "A"
-                  },
-
-                  "warnLower": {
-                    "type": "number",
-                    "description": "Lower operational current limit",
-                    "units": "A"
-                  },
-
-                  "faultUpper": {
-                    "type": "number",
-                    "description": "Upper fault current limit - device may disable/disconnect",
-                    "units": "A"
-                  },
-
-                  "faultLower": {
-                    "type": "number",
-                    "description": "Lower fault current limit - device may disable/disconnect",
-                    "units": "A"
-                  }
-                }
-              }
-            }
-          }]
-        },
-
-        "temperature": {
-          "type": "object",
-          "description": "Temperature measured within or on the device",
-          "units": "K",
-          "title": "temperature",
-          "allOf": [{
-            "$ref": "../definitions.json#/definitions/numberValue"
-          }, {
-            "properties": {
-              "warnUpper": {
-                "type": "number",
-                "description": "Upper operational temperature limit",
-                "units": "K"
-              },
-
-              "warnLower": {
-                "type": "number",
-                "description": "Lower operational temperature limit",
-                "units": "K"
-              },
-
-              "faultUpper": {
-                "type": "number",
-                "description": "Upper fault temperature limit - device may disable/disconnect",
-                "units": "K"
-              },
-
-              "faultLower": {
-                "type": "number",
-                "description": "Lower fault temperature limit - device may disable/disconnect",
-                "units": "K"
-              }
-            }
-          }]
-        }
-      }
-    },
-
-    "acQualities": {
-      "type": "object",
-      "title": "AC Qualities",
-      "description": "AC equipment common qualities",
-      "properties": {
-        "associatedBus": {
-          "type": "string",
-          "description": "Name of BUS device is associated with"
-        },
-        "lineNeutralVoltage": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "RMS voltage measured between phase and neutral",
-          "units": "V"
-        },
-        "lineLineVoltage": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "RMS voltage measured between phases",
-          "units": "V"
-        },
-        "current": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "RMS current",
-          "units": "A"
-        },
-        "frequency": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "AC frequency.",
-          "units": "Hz"
-        },
-        "reactivePower": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Reactive power",
-          "units": "W"
-        },
-        "powerFactor": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Power factor",
-          "unit": "ratio"
-        },
-        "powerFactorLagging": {
-          "description": "Lead/lag status.",
-          "example": "leading",
-          "type": "string",
-          "enum": [
-            "leading",
-            "lagging",
-            "error",
-            "not available"
-          ]
-        },
-        "realPower": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Real power.",
-          "units": "W"
-        },
-        "apparentPower": {
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "description": "Apparent power.",
-          "units": "W"
-        }
-      }
-    },
-  
-    "chargerQualities": {
-      "type": "object",
-      "title": "Charger Qualities",
-      "description": "Common charger qualities",
-      "properties": {
-        "chargingAlgorithm": {
-          "type": "object",
-          "description": "Algorithm being used by the charger",
-          "allOf": [
-            {
-              "$ref": "../definitions.json#/definitions/commonValueFields"
-            },
-            {
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "enum": [
-                    "trickle",
-                    "two stage",
-                    "three stage",
-                    "four stage",       
-                    "constant current",
-                    "constant voltage",
-                    "custom profile"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        "chargerRole": {
-          "type": "object",
-          "description": "How is charging source configured?  Standalone, or in sync with another charger?",
-          "allOf": [
-            {
-              "$ref": "../definitions.json#/definitions/commonValueFields"
-            },
-            {
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "enum": [
-                    "standalone",
-                    "master",
-                    "slave",
-                    "standby"
-                   ]
-                }
-              }
-            }
-          ]
-        },
-        "chargingMode": {
-          "type": "object",
-          "description": "Charging mode i.e. float, overcharge, etc.",
-          "allOf": [
-            {
-              "$ref": "../definitions.json#/definitions/commonValueFields"
-            },
-            {
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "enum": [
-                    "bulk",
-                    "acceptance",
-                    "overcharge",
-                    "float",
-                    "equalize",
-                    "unknown",
-                    "other"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-       "setpointVoltage": {
-          "description": "Target regulation voltage",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "V"
-       }, 
-       "setpointCurrent": {
-          "description": "Target current limit",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "A"
-      }
-    }
-  }
-  },
-  
-  
   "properties": { 
     "batteries": {
       "description": "Data about the vessel's batteries",
@@ -346,9 +13,9 @@
           "title": "Battery keyed by instance id",
           "description": "Batteries, one or many, within the vessel",
           "allOf": [{
-              "$ref": "#/definitions/identity"
+              "$ref": "../definitions.json#/definitions/identity"
                },{
-              "$ref": "#/definitions/dcQualities"
+              "$ref": "../definitions.json#/definitions/dcQualities"
               }],
            "properties": { 
             "chemistry": {
@@ -465,14 +132,14 @@
           "title": "Inverter",
           "description": "DC to AC inverter, one or many, within the vessel",
           "allOf": [{
-            "$ref": "#/definitions/identity"
+            "$ref": "../definitions.json#/definitions/identity"
             }],   
           "properties": {   
             "dc": {
-              "$ref": "#/definitions/dcQualities"
+              "$ref": "../definitions.json#/definitions/dcQualities"
             },
             "ac": {
-              "$ref": "#/definitions/acQualities"
+              "$ref": "../definitions.json#/definitions/acQualities"
             },
             "inverterMode": {
               "type": "object",
@@ -511,11 +178,11 @@
           "title": "Charger",
           "description": "Battery charger",
           "allOf": [{
-            "$ref": "#/definitions/identity"
+            "$ref": "../definitions.json#/definitions/identity"
           },{
-            "$ref": "#/definitions/dcQualities"
+            "$ref": "../definitions.json#/definitions/dcQualities"
           },{
-            "$ref": "#/definitions/chargerQualities"
+            "$ref": "../definitions.json#/definitions/chargerQualities"
           }]
         }
       }
@@ -528,11 +195,11 @@
           "title": "Alternator",
           "description": "Mechanically driven alternator, includes dynamos",
             "allOf": [{
-                "$ref": "#/definitions/identity"
+              "$ref": "../definitions.json#/definitions/identity"
               },{
-                "$ref": "#/definitions/dcQualities"
+                "$ref": "../definitions.json#/definitions/dcQualities"
               },{
-                "$ref": "#/definitions/chargerQualities"
+                "$ref": "../definitions.json#/definitions/chargerQualities"
               }],
             "properties": {  
               "revolutions": {
@@ -567,11 +234,11 @@
           "title": "Solar",
           "description": "Photovoltaic charging devices",
           "allOf": [{
-            "$ref": "#/definitions/identity"
+            "$ref": "../definitions.json#/definitions/identity"
           },{
-            "$ref": "#/definitions/dcQualities"
+            "$ref": "../definitions.json#/definitions/dcQualities"
           },{
-            "$ref": "#/definitions/chargerQualities"
+            "$ref": "../definitions.json#/definitions/chargerQualities"
           }],
           "properties": { 
             "controllerMode": {
@@ -642,14 +309,6 @@
         }
       }
     },
-
-
-  
-    
-    
-    
-    
-    
     "ac": {
       "description": "AC buses",
       "patternProperties": {
@@ -658,7 +317,7 @@
           "title": "AC Bus keyed by instance id",
           "description": "AC Bus, one or many, within the vessel",
           "allOf": [{
-            "$ref": "#/definitions/identity"
+            "$ref": "../definitions.json#/definitions/identity"
           }],
           "properties": {
             "phase": {
@@ -666,7 +325,7 @@
               "description": "Single or A,B or C in 3 Phase systems ",
               "patternProperties": {
                 "(single)|([A-C])": {
-                  "$ref": "#/definitions/acQualities"
+                  "$ref": "../definitions.json#/definitions/acQualities"
                 }
               }
             }

--- a/schemas/groups/generator.json
+++ b/schemas/groups/generator.json
@@ -1,0 +1,154 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://signalk.org/specification/1.0.0/schemas/groups/generator.json#",
+  "title": "Generator properties",
+  "description": "A generator, named by a unique name within this vessel",
+  "patternProperties": {
+    "(^[A-Za-z0-9]+$)": {
+      "description": "This regex pattern is used for validation of the identifier for the generator",
+      "properties": {
+        "label": {
+            "type": "string",
+            "description": "Human readable label for the generator"
+        },
+        "state": {
+          "type": "object",
+          "description": "The current state of the generator",
+          "allOf": [
+            {
+              "$ref": "../definitions.json#/definitions/commonValueFields"
+            },
+            {
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "enum": [
+                    "stopped",
+                    "started",
+                    "unusable"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "revolutions": {
+          "description": "Engine revolutions (x60 for RPM)",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Hz"
+        },
+        "temperature": {
+          "description": "Generator temperature",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "K"
+        },
+        "oilTemperature": {
+          "description": "Oil temperature",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "K"
+        },
+        "oilPressure": {
+          "description": "Oil pressure",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Pa"
+        },
+        "alternatorVoltage": {
+          "description": "Alternator voltage",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "V"
+        },
+        "runTime": {
+          "description": "Total running time for engine (Engine Hours in seconds)",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "s"
+        },
+        "coolantTemperature": {
+          "description": "Coolant temperature",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "K"
+        },
+        "coolantPressure": {
+          "description": "Coolant pressure",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Pa"
+        },
+        "boostPressure": {
+          "description": "Engine boost (turbo, supercharger) pressure",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "Pa"
+        },
+        "intakeManifoldTemperature": {
+          "description": "Intake manifold temperature",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "K"
+        },
+        "engineLoad": {
+          "description": "Engine load ratio, 0<=ratio<=1, 1 is 100%",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "ratio"
+        },
+        "engineTorque": {
+          "description": "Engine torque ratio, 0<=ratio<=1, 1 is 100%",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "ratio"
+        },
+        "fuel": {
+          "type": "object",
+          "description": "Data about the engine's Fuel Supply",
+		      "properties": {
+            "type": {
+              "description": "Fuel type",
+              "enum": [
+                "diesel",
+                "petrol",
+                "other"
+              ]
+            },
+            "used": {
+              "description": "Used fuel since last reset. Resetting is at user discretion",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "m3"
+            },
+            "pressure": {
+              "description": "Fuel pressure",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "Pa"
+            },
+            "rate": {
+              "description": "Fuel rate  of consumption",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "m3/s"
+            },
+            "economyRate": {
+              "description": "Economy fuel rate of consumption",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "m3/s"
+            },
+            "averageRate": {
+              "description": "Average fuel rate of consumption",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "m3/s"
+            },
+            "vacuum": {
+              "description": "vacuum measured at the fuel filter - an indication of the state of the fuel filter. The higher the vacuum, the more clogged the filter.",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "Pa"
+            }
+          }
+        },
+        "exhaustTemperature": {
+          "description": "Exhaust temperature",
+          "$ref": "../definitions.json#/definitions/numberValue",
+          "units": "K"
+        },
+        "dcOutput": {
+            "$ref": "../definitions.json#/definitions/dcQualities"
+        },
+        "acOutput": {
+            "$ref": "../definitions.json#/definitions/acQualities"
+        }
+      }
+    }
+  }
+}

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -257,6 +257,12 @@
     "performance": {
       "description": "Performance Sailing data including VMG, Polar Speed, tack angle, etc.",
       "$ref": "groups/performance.json#"
+    },
+    "generator": {
+      "type": "object",
+      "title": "generator",
+      "description": "Generator data, each generator identified by a unique name",
+      "$ref": "groups/generator.json#"
     }
   }
 }

--- a/test/data/vessel-valid/generator-sample.json
+++ b/test/data/vessel-valid/generator-sample.json
@@ -1,0 +1,89 @@
+{
+  "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
+  "generator": {
+    "label": "Northern Lights 16kw",
+    "acOutput": {
+        "lineNeutralVoltage": {
+          "value": 121.3,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        },
+        "current": {
+          "value": 88,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        }
+    },
+    "fuel": {
+        "type": "diesel",
+        "used": {
+          "value": 12.5,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        },
+        "rate": {
+          "value": 0.6,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        }
+    },
+    "state": {
+        "value": "started",
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    },
+    "revolutions": {
+        "value": 30.1,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar",
+        "meta": {
+          "description": "Engine revolutions (x60 for RPM)",
+          "units": "Hz",
+          "displayName": "Tachometer",
+          "shortName": "RPM",
+          "warnMethod": ["visual"],
+          "alarmMethod": ["sound"],
+          "zones": [{
+            "upper": 30.5,
+            "state": "warn",
+            "message": "Generator RPM too fast"
+          }, 
+          {
+            "lower": 29.5,
+            "state": "alarm",
+            "message": "Generator RPM too slow"
+          }]
+        }
+    },
+    "oilPressure": {
+        "value": 110,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    },
+    "oilTemperature": {
+        "value": 345,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    },
+    "coolantTemperature": {
+        "value": 355,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    },
+    "exhaustTemperature": {
+        "value": 420,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    },
+    "runTime": {
+        "value": 3102234,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    },
+    "alternatorVoltage": {
+        "value": 14.1,
+        "timestamp": "2014-08-15T19:00:15.402Z",
+        "$source": "foo.bar"
+    }
+  }
+}


### PR DESCRIPTION
per @tkurki, moved common electrical properties out of /groups/electrical.json into definitions.json.

then, created /groups/generator.json, along with valid test data.

`npm test` fails with:
`     AssertionError: There should be no missing schema uris, but found https://signalk.org/specification/1.0.0/schemas/groups/generator.json: expected [ Array(1) ] to have a length of 0 but got 1`
@tkurki said to submit the PR with this, and that he would investigate.