### PR TITLE
doc: fix link to Metadata doc from notifications

### DIFF
--- a/mdbook/src/notifications.md
+++ b/mdbook/src/notifications.md
@@ -7,7 +7,7 @@ We need a flexible model to define alarm conditions, and a standard way to annou
 
 ## Alarm Process
 
-* Define alarm states as zones in the meta object attached to any Signal K value. See [[Metadata for Data Values]]
+* Define alarm states as zones in the meta object attached to any Signal K value. See [Metadata for a Data Value](data_model_metadata.html#metadata-for-a-data-value)
 * If the value is within an alarm zone raise the defined alarm.
 * If the value goes out of the zone, remove the alarm by setting its value to null
 * Alarms are raised by placing an alarm object in the `vessels.self.notifications` tree


### PR DESCRIPTION
Currently broken on this page: https://signalk.org/specification/1.7.0/doc/notifications.html#alarm-process