### PR TITLE
improve autopilot specification

### DIFF
--- a/schemas/groups/steering.json
+++ b/schemas/groups/steering.json
@@ -82,48 +82,6 @@
             }
 
           }
-        },
-
-
-        "deadZone": {
-          "description": "Dead zone to ignore for rudder corrections",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "rad"
-        },
-
-        "backlash": {
-          "description": "Slack in the rudder drive mechanism",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "rad"
-        },
-
-        "gain": {
-          "description": "Auto-pilot gain, higher number equals more rudder movement for a given turn",
-          "$ref": "../definitions.json#/definitions/numberValue"
-        },
-
-        "maxDriveCurrent": {
-          "description": "Maximum current to use to drive servo",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "A"
-        },
-
-        "maxDriveRate": {
-          "description": "Maximum rudder rotation speed",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "rad/s"
-        },
-
-        "portLock": {
-          "description": "Position of servo on port lock",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "rad"
-        },
-
-        "starboardLock": {
-          "description": "Position of servo on starboard lock",
-          "$ref": "../definitions.json#/definitions/numberValue",
-          "units": "rad"
         }
       }
     }

--- a/schemas/groups/steering.json
+++ b/schemas/groups/steering.json
@@ -24,7 +24,7 @@
       "properties": {
         "state": {
           "type": "object",
-          "description": "Autopilot state",
+          "description": "Autopilot state, status and any error flags",
           "allOf": [
             {
               "$ref": "../definitions.json#/definitions/commonValueFields"
@@ -32,17 +32,7 @@
             {
               "properties": {
                 "value": {
-                  "type": "string",
-                  "enum": [
-                    "auto",
-                    "standby",
-                    "alarm",
-                    "noDrift",
-                    "wind",
-                    "depthContour",
-                    "route",
-                    "directControl"
-                  ]
+                  "type": "string"
                 }
               }
             }
@@ -60,11 +50,6 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "enum": [
-                    "powersave",
-                    "normal",
-                    "accurate"
-                  ]
                 }
               }
             }
@@ -77,6 +62,11 @@
           "properties": {
             "windAngleApparent": {
               "description": "Target angle to steer, relative to Apparent wind +port -starboard",
+              "$ref": "../definitions.json#/definitions/numberValue",
+              "units": "rad"
+            },
+            "windAngleTrue": {
+              "description": "Target angle to steer, relative to true wind +port -starboard",
               "$ref": "../definitions.json#/definitions/numberValue",
               "units": "rad"
             },


### PR DESCRIPTION
Make the specification more generic and flexible to support more autopilots without being biased toward a specific pilot.    This does not appear to break anything as keys can always be used outside the spec, but the ones removed are not currently used by any existing code anywhere.