### PR TITLE
feat(subscribe): add sourcePolicy and excludeSources to subscribe message

### DIFF
--- a/mdbook/src/streaming_api.md
+++ b/mdbook/src/streaming_api.md
@@ -15,6 +15,10 @@ messages in the WebSocket stream.
 
 A server may send the latest values it has cached when a client connects via WebSocket. A client can control this behavior with query parameter `sendCachedValues`. `false` will suppress sending the values and `true` force it. With no `sendCachedValues` parameter the server should send them.
 
+A server MAY accept a `sourcePolicy` query parameter (`preferred` or `all`) that sets the default source-selection
+policy for the connection's bootstrap snapshot and for subscribe messages that do not carry their own
+`sourcePolicy`. See [Source selection](subscription_protocol.md#source-selection) for the semantics.
+
 If a server does not support some streaming options listed in here it must respond with HTTP status code `501 Not
 Implemented`.
 

--- a/mdbook/src/subscription_protocol.md
+++ b/mdbook/src/subscription_protocol.md
@@ -101,6 +101,55 @@ duplication as it prefers on a per connection basis. At the same time it is good
 connections necessary, for instance one WebSocket connection shared between an instrument panel with many gauges,
 rather then one WebSocket connection per gauge.
 
+## Source selection
+
+A subscribed path commonly has more than one source publishing values (see
+[Multiple Values for a Key](data_model_multiple_values.md)). The subscribe message has two top-level fields that let
+the client control which of those sources are delivered:
+
+* `sourcePolicy=[preferred|all]`. Default: `preferred`.
+ * `preferred` delivers a single value per path, resolved through the server's source-priority cascade. If the
+   server has no priority configuration for a path the first source seen wins and is held until it goes silent past
+   its fallback timeout.
+ * `all` delivers every source unranked. Useful for source comparison, diagnostics and clients that maintain their
+   own per-source state.
+ The setting applies to every row in the subscribe message and to the bootstrap snapshot the server replays when
+ the subscription is established.
+* `excludeSources=[sourceRef, ...]`. Optional list of `$source` refs to drop from the priority cascade's candidate
+ set. The subscription still delivers a single priority-resolved value per path; the cascade just runs without the
+ excluded sources, with the configured fallback timeouts honoured. Has effect only when `sourcePolicy` is
+ `preferred`; ignored under `sourcePolicy=all`, which already bypasses priority resolution.
+
+The canonical use case for `excludeSources` is a derived-data plugin that publishes on the same path it consumes.
+With the user's source-priority ranking placing the plugin's output above the upstream sources, downstream
+consumers get the improved value, but the plugin itself cannot subscribe with `sourcePolicy=preferred` without
+seeing its own output. `excludeSources` removes the plugin's own `$source` ref(s) from the cascade so the plugin
+sees the user-configured ranking applied across the remaining (upstream) sources only.
+
+[>]: # (mdpInsert ```json fsnip ../../samples/subscribe/docs-subscription_protocol-excludeSources.json --prettify)
+```json
+{
+  "context": "vessels.self",
+  "sourcePolicy": "preferred",
+  "excludeSources": ["myDerivedPlugin"],
+  "subscribe": [
+    {
+      "path": "environment.wind.speedTrue"
+    }
+  ]
+}
+```
+[<]: #
+
+With a configured ranking of `myDerivedPlugin > sourceB > sourceA`, the subscription above receives `sourceB`
+while `sourceB` is publishing, falls back to `sourceA` once `sourceB` goes silent past its fallback timeout,
+returns to `sourceB` when it resumes, and never receives `myDerivedPlugin` even though it ranks highest.
+
+> Plugin-API implementations MAY offer a shorthand for excluding the plugin's own `$source` ref(s) without the
+> plugin having to know its own id (the Node server exposes this as `excludeSelf: true` on the in-process subscribe
+> API). The shorthand is plugin-API only: WebSocket and TCP clients have no plugin identity for the server to
+> resolve against and MUST use the explicit `excludeSources` form.
+
 ## Meta data
 Meta is updated via the `meta` section within the delta message. As meta changes infrequently it is only sent when it has changed.
 

--- a/samples/subscribe/docs-subscription_protocol-excludeSources.json
+++ b/samples/subscribe/docs-subscription_protocol-excludeSources.json
@@ -1,0 +1,10 @@
+{
+  "context": "vessels.self",
+  "sourcePolicy": "preferred",
+  "excludeSources": ["myDerivedPlugin"],
+  "subscribe": [
+    {
+      "path": "environment.wind.speedTrue"
+    }
+  ]
+}

--- a/schemas/messages/subscribe.json
+++ b/schemas/messages/subscribe.json
@@ -32,6 +32,28 @@
       "example": "signalk.3202a939-1681-4a74-ad4b-3a90212e4f33.vessels.motu.navigation"
     },
 
