### PR TITLE
fix: extend schema for meta properties

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -572,6 +572,38 @@
           "example": ["stopped", "started", "unusable"]
         },
 
+        "properties": {
+          "type": "object",
+          "title": "Properties for object valued properties",
+          "patternProperties": {
+            ".*": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "units": {
+                  "type": "string"
+                },
+                "example": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean",
+                    "object"
+                  ]
+                }
+              }
+            }
+          }
+        },
+
         "gaugeType": {
           "type": "string",
           "title": "gaugeType schema.",


### PR DESCRIPTION
Extend the schema to cover the cases where meta contains
schema data for object valued properties like

  "meta": {
    "description": "The position of the vessel in 2 or 3 dimensions (WGS84 datum)",
    "properties": {
      "longitude": {
        "type": "number",
        "description": "Longitude",
        "units": "deg",
        "example": 4.98765245
      },
      "latitude": {
        "type": "number",
        "description": "Latitude",
        "units": "deg",
        "example": 52.0987654
      },
      "altitude": {
        "type": "number",
        "description": "Altitude",
        "units": "m"
      }
    }
  },