### PR TITLE
doc: Change descriptions of keys for wind data to include standard identifiers such as AWS

### DIFF
--- a/gitbook-docs/keys.md
+++ b/gitbook-docs/keys.md
@@ -877,19 +877,19 @@ Current water temperature
 
 
 ## environment.wind.angleApparent
-Apparent wind angle, negative to port
+Apparent Wind Angle (AWA), negative to port
 
 **Units:**rad
 
 
 ## environment.wind.angleTrueGround
-True wind angle based on speed over ground, negative to port
+Ground Wind Angle (GWA) based on speed over ground (SOG), negative to port
 
 **Units:**rad
 
 
 ## environment.wind.angleTrueWater
-True wind angle based on speed through water, negative to port
+True Wind Angle (TWA) based on speed through water (STW), negative to port
 
 **Units:**rad
 
@@ -901,31 +901,32 @@ The angle the wind needs to shift to raise an alarm
 
 
 ## environment.wind.directionMagnetic
-The wind direction relative to magnetic north
+Wind direction based on speed through water (STW), relative to magnetic north
+
 
 **Units:**rad
 
 
 ## environment.wind.directionTrue
-The wind direction relative to true north
+True Wind Direction (TWD) based on speed through water (STW), relative to true north
 
 **Units:**rad
 
 
 ## environment.wind.speedApparent
-Apparent wind speed
+Apparent Wind Speed (AWS)
 
 **Units:**m/s
 
 
 ## environment.wind.speedOverGround
-Wind speed over ground (as calculated from speedApparent and vessel's speed over ground)
+Ground Wind Speed (GWS), calculated from apparent wind speed (AWS) and speed over ground (SOG)
 
 **Units:**m/s
 
 
 ## environment.wind.speedTrue
-Wind speed over water (as calculated from speedApparent and vessel's speed through water)
+True Wind Speed (TWS) over water, calculated from apparent wind speed (AWS) and speed through water (STW)
 
 **Units:**m/s
 

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -283,17 +283,17 @@
       "description": "Wind data.",
       "properties": {
         "angleApparent": {
-          "description": "Apparent wind angle, negative to port",
+          "description": "Apparent Wind Angle (AWA), negative to port",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "rad"
         },
         "angleTrueGround": {
-          "description": "True wind angle based on speed over ground, negative to port",
+          "description": "Ground Wind Angle (GWA) based on speed over ground (SOG), negative to port",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "rad"
         },
         "angleTrueWater": {
-          "description": "True wind angle based on speed through water, negative to port",
+          "description": "True Wind Angle (TWA) based on speed through water (STW), negative to port",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "rad"
         },
@@ -303,27 +303,27 @@
           "units": "rad"
         },
         "directionTrue": {
-          "description": "The wind direction relative to true north",
+          "description": "True Wind Direction (TWD) based on speed through water (STW), relative to true north",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "rad"
         },
         "directionMagnetic": {
-          "description": "The wind direction relative to magnetic north",
+          "description": "Wind direction based on speed through water (STW), relative to magnetic north",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "rad"
         },
         "speedTrue": {
-          "description": "Wind speed over water (as calculated from speedApparent and vessel's speed through water)",
+          "description": "True Wind Speed (TWS) over water, calculated from apparent wind speed (AWS) and speed through water (STW)",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "m/s"
         },
         "speedOverGround": {
-          "description": "Wind speed over ground (as calculated from speedApparent and vessel's speed over ground)",
+          "description": "Ground Wind Speed (GWS), calculated from apparent wind speed (AWS) and speed over ground (SOG)",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "m/s"
         },
         "speedApparent": {
-          "description": "Apparent wind speed",
+          "description": "Apparent Wind Speed (AWS)",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "m/s"
         }


### PR DESCRIPTION
The description of the sk-keys for wind data did not refer to the standard identifiers commonly used in watersports (e.g. AWS, AWA, TWD, ...). For an unambiguous interpretation of what the specific keys represent the standard identifiers are added to the description of the keys.