### PR TITLE
Waypoint ID added to Course Definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
   },
   "homepage": "https://github.com/SignalK/specification",
   "dependencies": {
-    "JSONStream": "^0.7.4",
-    "debug": "^4.3.1",
     "@apidevtools/json-schema-ref-parser": "^9.1.0",
+    "debug": "^4.3.1",
+    "JSONStream": "^0.7.4",
     "lodash": "^4.17.21",
     "tv4": "^1.2.7",
     "tv4-formats": "^3.0.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "chai": "^1.9.2",
     "cross-var": "1.1.0",

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -98,7 +98,11 @@
                 "estimatedTimeOfArrival": {
                   "$ref": "../definitions.json#/definitions/datetimeValue",
                   "description": "The estimated time of arrival at nextPoint position"
-                }
+                },
+                "ID": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "description": "The waypoint ID"
+                }                
               }
             }
           ]
@@ -133,7 +137,11 @@
                 "position": {
                   "description": "The position of lastPoint in two dimensions",
                   "$ref": "../definitions.json#/definitions/position"
-                }
+                },
+                "ID": {
+                  "$ref": "../definitions.json#/definitions/numberValue",
+                  "description": "The waypoint ID"
+                }  
               }
             }
           ]


### PR DESCRIPTION
Updating the specification to be inline with how its parsed in some of the nmea0183-signalk hooks.  for example, APB.  see: https://github.com/SignalK/nmea0183-signalk/issues/239
This is a partial fix