### PR TITLE
Add propulsion diagnostics group: engine fault lamps and active trouble codes

### DIFF
--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -220,6 +220,109 @@
           "description": "Exhaust temperature",
           "$ref": "../definitions.json#/definitions/numberValue",
           "units": "K"
+        },
+        "diagnostics": {
+          "type": "object",
+          "description": "Diagnostics reported by the engine controller: fault lamp states and active diagnostic trouble codes (e.g. J1939 DM1)",
+          "properties": {
+            "malfunctionLamp": {
+              "type": "object",
+              "description": "Malfunction indicator lamp (emissions-related fault). True when the lamp is commanded on, steady or flashing",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            "redStopLamp": {
+              "type": "object",
+              "description": "Red stop lamp (fault severe enough to stop the engine). True when the lamp is commanded on, steady or flashing",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            "amberWarningLamp": {
+              "type": "object",
+              "description": "Amber warning lamp (fault that does not require an immediate stop). True when the lamp is commanded on, steady or flashing",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            "protectLamp": {
+              "type": "object",
+              "description": "Protect lamp (problem with an engine system, e.g. high coolant temperature). True when the lamp is commanded on, steady or flashing",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            "activeCodes": {
+              "type": "object",
+              "description": "Active diagnostic trouble codes. Each entry identifies the faulting parameter (SPN), the failure mode (FMI) and how often it has occurred",
+              "allOf": [
+                {
+                  "$ref": "../definitions.json#/definitions/commonValueFields"
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "spn": {
+                            "type": "number",
+                            "description": "Suspect Parameter Number identifying the faulting parameter"
+                          },
+                          "fmi": {
+                            "type": "number",
+                            "description": "Failure Mode Identifier describing how the parameter failed"
+                          },
+                          "occurrenceCount": {
+                            "type": "number",
+                            "description": "How many times this fault has occurred"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
         }
       }
     }

--- a/test/data/vessel-valid/propulsion-sample.json
+++ b/test/data/vessel-valid/propulsion-sample.json
@@ -42,7 +42,6 @@
           "value": 1100,
           "timestamp": "2014-08-15T19:00:15.402Z",
           "$source": "foo.bar"
-
         }
       },
       "state": {
@@ -59,29 +58,37 @@
           "units": "Hz",
           "displayName": "Tachometer",
           "shortName": "RPM",
-          "warnMethod": ["visual"],
-          "alarmMethod": ["sound"],
-          "zones": [{
-            "upper": 8,
-            "state": "warn",
-            "message": "Engine stopped or rpm very slow!"
-          }, {
-            "lower": 50,
-            "upper": 58.33333333333,
-            "state": "warn",
-            "message": "Engine near maximum rpm!"
-          }, {
-            "lower": 58.33333333333,
-            "upper": 66.66666666666667,
-            "state": "alarm",
-            "message": "Engine exceeds maximum rpm!"
-          }, {
-            "lower": 66.66666666666667,
-            "state": "alarm",
-            "message": "Engine exceeds maximum rpm!"
-          }]
+          "warnMethod": [
+            "visual"
+          ],
+          "alarmMethod": [
+            "sound"
+          ],
+          "zones": [
+            {
+              "upper": 8,
+              "state": "warn",
+              "message": "Engine stopped or rpm very slow!"
+            },
+            {
+              "lower": 50,
+              "upper": 58.33333333333,
+              "state": "warn",
+              "message": "Engine near maximum rpm!"
+            },
+            {
+              "lower": 58.33333333333,
+              "upper": 66.66666666666667,
+              "state": "alarm",
+              "message": "Engine exceeds maximum rpm!"
+            },
+            {
+              "lower": 66.66666666666667,
+              "state": "alarm",
+              "message": "Engine exceeds maximum rpm!"
+            }
+          ]
         }
-
       },
       "oilPressure": {
         "value": 110,
@@ -102,13 +109,11 @@
         "value": 200,
         "timestamp": "2014-08-15T19:00:15.402Z",
         "$source": "foo.bar"
-
       },
       "engineTorque": {
         "value": 200,
         "timestamp": "2014-08-15T19:00:15.402Z",
         "$source": "foo.bar"
-
       },
       "oilTemperature": {
         "value": 345,
@@ -153,6 +158,39 @@
         },
         "oilTemperature": {
           "value": 310,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        }
+      },
+      "diagnostics": {
+        "malfunctionLamp": {
+          "value": false,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        },
+        "redStopLamp": {
+          "value": true,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        },
+        "amberWarningLamp": {
+          "value": false,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        },
+        "protectLamp": {
+          "value": false,
+          "timestamp": "2014-08-15T19:00:15.402Z",
+          "$source": "foo.bar"
+        },
+        "activeCodes": {
+          "value": [
+            {
+              "spn": 100,
+              "fmi": 1,
+              "occurrenceCount": 3
+            }
+          ],
           "timestamp": "2014-08-15T19:00:15.402Z",
           "$source": "foo.bar"
         }


### PR DESCRIPTION
Engine controllers report structured diagnostics that currently have no home in the spec: the four standard fault lamps (malfunction, red stop, amber warning, protect) and the list of active diagnostic trouble codes identified by SPN and FMI — J1939's DM1 message, which many marine engines (Yamaha, Volvo Penta, Yanmar, ...) emit natively and NMEA 2000 gateways translate.

This adds `propulsion.<id>.diagnostics` with boolean lamp values and an `activeCodes` array of `{spn, fmi, occurrenceCount}` objects. Engine *measurements* need no spec change — the existing propulsion paths cover the J1939 engine suite — and the alerting side stays with the notifications tree; this is only the structured-data surface, so a consumer can show the actual fault codes rather than just "engine alarm".

Context: canboat is growing a J1939 decode flavor (canboat/canboat#820) and Signal K Server a listen-only J1939 socketcan connection, with n2k-signalk mapping the decoded records (SignalK/n2k-signalk#340). DM1 lamp states currently land as a notification; once this is in, the structured codes get proper paths.

Tested: schema validates the extended `propulsion-sample.json` (207 passing), and rejects a malformed `activeCodes` value (verified, then removed the negative fixture).