### PR TITLE
chore: prepublish run order change, json-schema-ref-parser update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "babel src --out-dir dist --copy-files && mocha",
-    "prepublish": "npm run js:dist && npm run docs:keys",
+    "prepublish": "npm run docs:keys && npm run js:dist",
     "js:watch": "babel --watch src --out-dir dist --copy-files",
     "js:dist": "babel src --out-dir dist --copy-files",
     "schema:version": "cross-var replace-in-file /https:\\\\/\\\\/signalk.org\\\\/specification\\\\/[\\\\w\\\\.]+\\\\/schemas\\\\//g https://signalk.org/specification/$npm_package_version/schemas/ './**/*.j*' --ignore=./package.json,./node_modules/** --isRegex --verbose",

--- a/test/schemaReferences.js
+++ b/test/schemaReferences.js
@@ -1,7 +1,7 @@
 var assert = require('chai').assert
 
 var signalk = require('../');
-var RefParser = require('json-schema-ref-parser');
+var RefParser = require('@apidevtools/json-schema-ref-parser');
 var path = require('path');
 
 describe('Schema references', function() {


### PR DESCRIPTION
- `docs:keys` need to be run before `js:dist` to get `keyswithmetadata.json` to `src` folder and then copied to `dist` folder
- test updated to use `@apidevtools/json-schema-ref-parser`