### PR TITLE
fix: keyswithmetadata require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -317,13 +317,12 @@ module.exports.chaiModule = chaiAsPromised;
 module.exports.getTv4 = getTv4;
 module.exports.subSchemas = subSchemas;
 module.exports.units = require('../schemas/definitions').definitions.units;
-module.exports.metadata = require('./keyswithmetadata');
+module.exports.metadata = require('./keyswithmetadata.json');
 module.exports.FullSignalK = FullSignalK;
 module.exports.fakeMmsiId = "urn:mrn:imo:mmsi:230099999";
 module.exports.getSourceId = getSourceId;
 module.exports.keyForSourceIdPath = keyForSourceIdPath;
 
-module.exports.metadata = require('./keyswithmetadata');
 
 var metadataByRegex = []
 _.forIn(module.exports.metadata, (value, key) => {


### PR DESCRIPTION
Remove the duplicate require & exports line and change the remaining import to include .json in the file reference. This makes the require Webpack-friendly and allows usage in browser environment.