### PR TITLE
feat: add new schema group "winches"

### DIFF
--- a/schemas/groups/winches.json
+++ b/schemas/groups/winches.json
@@ -45,13 +45,18 @@
       "description": "Properties common to all winch types",
       "type": "object",
       "properties": {
+	"type": {
+	  "description": "The type of winch installation",
+	  "type": "string",
+	  "enum": [ "capstan", "generic", "hoist", "windlass" ]
+	},
         "state": {
           "description": "Current operating state of the winch",
           "type": "string",
           "enum": [ "deploying", "retrieving", "stopped" ]
         },
         "speed": {
-          "description": "Winch current speed in range 1..n",
+          "description": "Winch current speed in range 1..n (1 is slowest)",
           "$ref": "../definitions.json#/definitions/numberValue"
         },
         "inService": {
@@ -66,7 +71,7 @@
             "direction": {
               "description": "Direction of the most recent winch operation",
               "type": "string",
-              "enum": [ "in", "out" ]
+              "enum": [ "deploy", "retrieve" ]
             },
             "speed": {
               "description": "Speed of the most recent winch operation",
@@ -127,7 +132,7 @@
         }
       }
     },
-    "windcapProperties": {
+    "wincapProperties": {
       "title": "Properties specific to a windlass or capstan",
       "description": "Properties which characterise a windlass or capstan, over and above a winch",
       "type": "object",
@@ -156,40 +161,6 @@
     }
   },
   "properties": { 
-    "windlasses": {
-      "description": "Data about the vessel's windlasses",
-      "patternProperties": {
-        "(^[A-Za-z0-9]+$)": {
-          "title": "Windlass keyed by instance id",
-          "description": "Windlasses, one or many, within the vessel",
-          "type": "object",
-          "allOf": [
-            { "$ref": "#/definitions/identity" },
-            { "$ref": "#/definitions/winchProperties" },
-            { "$ref": "#/definitions/windcapProperties" }
-          ],
-          "properties": {
-          } 
-        }
-      }
-    },
-    "capstans": {
-      "description": "Data about the vessel's capstans",
-      "patternProperties": {
-        "(^[A-Za-z0-9]+$)": {
-          "type": "object",
-          "title": "Capstan keyed by instance id",
-          "description": "Capstan, one or many, within the vessel",
-          "allOf": [
-            { "$ref": "#/definitions/identity" },
-            { "$ref": "#/definitions/winchProperties" },
-            { "$ref": "#/definitions/windcapProperties" }
-          ],
-          "properties": {
-          }
-        }
-      }
-    },
     "patternProperties": {
       "(^[A-Za-z0-9]+$)": {
         "title": "Winch keyed by instance id",
@@ -198,7 +169,17 @@
         "allOf": [
           { "$ref": "#/definitions/identity" },
           { "$ref": "#/definitions/winchProperties" }
-        ]
+        ],
+	"oneOf": [
+	  {
+            "type": { "const": "capstan" },
+	    "$ref": "#/definitions/wincapProperties"
+	  },
+	  {
+            "type": { "const": "windlass" },
+	    "$ref": "#/definitions/wincapProperties"
+	  }
+	]
       }
     }
   }

