### PR TITLE
fix: deprecated package updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "JSONStream": "^0.7.4",
     "debug": "^4.3.1",
-    "json-schema-ref-parser": "^9.0.7",
+    "@apidevtools/json-schema-ref-parser": "^9.1.0",
     "lodash": "^4.17.21",
     "tv4": "^1.2.7",
     "tv4-formats": "^3.0.3"

--- a/scripts/processSchemaFiles.js
+++ b/scripts/processSchemaFiles.js
@@ -22,7 +22,7 @@ const fs = require('mz/fs')
 const path = require('path')
 const rimraf = require('rimraf')
 const markdown = new (require('markdown-it'))()
-const RefParser = require('json-schema-ref-parser')
+const RefParser = require('@apidevtools/json-schema-ref-parser')
 
 
 const units = {


### PR DESCRIPTION
Update npm package to remove `core-js` warning about deprecated version.
Links to Signal K Server vulnerabilities and deprecated fix.
https://github.com/SignalK/signalk-server/pull/1508

Tested with updated npmjs version of signalk-schema@1.6.0 version with SignalK Server fixes.
As version 1.6.0 is not visible here and 1.7.0 seemed to cause some issues, This might need more investigation.
Which commit is npmjs 1.6.0? 