### PR TITLE
Sync schema id versions to 1.8.2 and stop the drift recurring

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "js:watch": "babel --watch src --out-dir dist --copy-files",
     "js:dist": "babel src --out-dir dist --copy-files",
     "schema:version": "cross-var replace-in-file /https:\\\\/\\\\/signalk.org\\\\/specification\\\\/[\\\\w\\\\.]+\\\\/schemas\\\\//g https://signalk.org/specification/$npm_package_version/schemas/ './**/*.j*' --ignore=./package.json,./node_modules/** --isRegex --verbose",
+    "version": "npm run schema:version && git add schemas src",
     "schema:publish": "git checkout gh-pages && git checkout master -- schemas && cross-var mkdir -p $npm_package_version && cross-var git add  $npm_package_version  && cross-var git mv schemas/ $npm_package_version/ && git commit -m \"Schemas from master\" && git push",
     "docs:prep": "cross-var replace-in-file /_version_/g $npm_package_version ./mdbook/src/* --isRegex --verbose && mdprepare mdbook/src/*.md",
     "docs:keys": "node scripts/processSchemaFiles.js",

--- a/schemas/aircraft.json
+++ b/schemas/aircraft.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/aircraft.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/aircraft.json#",
   "description": "An object describing an individual aircraft. It should be an object in aircraft, named using MMSI or a UUID",
   "title": "aircraft",
   "anyOf": [

--- a/schemas/aton.json
+++ b/schemas/aton.json
@@ -1,7 +1,7 @@
   {
     "type": "object",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://signalk.org/specification/1.5.1/schemas/aton.json#",
+    "id": "https://signalk.org/specification/1.8.2/schemas/aton.json#",
     "description": "An object describing an individual aid to navigation. It should be an object in aton, named using MMSI or a UUID",
     "title": "aid to navigation",
     "anyOf": [

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/definitions.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/definitions.json#",
   "title": "definitions",
   "description": "Reusable definitions of core object types",
   "definitions": {

--- a/schemas/delta.json
+++ b/schemas/delta.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/delta.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/delta.json#",
   "title": "SignalK Delta message schema",
   "description": "Schema for defining updates and subscriptions to parts of a SignalK data model, for example for communicating updates of data",
   "required": [

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/discovery.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/discovery.json#",
   "title": "SignalK Discovery",
   "description": "Schema for SignalK discovery resources used to locate server endpoints.",
   "properties": {

--- a/schemas/groups/communication.json
+++ b/schemas/groups/communication.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/communication.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/communication.json#",
   "description": "Schema describing the communication child-object of a Vessel.",
   "title": "communication",
   "properties": {

--- a/schemas/groups/design.json
+++ b/schemas/groups/design.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/design.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/design.json#",
   "description": "An object describing the vessels primary dimensions and statistics.",
   "title": "design",
   "properties": {

--- a/schemas/groups/electrical.json
+++ b/schemas/groups/electrical.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/electrical.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/electrical.json#",
   "description": "Schema describing the electrical child-object of a Vessel.",
   "title": "Electrical Properties",
   "type": "object",

--- a/schemas/groups/environment.json
+++ b/schemas/groups/environment.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/environment.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/environment.json#",
   "description": "Schema describing the environmental child-object of a Vessel.",
   "title": "environment",
   "definitions": {

--- a/schemas/groups/navigation.json
+++ b/schemas/groups/navigation.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/navigation.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/navigation.json#",
   "description": "Schema describing the navigation child-object of a Vessel.",
   "title": "navigation",
   "definitions": {

--- a/schemas/groups/notifications.json
+++ b/schemas/groups/notifications.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/notifications.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/notifications.json#",
   "title": "notifications",
   "definitions": {
     "notification": {

--- a/schemas/groups/performance.json
+++ b/schemas/groups/performance.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/performance.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/performance.json#",
   "description": "Schema describing the performance child-object of a Vessel.",
   "title": "performance",
   "properties": {

--- a/schemas/groups/propulsion.json
+++ b/schemas/groups/propulsion.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/propulsion.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/propulsion.json#",
   "title": "propulsion",
   "description": "An engine, named by a unique name within this vessel",
   "patternProperties": {

--- a/schemas/groups/resources.json
+++ b/schemas/groups/resources.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/resources.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/resources.json#",
   "title": "resources",
   "description": "Resources to aid in navigation and operation of the vessel",
   "properties": {

--- a/schemas/groups/sails.json
+++ b/schemas/groups/sails.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/sails.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/sails.json#",
   "description": "An object describing the vessels sails if the vessel is a sailboat.",
   "title": "sails",
   "properties": {

--- a/schemas/groups/sensors.json
+++ b/schemas/groups/sensors.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/sensors.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/sensors.json#",
   "description": "An object describing an individual sensor. It should be an object in vessel, named using a unique name or UUID",
   "title": "sensor",
   "properties": {

--- a/schemas/groups/sources.json
+++ b/schemas/groups/sources.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/sources.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/sources.json#",
   "title": "sources",
   "description": "Metadata about the sources, eg. buses and connected sensors",
   "patternProperties": {

--- a/schemas/groups/steering.json
+++ b/schemas/groups/steering.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/steering.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/steering.json#",
   "description": "Schema describing the steering child-object of a vessel.",
   "title": "steering",
   "properties": {

--- a/schemas/groups/tanks.json
+++ b/schemas/groups/tanks.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/groups/tanks.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/groups/tanks.json#",
   "description": "A tank, named by a unique identifier",
   "definitions": {
     "tankCollection": {

--- a/schemas/hello.json
+++ b/schemas/hello.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/hello.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/hello.json#",
   "title": "SignalK Websockets Hello message schema",
   "description": "Schema for defining the hello message passed from the server to a client following succesful websocket connection",
   "required": [

--- a/schemas/messages/auth.json
+++ b/schemas/messages/auth.json
@@ -1,7 +1,7 @@
 {
     "type": "object",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://signalk.org/specification/1.5.1/schemas/messages/auth.json#",
+    "id": "https://signalk.org/specification/1.8.2/schemas/messages/auth.json#",
     "title": "SignalK Auth message schema",
     "description": "Schema for authentication messages",
     "required": ["requestId"],

--- a/schemas/messages/get.json
+++ b/schemas/messages/get.json
@@ -1,7 +1,7 @@
 {
     "type": "object",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://signalk.org/specification/1.5.1/schemas/messages/get.json#",
+    "id": "https://signalk.org/specification/1.8.2/schemas/messages/get.json#",
     "title": "SignalK GET message schema",
     "description": "Schema for getting values of parts of a SignalK data model, for example the state of the anchor watch",
     "required": [

--- a/schemas/messages/put.json
+++ b/schemas/messages/put.json
@@ -1,7 +1,7 @@
 {
     "type": "object",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://signalk.org/specification/1.5.1/schemas/messages/put.json#",
+    "id": "https://signalk.org/specification/1.8.2/schemas/messages/put.json#",
     "title": "SignalK PUT message schema",
     "description": "Schema for request/response updates to parts of a SignalK data model, for example turning on anchor watch",
     "required": [

--- a/schemas/messages/subscribe.json
+++ b/schemas/messages/subscribe.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/messages/subscribe.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/messages/subscribe.json#",
   "title": "SignalK SUBSCRIBE message schema",
   "type": "object",
   "description": "A message to allow a client to subscribe for data updates from a signalk server",

--- a/schemas/messages/unsubscribe.json
+++ b/schemas/messages/unsubscribe.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/messages/unsubscribe.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/messages/unsubscribe.json#",
   "title": "SignalK UNSUBSCRIBE message schema",
   "type": "object",
   "description": "A message to allow a client to unsubscribe from data updates from a signalk server",

--- a/schemas/sar.json
+++ b/schemas/sar.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/aton.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/aton.json#",
   "description": "An object describing an individual SAR beacon, eg EPIRB or transponser. It should be an object in sar, named using MMSI or a UUID",
   "title": "Search and rescue beacons",
   "anyOf": [

--- a/schemas/signalk.json
+++ b/schemas/signalk.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/signalk.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/signalk.json#",
   "title": "SignalK",
   "description": "Root schema of Signal K. Contains the list of vessels plus a reference to the local boat (also contained in the vessels list).",
   "required": [

--- a/schemas/vessel.json
+++ b/schemas/vessel.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://signalk.org/specification/1.5.1/schemas/vessel.json#",
+  "id": "https://signalk.org/specification/1.8.2/schemas/vessel.json#",
   "description": "An object describing an individual vessel. It should be an object in vessels, named using MMSI or a UUID",
   "title": "vessel",
   "anyOf": [

--- a/src/index.js
+++ b/src/index.js
@@ -39,23 +39,23 @@ var FullSignalK = require('./fullsignalk');
 function getTv4() {
   var tv4 = require('tv4');
   var vesselSchema = require('../schemas/vessel.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/vessel.json', vesselSchema);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/vessel.json', vesselSchema);
   var aircraftSchema = require('../schemas/aircraft.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/aircraft.json', aircraftSchema);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/aircraft.json', aircraftSchema);
   var atonSchema = require('../schemas/aton.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/aton.json', atonSchema);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/aton.json', atonSchema);
   var sarSchema = require('../schemas/sar.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/sar.json', sarSchema);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/sar.json', sarSchema);
   var definitions = require('../schemas/definitions.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/definitions.json', definitions);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/definitions.json', definitions);
 
   for (var schema in subSchemas) {
-    tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/groups/' + schema + '.json', subSchemas[schema]);
+    tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/groups/' + schema + '.json', subSchemas[schema]);
   }
 
   // HACK! two different IDs should not point to the same schema
   var externalGeometry = require('../schemas/external/geojson/geometry.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/external/geojson/geometry.json', externalGeometry);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/external/geojson/geometry.json', externalGeometry);
   tv4.addSchema('http://json-schema.org/geojson/geometry.json', externalGeometry);
 
   tv4.addFormat(require('tv4-formats'))
@@ -79,7 +79,7 @@ function validateDelta(delta, ignoreContext) {
   var tv4 = require('tv4');
   var deltaSchema = require('../schemas/delta.json');
   var definitions = require('../schemas/definitions.json');
-  tv4.addSchema('https://signalk.org/specification/1.5.1/schemas/definitions.json', definitions);
+  tv4.addSchema('https://signalk.org/specification/1.8.2/schemas/definitions.json', definitions);
 
   if (ignoreContext) {
     delta.context = 'ignored the context, so place a placeholder there';


### PR DESCRIPTION
The schema `id` URLs still declare `1.5.1` while `package.json` is at `1.8.2`. All 36 references across `schemas/` and `src/index.js` carry the stale version, so `1.7.1`, `1.8.0`, `1.8.1` and `1.8.2` each published schemas identifying themselves as `1.5.1`.

`id` is the schema's canonical identifier, and `schema:publish` copies `schemas/` into a version-named `gh-pages` directory — so files served from `.../1.8.2/schemas/` declare themselves `1.5.1`, and anything resolving or caching by that URL cannot tell four releases apart.

## Why it drifted

The `schema:version` script already existed to do this rewrite, but was referenced by nothing — not `prepublish`, not any other script — so it only ran when a maintainer remembered. The last run was `3cdea5a`, *"chore: update schema versions to 1.5.1"*.

Re-running it alone would just defer the problem to 1.8.3, so this also adds an npm `version` lifecycle script. The rewrite now runs automatically on every version bump and stages the result.

Note `src/index.js` registers schemas with tv4 by these same URLs, so it has to move in lockstep with the schema files — another reason to automate rather than rely on a manual step.

## Tested

`npm test` passes (207). Verified the lifecycle hook in a scratch clone: `npm version 1.9.0` rewrote all 36 references and staged `schemas/` and `src/`.

Published `gh-pages` copies for 1.7.x/1.8.x are left as historical artifacts rather than rewritten retroactively — happy to change that if you'd prefer.