--- a/schemas/groups/winches.json
+++ b/schemas/groups/winches.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://signalk.org/specification/1.0.0/schemas/groups/winches.json#",
+  "description": "Schema describing the winches child-object of a Vessel.",
+  "title": "Winch Properties",
+  "type": "object",
+  "definitions": {
+    "identity": {
+      "title": "Winch id",
+      "description": "Common ID items shared by winch items",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Unique ID of installation (winch, windlass, capstan and so on)",
+          "type": "string"
+        },
+        "location": {
+          "description": "Location of installation on vessel",
+          "type": "string"
+        },
+        "dateInstalled": {
+          "description": "Date device was installed",
+          "$ref": "../definitions.json#/definitions/timestamp"
+        },
+        "manufacturer": {
+          "properties": {
+            "name": {
+              "description": "Manufacturer's name",
+              "type": "string"
+            },
+            "model": {
+              "description": "Model or part number",
+              "type": "string"
+            },
+            "URL": {
+              "description": "Web referance / URL",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "winchProperties": {
+      "title": "Winch properties",
+      "description": "Properties common to all winch types",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "Current operating state of the winch",
+          "type": "string",
+          "enum": [ "deploying", "retrieving", "stopped" ]
+        },
+        "speed": {
+          "description": "Winch current speed in range 1..n",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "inService": {
+          "description": "Whether or not the winch is available for use",
+          "type": "string",
+          "enum": [ "no", "yes" ]
+        },
+        "lastOperation": {
+          "description": "What the winch did most recently - updated every time winch stops/changes speed",
+          "type": "object",
+          "properties": {
+            "direction": {
+              "description": "Direction of the most recent winch operation",
+              "type": "string",
+              "enum": [ "in", "out" ]
+            },
+            "speed": {
+              "description": "Speed of the most recent winch operation",
+              "units": "m/s",
+              "$ref": "../definitions.json#/definitions/numberValue"
+            },
+            "duration": {
+              "description": "Duration of the most recent winch operation",
+              "units": "s",
+              "$ref": "../definitions.json#/definitions/numberValue"
+            }
+          }
+        },
+        "meta": {
+          "description": "Winch installation static properties",
+          "type": "object",
+          "properties": {
+            "availableSpeeds": {
+              "type": "array",
+              "description": "Speeds supported by this windlass",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "description": "Identifier for this speed definition, 1...",
+                    "$ref": "../definitions.json#/definitions/numberValue"
+                  },
+                  "rate": {
+                    "description": "Handling velocity at this speed",
+                    "units": "m/s",
+                    "$ref": "../definitions.json#/definitions/numberValue"
+                  }
+                }
+              }
+            },
+            "powerType": {
+              "description": "Power source for this winch",
+              "type": "string",
+              "enum": [ "electrical", "hydraulic", "manual" ]
+            },
+            "spoolDimensions": {
+              "description": "Size of winch spool",
+              "type": "object",
+              "properties": {
+                "diameter": {
+                  "description": "Diameter of winch spool",
+                  "units": "m",
+                  "$ref": "../definitions.json#/definitions/numberValue"
+                },
+                "length": {
+                  "description": "Usable length of winch spool",
+                  "units": "m",
+                  "$ref": "../definitions.json#/definitions/numberValue"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "windcapProperties": {
+      "title": "Properties specific to a windlass or capstan",
+      "description": "Properties which characterise a windlass or capstan, over and above a winch",
+      "type": "object",
+      "properties": {
+        "deploymentState": {
+          "description": "Windlass/capstan deployment state",
+          "type": "string",
+          "enum": [ "docked", "nearlyDocked", "deployed", "fullyDeployed" ]
+        },
+        "rodeType": {
+          "description": "Currently detected rode type",
+          "type": "string",
+          "enum": [ "rope", "chain" ]
+        },
+        "rodeCounter": {
+          "description": "Rode counter value in metres",
+          "units": "m",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        },
+        "lineSpeed": {
+          "description": "Rode deployment speed",
+          "units": "m/s",
+          "$ref": "../definitions.json#/definitions/numberValue"
+        }
+      }
+    }
+  },
+  "properties": { 
+    "windlasses": {
+      "description": "Data about the vessel's windlasses",
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "title": "Windlass keyed by instance id",
+          "description": "Windlasses, one or many, within the vessel",
+          "type": "object",
+          "allOf": [
+            { "$ref": "#/definitions/identity" },
+            { "$ref": "#/definitions/winchProperties" },
+            { "$ref": "#/definitions/windcapProperties" }
+          ],
+          "properties": {
+          } 
+        }
+      }
+    },
+    "capstans": {
+      "description": "Data about the vessel's capstans",
+      "patternProperties": {
+        "(^[A-Za-z0-9]+$)": {
+          "type": "object",
+          "title": "Capstan keyed by instance id",
+          "description": "Capstan, one or many, within the vessel",
+          "allOf": [
+            { "$ref": "#/definitions/identity" },
+            { "$ref": "#/definitions/winchProperties" },
+            { "$ref": "#/definitions/windcapProperties" }
+          ],
+          "properties": {
+          }
+        }
+      }
+    },
+    "patternProperties": {
+      "(^[A-Za-z0-9]+$)": {
+        "title": "Winch keyed by instance id",
+        "description": "Winch, one or many, within the vessel",
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/definitions/identity" },
+          { "$ref": "#/definitions/winchProperties" }
+        ]
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Motivation

1. The next release of the N2K specification will include three new Windlass Network Messages PGNs (see [this Technical Bulletin](https://www.nmea.org/Assets/20190613%20windlass%20amendment,%20128776,%20128777,%20128778.pdf).
2. The Signal K specification has no framework for windlass data.

## Proposal
1. Accept that a windlass is a type of winch (as is a capstan and maybe even hoist) and focus this discussion on supporting winches as a top-level group in Signal K.
2. Accept that we model the winches group structure simply as winches._id_, where _id_ is an arbitrary identifier (in the case of an N2K connected winch this would be the installation's N2K instance number).
3. Take this draft pull request as an RFC which will allow refinement of the detail of how we represent winch data in Signal K.

## Straw man

### Windlass identity

Common to all winches and just like some other installation identities in Signal K.
```
identity {
  name:
  location:
  dateInstalled:
  manufacturer {
    name:
    model:
    URL:
  }
}
```

### Winch properties

Common to all winches.
```
type: [ "capstan" | "generic" | "hoist" | "windlass" ]
state: [ "deploying" | "retrieving" | "stopped" ] // what the winch is currently doing
speed: n, n>=1 // logical speed - a meta object may map this into the physical values
inService: [ "no" | "yes" ] // whether or not the winch is available for use
lastOperation: { // changes when state and or speed change
  direction: [ "deploy" | "retrieve" ]
  speed: n, n>=1
  duration: s
}
meta: { // static winch data
  availableSpeeds: [
    {
      id: n,n>=1,
      rate: m/s
    }
  ]
  powerType: [ "electrical" | "hydraulic" | "manual" ]
  spoolDimensions: {
    diameter: m
    length: m
  }
}
```

### Windlass and capstan properties

Additional properties for windlasses and capstans.
```
deploymentState: [ "docked" | "nearlyDocked" | "deployed" | "fullyDeployed" ]
rodeType: [ "rope" | "chain" ]
rodeCounter: m
lineSpeed: m/s
```

This draft pull request includes a very draft winches.json that reflects the straw man for those who like that sort of thing.