+    "sourcePolicy": {
+      "id": "sourcePolicy",
+      "type": "string",
+      "enum": ["preferred", "all"],
+      "title": "Source policy.",
+      "description": "Selects which sources are delivered for each subscribed path. 'preferred' (default) delivers a single value per path, resolved through the server's source-priority cascade. 'all' delivers every source unranked and bypasses priority resolution. Applies to every row in this subscribe message and to the bootstrap snapshot replayed when the subscription is established.",
+      "name": "sourcePolicy",
+      "default": "preferred"
+    },
+
+    "excludeSources": {
+      "id": "excludeSources",
+      "type": "array",
+      "title": "Exclude sources.",
+      "description": "Optional list of `$source` refs to drop from the priority cascade's candidate set. The subscription still delivers a single priority-resolved value per path, computed over the remaining sources with the configured fallback timeouts honoured. Has effect only when sourcePolicy is 'preferred'; ignored under sourcePolicy='all'. The typical use case is a derived-data plugin that publishes on the same path it consumes and wants the priority cascade across the upstream sources without seeing its own output.",
+      "name": "excludeSources",
+      "items": {
+        "type": "string",
+        "example": "myDerivedPlugin"
+      }
+    },
+
     "subscribe": {
       "id": "subscribe",
       "type": "array",
@@ -79,7 +101,7 @@
               "name": "policy",
               "default": "ideal"
             },
-            
+
             "minPeriod": {
               "id": "minPeriod",
               "type": "integer",

--- a/test/data/subscribe-invalid/subscribe-sourcePolicy_invalid_value.json
+++ b/test/data/subscribe-invalid/subscribe-sourcePolicy_invalid_value.json
@@ -1,0 +1,7 @@
+{
+  "context": "vessels.self",
+  "sourcePolicy": "bogus",
+  "subscribe": [{
+    "path": "navigation.speedThroughWater"
+  }]
+}

--- a/test/data/subscribe-valid/subscribe-excludeSources.json
+++ b/test/data/subscribe-valid/subscribe-excludeSources.json
@@ -1,0 +1,8 @@
+{
+  "context": "vessels.self",
+  "sourcePolicy": "preferred",
+  "excludeSources": ["myDerivedPlugin", "actisense.115"],
+  "subscribe": [{
+    "path": "environment.wind.speedTrue"
+  }]
+}

--- a/test/data/subscribe-valid/subscribe-sourcePolicy-all.json
+++ b/test/data/subscribe-valid/subscribe-sourcePolicy-all.json
@@ -1,0 +1,7 @@
+{
+  "context": "vessels.self",
+  "sourcePolicy": "all",
+  "subscribe": [{
+    "path": "navigation.speedThroughWater"
+  }]
+}

--- a/test/data/subscribe-valid/subscribe-sourcePolicy-preferred.json
+++ b/test/data/subscribe-valid/subscribe-sourcePolicy-preferred.json
@@ -1,0 +1,7 @@
+{
+  "context": "vessels.self",
+  "sourcePolicy": "preferred",
+  "subscribe": [{
+    "path": "navigation.speedThroughWater"
+  }]
+}


### PR DESCRIPTION
## Motivation

Closes #678 — follow-up to SignalK/signalk-server#2688.

The subscribe schema is silent on how a client controls source selection when a path has multiple producers. Server implementations (and the Node server specifically, as of #2688) support it; the spec needs to catch up so other clients and servers can interop on a documented contract.

The concrete gap: a derived-data plugin that publishes on the same path it consumes cannot benefit from source priority today. Under `sourcePolicy: 'preferred'` it would see its own output and feed back on itself; under `'all'` it loses the user's priority cascade across the upstream sources.

## What this PR adds

Two top-level fields on `SubscribeMessage`:

- **`sourcePolicy`** (`"preferred"` | `"all"`, default `"preferred"`) — selects whether each subscribed path delivers a single priority-resolved value or every source unranked. Applies to every row in the message and to the bootstrap snapshot the server replays on subscribe.
- **`excludeSources`** (array of `$source` refs) — drops the listed sources from the priority cascade's candidate set. The subscription still delivers a single priority-resolved value per path; the cascade just runs without the excluded sources, with the configured fallback timeouts honoured. Effective only under `sourcePolicy: 'preferred'`; ignored under `'all'`.

The canonical use case for `excludeSources` is the derived-data plugin: with user ranking `myPlugin > sourceB > sourceA`, a subscription with `excludeSources: ["myPlugin"]` receives `sourceB` while it publishes, falls back to `sourceA` past `sourceB`'s timeout, returns to `sourceB` when it resumes, and never sees `myPlugin` even though it ranks highest.

## What this PR does not add

`excludeSelf` is a plugin-API shorthand only — the server resolves it to the plugin's id, which has no analogue on a WebSocket/TCP wire. The Node server exposes it on its in-process subscribe API; documentation calls it out as plugin-API-only and points wire clients at `excludeSources`. It is not added to the schema (would be misleading on the wire) and not added as a query parameter (same reason).

## Changes

- `schemas/messages/subscribe.json` — `sourcePolicy` (string + enum) and `excludeSources` (array of strings) added as top-level optional properties.
- `mdbook/src/subscription_protocol.md` — new "Source selection" section with both fields, the cascade-fallback example and the plugin-shorthand note.
- `mdbook/src/streaming_api.md` — short note that servers MAY accept `?sourcePolicy=...` as a connection default.
- `samples/subscribe/docs-subscription_protocol-excludeSources.json` — the example referenced from the new prose, validated by the subscribe sample tests.
- `test/data/subscribe-valid/` — three new valid samples (preferred, all, excludeSources).
- `test/data/subscribe-invalid/` — one new invalid sample (`sourcePolicy: "bogus"`) to lock in the enum.

## Tested

- `npm test` — 212 passing (was 207). The five new samples are picked up by the existing valid/invalid harnesses; the negative case confirms tv4 enforces the `sourcePolicy` enum.
- `node -e 'JSON.parse(...)'` smoke check on `subscribe.json`.